### PR TITLE
feat: better request handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "isomorphic-unfetch": "^3.0.0",
     "lodash": "^4.17.15",
     "mobx-react-lite": "^1.4.1",
+    "object-hash": "^1.3.1",
     "openapi-sampler": "^1.0.0-beta.15",
     "react-error-boundary": "^1.2.5",
     "urijs": "^1.19.1"
@@ -66,6 +67,7 @@
     "@types/enzyme-adapter-react-16": "1.x.x",
     "@types/jest": "24.x.x",
     "@types/lodash": "^4.14.136",
+    "@types/object-hash": "^1.3.0",
     "@types/react": "16.x.x",
     "@types/react-dom": "16.x.x",
     "@types/typescript": "^2.0.0",

--- a/src/__stories__/containers/Hub.tsx
+++ b/src/__stories__/containers/Hub.tsx
@@ -1,18 +1,17 @@
+import { IComponentMapping } from '@stoplight/markdown-viewer';
 import { withKnobs } from '@storybook/addon-knobs';
 import { boolean, text } from '@storybook/addon-knobs/react';
 import { storiesOf } from '@storybook/react';
 import cn from 'classnames';
 import * as React from 'react';
-
 import { Hub, IHub } from '../../containers/Hub';
-import { LinkProps, Provider } from '../../containers/Provider';
+import { Provider } from '../../containers/Provider';
 import { providerKnobs } from './Provider';
 
 export const darkMode = () => boolean('dark mode', false);
 
 export const knobs = (): IHub => ({
-  // srn: text('srn', 'sl/acxiom/handcrafted-metal-ball/docs/markdown/basic-syntax.md', 'Hub'),
-  srn: text('srn', 'sl/acxiom/handcrafted-metal-ball/reference/todos/openapi.json/paths/~1todos/get', 'Hub'),
+  srn: text('srn', 'gh/stoplightio/spectral/docs/cli.md', 'Hub'),
 });
 
 storiesOf('containers/Hub', module)
@@ -29,22 +28,36 @@ storiesOf('containers/Hub', module)
 
 const Wrapper = ({ providerProps, hubProps }: any) => {
   return (
-    <Provider {...providerProps} Link={Link}>
+    <Provider {...providerProps} components={components}>
       <Hub className="h-full" srn={hubProps.srn} />
     </Provider>
   );
 };
 
-const Link: LinkProps = ({ className, srn, children }) => {
+const Link: React.FunctionComponent<{
+  className?: string;
+  title?: string;
+  url: string;
+}> = ({ className, url, children }) => {
   return (
     <a
       className={className}
       onClick={e => {
         e.preventDefault();
-        console.log(srn);
+        console.log(url);
       }}
     >
       {children}
     </a>
   );
+};
+
+const components: IComponentMapping = {
+  link: (props, key) => {
+    return (
+      <Link key={key} className={props.node.className} url={props.node.url} title={props.node.title}>
+        {props.children}
+      </Link>
+    );
+  },
 };

--- a/src/containers/Provider.tsx
+++ b/src/containers/Provider.tsx
@@ -10,7 +10,7 @@ export interface IProvider {
 
 const defaultHost = 'http://localhost:4060';
 export const HostContext = React.createContext(defaultHost);
-export const ApolloContext = React.createContext(axios.create());
+export const AxiosContext = React.createContext(axios.create());
 export const ComponentsContext = React.createContext<IComponentMapping | undefined>(undefined);
 
 export const Provider: React.FunctionComponent<IProvider> = ({ host, token, components, children }) => {
@@ -28,9 +28,9 @@ export const Provider: React.FunctionComponent<IProvider> = ({ host, token, comp
 
   return (
     <HostContext.Provider value={host || defaultHost}>
-      <ApolloContext.Provider value={client}>
+      <AxiosContext.Provider value={client}>
         <ComponentsContext.Provider value={components}>{children}</ComponentsContext.Provider>
-      </ApolloContext.Provider>
+      </AxiosContext.Provider>
     </HostContext.Provider>
   );
 };

--- a/src/hooks/useProjectNodes.ts
+++ b/src/hooks/useProjectNodes.ts
@@ -1,13 +1,17 @@
 import { IProjectNode } from '../types';
+import { deserializeSrn, serializeSrn } from '../utils/srns';
 import { IPaginatedResponse, useRequest } from './useRequest';
 
 const MAX_PAGE_SIZE = 300; // maximumn number of items the API can return on a single request
 
 export function useProjectNodes(srn: string) {
+  // Remove node uri from the SRN
+  const projectSrn = serializeSrn({ ...deserializeSrn(srn), uri: undefined });
+
   return useRequest<IPaginatedResponse<IProjectNode>>({
     url: '/projects.nodes',
     params: {
-      srn,
+      srn: projectSrn,
       first: MAX_PAGE_SIZE, // return the max number of nodes for a single request
     },
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,7 @@ export * from './containers/Hub';
 export * from './containers/Page';
 export * from './containers/Provider';
 export * from './containers/TableOfContents';
+
+export * from './hooks/useComputeToc';
+export * from './hooks/useNodeInfo';
+export * from './hooks/useProjectNodes';

--- a/src/styles/_Page.scss
+++ b/src/styles/_Page.scss
@@ -23,3 +23,12 @@
     }
   }
 }
+
+.HttpOperation__Schema {
+  .#{$ns}-simple-tab-panel {
+    .#{$ns}-code-editor {
+      // Don't add margin when inside a tab panel
+      margin: 0;
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
 
   "compilerOptions": {
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,6 +2446,13 @@
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/object-hash@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@types/object-hash/-/object-hash-1.3.0.tgz#b20db2074129f71829d61ff404e618c4ac3d73cf"
+  integrity sha512-il4NIe4jTx4lfhkKaksmmGHw5EsVkO8sHWkpJHM9m59r1dtsVadLSrJqdE8zU74NENDAsR3oLIOlooRAXlPLNA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/prop-types@*":
   version "15.7.1"
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"


### PR DESCRIPTION
- Removes the extra project.nodes request when the active node changes
- Properly reads and sets response data in the request cache
- Shows an error message instead of infinitely loading
- Exports some hooks that are used by the container components
- Removes negative margin from code blocks inside tabs

Once we have better error handling in the API, we will be able to make the error message prettier:

![image](https://user-images.githubusercontent.com/7423098/62839943-15c6ba00-bc58-11e9-978a-03ee5facef42.png)
