### PR TITLE
fix: request maker resetting response

### DIFF
--- a/src/components/TryIt/store.ts
+++ b/src/components/TryIt/store.ts
@@ -74,7 +74,6 @@ export class Request {
       method: this._httpOperation ? (this._httpOperation.method as AxiosRequestConfig['method']) : 'GET',
       url: this.url,
       headers: this.headerParams,
-      params: this.queryParams,
       data: safeParse(this.body),
       auth: this.auth,
     };


### PR DESCRIPTION
Response and error objects were not reset after receiving opposite responses.

Changes:
- reset response on error and error on response