### PR TITLE
feat: button maximizes dependency graph

### DIFF
--- a/src/__stories__/components/Page.tsx
+++ b/src/__stories__/components/Page.tsx
@@ -5,7 +5,6 @@ import { boolean } from '@storybook/addon-knobs/react';
 import { storiesOf } from '@storybook/react';
 import cn from 'classnames';
 import * as React from 'react';
-import CircularModel from '../../__fixtures__/schemas/circular';
 import { Changelog } from '../../components/Changelog';
 import { Dependencies } from '../../components/Dependencies';
 import { Docs } from '../../components/Docs';
@@ -16,7 +15,7 @@ export const darkMode = () => boolean('dark mode', false);
 
 const article = require('../../__fixtures__/articles/kitchen-sink.md');
 const httpOperation = require('../../__fixtures__/operations/put-todos.json');
-const modelWithThreeExamples = require('../../__fixtures__/models/model-with-three-examples.json');
+const model = require('../../__fixtures__/schemas/media-entry.json');
 const httpService = require('../../__fixtures__/services/petstore.json');
 
 const knobs = () => ({
@@ -64,7 +63,7 @@ storiesOf('components/Page', module)
             srn: 'gh/stoplightio/studio-demo/reference/common/models/error.v1.yaml',
             name: 'Error',
             type: NodeType.Model,
-            data: CircularModel,
+            data: model,
             changes: [
               {
                 createdAt: '1569423416682',

--- a/src/components/Dependencies/index.tsx
+++ b/src/components/Dependencies/index.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 // @ts-ignore: For documentation, see https://visjs.github.io/vis-network/docs/network/
 import { default as Graph } from 'react-graph-vis';
 
-import { Button, ProgressBar } from '@stoplight/ui-kit';
+import { Button, ProgressBar, Tooltip } from '@stoplight/ui-kit';
 import { get } from 'lodash';
 import { HostContext } from '../../containers/Provider';
 import { useComponents } from '../../hooks/useComponents';
@@ -112,50 +112,48 @@ export const Dependencies: React.FC<IDependencies> = ({ className, node, padding
   }
 
   return (
-    <div className={cn(className, 'Page__dependencies relative h-full')}>
+    <div
+      className={cn(className, 'Page__dependencies', {
+        'fixed inset-0 bg-white dark:bg-gray-7 z-50': isFullScreen,
+        'relative h-full': !isFullScreen,
+      })}
+    >
       {isLoading && (
         <div className="absolute inset-0 bg-lighten-9 flex items-center justify-center z-20">
           <ProgressBar className="w-1/2" value={isStable} />
         </div>
       )}
 
-      <div
-        className={cn(className, {
-          'fixed inset-0 bg-white dark:bg-gray-7 z-50': isFullScreen,
-          'Page_dependencies relative h-full': !isFullScreen,
+      <Tooltip
+        content={isFullScreen ? 'Exit Fullscreen' : 'Go Fullscreen'}
+        className={cn('absolute top-0 right-0 mx-8', {
+          '-mt-10': !isFullScreen,
+          'mt-8 z-10': isFullScreen,
         })}
       >
-        <div className="flex justify-end">
-          <div
-            className={cn(className, 'Page__dependencies', {
-              'justify-content flex-end': isFullScreen,
-              'justify-content flex-end -mt-8': !isFullScreen,
-            })}
-          >
-            <Button
-              minimal={true}
-              small={true}
-              active={true}
-              icon={isFullScreen ? 'minimize' : 'maximize'}
-              onClick={() => setIsFullScreen(!isFullScreen)}
-            />
-          </div>
-        </div>
-        <Graph
-          id={node.srn.replace(/[^a-zA-Z]+/g, '-')}
-          graph={visGraph}
-          events={{
-            click: onClickNode,
-            stabilizationProgress: (data: any) => {
-              setIsStable(data.iterations);
-            },
-            stabilized: (data: any) => {
-              setIsLoading(false);
-            },
-          }}
-          options={visGraphOptions}
+        <Button
+          minimal
+          small
+          active
+          icon={<Icon icon={isFullScreen ? 'minimize' : 'fullscreen'} iconSize={10} />}
+          onClick={() => setIsFullScreen(!isFullScreen)}
         />
-      </div>
+      </Tooltip>
+
+      <Graph
+        id={node.srn.replace(/[^a-zA-Z]+/g, '-')}
+        graph={visGraph}
+        events={{
+          click: onClickNode,
+          stabilizationProgress: (data: any) => {
+            setIsStable(data.iterations);
+          },
+          stabilized: (data: any) => {
+            setIsLoading(false);
+          },
+        }}
+        options={visGraphOptions}
+      />
 
       {activeNode && typeof activeNode.data === 'object' && (
         <div className={cn('absolute bottom-0 left-0 right-0', `px-${padding} pb-${padding}`)}>


### PR DESCRIPTION
Created  button that expands and undoes expansion of dependency graph

Will likely need to make additional updates, so didn't change back example graph yet (importing CircularModel from '../../__fixtures__/schemas/circular'; currently)

expand to full screen
![Screenshot 2019-11-21 at 2 44 16 PM](https://user-images.githubusercontent.com/47359669/69375290-a193ad80-0c6d-11ea-8113-cf20724ecf1d.png)

go back to tabbed view
![Screenshot 2019-11-21 at 2 44 25 PM](https://user-images.githubusercontent.com/47359669/69375292-a193ad80-0c6d-11ea-8b9e-06864f0840a4.png)

