### PR TITLE
feat: resize dependency graph to fit screen when toggling fullscreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/react-dom": "16.x.x",
     "@types/typescript": "^2.0.0",
     "@types/urijs": "^1.19.4",
+    "@types/vis": "^4.21.19",
     "autoprefixer": "^9.7.2",
     "babel-loader": "^8.0.6",
     "copyfiles": "^2.1.1",

--- a/src/components/Dependencies/index.tsx
+++ b/src/components/Dependencies/index.tsx
@@ -1,6 +1,7 @@
 import { Classes, Icon } from '@blueprintjs/core';
 import cn from 'classnames';
 import * as React from 'react';
+import { Network } from 'vis';
 
 // @ts-ignore: For documentation, see https://visjs.github.io/vis-network/docs/network/
 import { default as Graph } from 'react-graph-vis';
@@ -69,6 +70,7 @@ export const Dependencies: React.FC<IDependencies> = ({ className, node, padding
   const [isStable, setIsStable] = React.useState(0);
   const [isLoading, setIsLoading] = React.useState(true);
   const [isFullScreen, setIsFullScreen] = React.useState(false);
+  const visNetwork = React.useRef<Network>();
 
   const onClickNode = React.useCallback(
     e => {
@@ -140,7 +142,13 @@ export const Dependencies: React.FC<IDependencies> = ({ className, node, padding
           small
           active
           icon={<Icon icon={isFullScreen ? 'minimize' : 'fullscreen'} iconSize={10} />}
-          onClick={() => setIsFullScreen(!isFullScreen)}
+          onClick={() => {
+            setIsFullScreen(!isFullScreen);
+
+            if (visNetwork.current) {
+              visNetwork.current.fit();
+            }
+          }}
         />
       </Tooltip>
 
@@ -155,6 +163,9 @@ export const Dependencies: React.FC<IDependencies> = ({ className, node, padding
           stabilized: (data: any) => {
             setIsLoading(false);
           },
+        }}
+        getNetwork={(network: Network) => {
+          visNetwork.current = network;
         }}
         options={visGraphOptions}
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3019,6 +3019,13 @@
   resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.4.tgz#29c4a694d4842d7f95e359a26223fc1865f1ab13"
   integrity sha512-uHUvuLfy4YkRHL4UH8J8oRsINhdEHd9ymag7KJZVT94CjAmY1njoUzhazJsZjwfy+IpWKQKGVyXCwzhZvg73Fg==
 
+"@types/vis@^4.21.19":
+  version "4.21.19"
+  resolved "https://registry.yarnpkg.com/@types/vis/-/vis-4.21.19.tgz#e1ad964deed4d1a5499312410e2ce19693378a78"
+  integrity sha512-SzD6R7pg3TcpzIj+F++ez83WuWhOZ+D05LCbjCaVR41NbMpS6xAdc8lActRK3Cwd9cv5LmoCeN5SAsvXIeAseg==
+  dependencies:
+    moment ">=2.13.0"
+
 "@types/webpack-env@*":
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.14.0.tgz#8edfc5f8e6eae20eeed3ca0d02974ed4ee5e4efc"
@@ -11106,7 +11113,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@^2.24.0:
+moment@>=2.13.0, moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
Implemented suggestions to make graph resize to fit window on toggling.

Still unsure if it's intended functionality to have the window appear as it does when graph is first loaded (below). Let me know if this should be its own issue.

![Screenshot 2019-12-06 at 2 51 22 PM](https://user-images.githubusercontent.com/47359669/70355490-e99efc80-1837-11ea-998f-e19f14329496.png)
