### PR TITLE
fix: allow long parameter names to overflow

### DIFF
--- a/src/__stories__/containers/Hub.tsx
+++ b/src/__stories__/containers/Hub.tsx
@@ -11,7 +11,7 @@ import { providerKnobs } from './Provider';
 export const darkMode = () => boolean('dark mode', false);
 
 export const knobs = (): IHub => ({
-  srn: text('srn', 'gh/stoplightio/studio/docs/Documentation/stoplight-flavored-markdown.md', 'Hub'),
+  srn: text('srn', 'gh/stoplightio/studio-demo/docs/markdown/stoplight-flavored-markdown.md', 'Hub'),
 });
 
 storiesOf('containers/Hub', module)

--- a/src/__stories__/containers/Page.tsx
+++ b/src/__stories__/containers/Page.tsx
@@ -11,7 +11,7 @@ import { providerKnobs } from './Provider';
 export const darkMode = () => boolean('dark mode', false);
 
 export const pageKnobs = (): IPage => ({
-  srn: text('srn', 'gh/stoplightio/studio/docs/Documentation/stoplight-flavored-markdown.md', 'Page'),
+  srn: text('srn', 'gh/stoplightio/studio-demo/docs/markdown/stoplight-flavored-markdown.md', 'Page'),
   version: text('version', '', 'Page'),
   scrollInnerContainer: boolean('scrollInnerContainer', true, 'Page'),
 });

--- a/src/__stories__/containers/TableOfContents.tsx
+++ b/src/__stories__/containers/TableOfContents.tsx
@@ -12,7 +12,7 @@ import { providerKnobs } from './Provider';
 export const darkMode = () => boolean('dark mode', false);
 
 export const tocKnobs = (): ITableOfContents => ({
-  srn: text('srn', 'gh/stoplightio/studio/docs/Documentation/stoplight-flavored-markdown.md', 'TableOfContents'),
+  srn: text('srn', 'gh/stoplightio/studio-demo/docs/markdown/stoplight-flavored-markdown.md', 'TableOfContents'),
 });
 
 storiesOf('containers/TableOfContents', module)

--- a/src/components/HttpOperation/Parameters.tsx
+++ b/src/components/HttpOperation/Parameters.tsx
@@ -4,33 +4,6 @@ import { IHttpParam } from '@stoplight/types';
 import cn from 'classnames';
 import * as React from 'react';
 
-export interface IParameterProps {
-  parameter: IHttpParam;
-  className?: string;
-}
-
-export const Parameter: React.FunctionComponent<IParameterProps> = ({ parameter, className }) => {
-  if (!parameter || !parameter.schema) return null;
-
-  return (
-    <tr className={cn('HttpOperation__Parameter', className)}>
-      <td style={{ width: '45%' }}>
-        <span className="flex break-all font-normal">{parameter.name}</span>
-        <span className={`font-semibold text-${parameter.required ? 'red' : 'gray'}-6 text-xs uppercase `}>
-          {parameter.required ? 'Required' : 'Optional'}
-        </span>
-      </td>
-      <td className="font-normal" style={{ width: '25%' }}>
-        {parameter.schema && parameter.schema.type}
-      </td>
-      <td className="font-normal" style={{ width: '30%' }}>
-        {parameter.description && <MarkdownViewer markdown={parameter.description} />}
-      </td>
-    </tr>
-  );
-};
-Parameter.displayName = 'HttpOperation.Parameter';
-
 export interface IParametersProps {
   parameters?: IHttpParam[];
   className?: string;
@@ -58,3 +31,32 @@ export const Parameters: React.FunctionComponent<IParametersProps> = ({ paramete
   );
 };
 Parameters.displayName = 'HttpOperation.Parameters';
+
+export interface IParameterProps {
+  parameter: IHttpParam;
+  className?: string;
+}
+
+export const Parameter: React.FunctionComponent<IParameterProps> = ({ parameter, className }) => {
+  if (!parameter || !parameter.schema) return null;
+
+  return (
+    <tr className={cn('HttpOperation__Parameter', className)}>
+      <td style={{ width: '45%', boxShadow: 'none' }}>
+        <span className="flex break-all font-normal">{parameter.name}</span>
+        <span className={`font-semibold text-${parameter.required ? 'red' : 'gray'}-6 text-xs uppercase `}>
+          {parameter.required ? 'Required' : 'Optional'}
+        </span>
+      </td>
+
+      <td className="font-normal" style={{ width: '25%', boxShadow: 'none' }}>
+        {parameter.schema && parameter.schema.type}
+      </td>
+
+      <td className="font-normal" style={{ width: '30%', boxShadow: 'none' }}>
+        {parameter.description && <MarkdownViewer markdown={parameter.description} />}
+      </td>
+    </tr>
+  );
+};
+Parameter.displayName = 'HttpOperation.Parameter';

--- a/src/components/HttpOperation/Request.tsx
+++ b/src/components/HttpOperation/Request.tsx
@@ -23,7 +23,7 @@ export const Request: React.FunctionComponent<IRequestProps> = ({ request, class
 
       {query && <Parameters className="mb-10" title="Query Parameters" parameters={query} />}
 
-      {body && <Body body={body} />}
+      {body && <Body className="mb-10" body={body} />}
     </div>
   );
 };

--- a/src/components/HttpOperation/index.tsx
+++ b/src/components/HttpOperation/index.tsx
@@ -24,7 +24,7 @@ const HttpOperationComponent: React.FunctionComponent<IHttpOperationProps> = ({ 
         <MarkdownViewer className="HttpOperation__Description mb-10" markdown={value.description} />
       )}
 
-      <Request className="mb-10" request={value.request} />
+      <Request request={value.request} />
 
       <Responses responses={value.responses} />
     </div>

--- a/src/components/TryIt/Parameters.tsx
+++ b/src/components/TryIt/Parameters.tsx
@@ -64,13 +64,14 @@ const Parameter = observer<IParameter>(({ type, parameter, className }) => {
 
   return (
     <tr className={cn('TryIt__Parameter', className)}>
-      <td className="break-all" style={{ minWidth: '12rem', maxWidth: '80%' }}>
+      <td className="break-all" style={{ minWidth: '12rem', maxWidth: '80%', boxShadow: 'none' }}>
         <span className="flex">{parameter.name}</span>
         <span className={`font-semibold text-${parameter.required ? 'red' : 'gray'}-6 text-xs uppercase `}>
           {parameter.required ? 'Required' : 'Optional'}
         </span>
       </td>
-      <td className="pl-10 w-1/2">
+
+      <td className="pl-10 w-1/2" style={{ boxShadow: 'none' }}>
         {options && options.length > 0 ? (
           <HTMLSelect
             className="w-full"


### PR DESCRIPTION
Fixes #53 

Long Names: 
![Screen Shot 2019-09-23 at 4 07 17 PM](https://user-images.githubusercontent.com/33187986/65471084-763e3f00-de33-11e9-989e-21bc9835f297.png)

![Screen Shot 2019-09-23 at 4 00 00 PM](https://user-images.githubusercontent.com/33187986/65471104-8e15c300-de33-11e9-8b2f-f9b3c9d923dd.png)

Regular-length Names: 
![Screen Shot 2019-09-23 at 4 06 28 PM](https://user-images.githubusercontent.com/33187986/65471080-72122180-de33-11e9-8c1f-cb2596d2e0ea.png)

![Screen Shot 2019-09-23 at 4 02 03 PM](https://user-images.githubusercontent.com/33187986/65471103-8d7d2c80-de33-11e9-8154-d885b2f74120.png)
