### PR TITLE
fix missing read view data for specs without host [STU-385]

### DIFF
--- a/src/HttpOperation/Info.tsx
+++ b/src/HttpOperation/Info.tsx
@@ -1,6 +1,7 @@
 import { MarkdownViewer } from '@stoplight/markdown-viewer';
 import { IHttpOperation } from '@stoplight/types';
 import cn from 'classnames';
+import { get } from 'lodash';
 import * as React from 'react';
 
 export const HttpMethodColors: { [method: string]: string } = {
@@ -15,7 +16,7 @@ export interface IInfoProps extends Pick<IHttpOperation, 'method' | 'path' | 'su
 
 export const Info: React.FunctionComponent<IInfoProps> = ({ method, path, summary, description, servers }) => {
   // TODO (CL): Support multiple servers
-  const host = (servers && servers.length && servers[0] && servers[0].url) || null;
+  const host = get(servers, '[0].url', null);
   return (
     <div>
       <div className="flex items-center">
@@ -26,7 +27,7 @@ export const Info: React.FunctionComponent<IInfoProps> = ({ method, path, summar
             {summary}
           </div>
         ) : (
-          <>{host && <Path host={host} path={path} />}</>
+          host && <Path host={host} path={path} />
         )}
       </div>
 


### PR DESCRIPTION
Related to [STU-385](https://stoplightio.atlassian.net/browse/STU-385)

Changes:
- fixes missing read view Info data for specs without host

Before:
![Screenshot from 2019-07-12 13-02-43](https://user-images.githubusercontent.com/14196079/61123981-08c27980-a4a6-11e9-9a77-19eacec15ec3.png)

After:
![Screenshot from 2019-07-12 13-07-25](https://user-images.githubusercontent.com/14196079/61123986-0c560080-a4a6-11e9-80e1-66d37e251bf3.png)
