### PR TITLE
fix: remove width calculation

### DIFF
--- a/src/styles/_TableOfContents.scss
+++ b/src/styles/_TableOfContents.scss
@@ -1,7 +1,8 @@
+$TableOfContentsWidth: 300px;
+
 .TableOfContentsSkeleton,
 .TableOfContents {
-  width: calc((100% - 1400px) / 2 + 300px);
-  min-width: 300px;
+  min-width: $TableOfContentsWidth + 20;
 }
 
 .TableOfContentsSkeleton__inner,


### PR DESCRIPTION
Addresses the feedback given here: https://github.com/stoplightio/studio-internal/pull/1102#issuecomment-548671084

This is a much better solution 😛 

![image](https://user-images.githubusercontent.com/7423098/68057849-38032d80-fcc5-11e9-913f-6101c8beb307.png)
