### PR TITLE
fix: show response even if schema is empty

### DIFF
--- a/src/components/HttpOperation/Responses.tsx
+++ b/src/components/HttpOperation/Responses.tsx
@@ -60,8 +60,7 @@ export const Responses: React.FunctionComponent<IResponsesProps> = ({ className,
 Responses.displayName = 'HttpOperation.Responses';
 
 export const Response: React.FunctionComponent<IResponseProps> = ({ className, response }) => {
-  const content = get(response, 'contents[0]');
-  if (content) return null;
+  if (!response || typeof response !== 'object') return null;
 
   return (
     <div className={cn('HttpOperation__Response', className)}>
@@ -69,7 +68,7 @@ export const Response: React.FunctionComponent<IResponseProps> = ({ className, r
 
       <Parameters className="mb-6" title="Headers" parameters={response.headers} />
 
-      <Schema value={get(content, 'schema')} examples={get(content, 'examples')} />
+      <Schema value={get(response, 'contents[0].schema')} examples={get(response, 'contents[0].examples')} />
     </div>
   );
 };

--- a/src/components/HttpOperation/Schema.tsx
+++ b/src/components/HttpOperation/Schema.tsx
@@ -4,6 +4,7 @@ import { IHttpContent, INodeExample, INodeExternalExample } from '@stoplight/typ
 import { CodeViewer } from '@stoplight/ui-kit/CodeViewer';
 import { SimpleTab, SimpleTabList, SimpleTabPanel, SimpleTabs } from '@stoplight/ui-kit/SimpleTabs';
 import cn from 'classnames';
+import { map, size } from 'lodash';
 import * as React from 'react';
 
 export interface ISchema {
@@ -17,7 +18,7 @@ export const Schema: React.FunctionComponent<ISchema> = ({ className, value, exa
   const [selectedIndex, setSelectedIndex] = React.useState(0);
 
   const schema = typeof value === 'string' ? safeParse(value) : value;
-  if ((!schema || !Object.keys(schema).length) && (!examples || !examples.length)) {
+  if (!schema && !size(examples)) {
     return null;
   }
 
@@ -28,35 +29,35 @@ export const Schema: React.FunctionComponent<ISchema> = ({ className, value, exa
       onSelect={setSelectedIndex}
     >
       <SimpleTabList>
-        {value && <SimpleTab>Schema</SimpleTab>}
+        {schema && <SimpleTab>Schema</SimpleTab>}
 
-        {examples &&
-          examples.map((example, index) => <SimpleTab key={index}>{example.summary || example.key}</SimpleTab>)}
+        {map(examples, (example, index) => (
+          <SimpleTab key={index}>{example.summary || example.key}</SimpleTab>
+        ))}
       </SimpleTabList>
 
-      {value && (
+      {schema && (
         <SimpleTabPanel className="p-0">
           <JsonSchemaViewer maxRows={JSV_MAX_ROWS} schema={schema} />
         </SimpleTabPanel>
       )}
 
-      {examples &&
-        examples.map((example, index) => (
-          <SimpleTabPanel key={index} className="p-0">
-            <CodeViewer
-              showLineNumbers
-              className="py-4 overflow-auto max-h-400px"
-              language="json"
-              value={safeStringify(
-                (example as INodeExample).value
-                  ? (example as INodeExample).value
-                  : (example as INodeExternalExample).externalValue,
-                undefined,
-                4,
-              )}
-            />
-          </SimpleTabPanel>
-        ))}
+      {map(examples, (example, index) => (
+        <SimpleTabPanel key={index} className="p-0">
+          <CodeViewer
+            showLineNumbers
+            className="py-4 overflow-auto max-h-400px"
+            language="json"
+            value={safeStringify(
+              (example as INodeExample).value
+                ? (example as INodeExample).value
+                : (example as INodeExternalExample).externalValue,
+              undefined,
+              4,
+            )}
+          />
+        </SimpleTabPanel>
+      ))}
     </SimpleTabs>
   );
 };

--- a/src/components/__tests__/HttpOperation.spec.tsx
+++ b/src/components/__tests__/HttpOperation.spec.tsx
@@ -1,8 +1,12 @@
-import { Validations } from '@stoplight/json-schema-viewer';
+import { JsonSchemaViewer, Validations } from '@stoplight/json-schema-viewer';
+import { MarkdownViewer } from '@stoplight/markdown-viewer';
+import { CodeViewer } from '@stoplight/ui-kit';
+import { SimpleTab } from '@stoplight/ui-kit/SimpleTabs';
 import { mount, ReactWrapper } from 'enzyme';
 import 'jest-enzyme';
 import * as React from 'react';
 import { HttpOperation } from '../HttpOperation';
+import { Parameters } from '../HttpOperation/Parameters';
 
 jest.mock('../../hooks/useResolver', () => ({
   useResolver: (type: any, result: any) => ({ result }),
@@ -147,6 +151,159 @@ describe('HttpOperation', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('Response', () => {
+    it('should render the MarkdownViewer with description', () => {
+      wrapper = mount(
+        <HttpOperation
+          value={{
+            responses: [
+              {
+                code: '200',
+                description: 'Hello world!',
+              },
+            ],
+          }}
+        />,
+      );
+
+      expect(wrapper.find(MarkdownViewer)).toHaveProp('markdown', 'Hello world!');
+    });
+
+    it('should render Parameters with headers', () => {
+      wrapper = mount(
+        <HttpOperation
+          value={{
+            responses: [
+              {
+                code: '200',
+                headers: [
+                  {
+                    schema: {
+                      type: 'string',
+                    },
+                    description: 'header-description',
+                    name: 'header-name',
+                    style: 'simple',
+                    required: true,
+                  },
+                ],
+              },
+            ],
+          }}
+        />,
+      );
+
+      expect(wrapper.find(Parameters)).toHaveProp('parameters', [
+        {
+          schema: {
+            type: 'string',
+          },
+          description: 'header-description',
+          name: 'header-name',
+          style: 'simple',
+          required: true,
+        },
+      ]);
+    });
+
+    it('should render JSV with schema', () => {
+      wrapper = mount(
+        <HttpOperation
+          value={{
+            responses: [
+              {
+                code: '200',
+                contents: [
+                  {
+                    mediaType: 'application/json',
+                    schema: {
+                      $schema: 'http://json-schema.org/draft-04/schema#',
+                      title: 'Todo',
+                      properties: {
+                        name: {
+                          type: 'string',
+                        },
+                        completed: {
+                          type: ['boolean', 'null'],
+                        },
+                      },
+                      required: ['name', 'completed'],
+                    },
+                  },
+                ],
+              },
+            ],
+          }}
+        />,
+      );
+
+      expect(wrapper.find(SimpleTab)).toHaveText('Schema');
+      expect(wrapper.find(JsonSchemaViewer)).toHaveProp('schema', {
+        $schema: 'http://json-schema.org/draft-04/schema#',
+        title: 'Todo',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          completed: {
+            type: ['boolean', 'null'],
+          },
+        },
+        required: ['name', 'completed'],
+      });
+    });
+
+    it('should render response example tabs even with no schema defined', () => {
+      wrapper = mount(
+        <HttpOperation
+          value={{
+            responses: [
+              {
+                code: '200',
+                contents: [
+                  {
+                    mediaType: 'application/json',
+                    examples: [
+                      {
+                        key: 'application/json',
+                        value: {
+                          id: 9000,
+                          name: "It's Over 9000!!!",
+                          completed: true,
+                          completed_at: null,
+                          created_at: '2014-08-28T14:14:28.494Z',
+                          updated_at: '2015-08-28T14:14:28.494Z',
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }}
+        />,
+      );
+
+      expect(wrapper.find(SimpleTab)).toHaveText('application/json');
+
+      expect(wrapper.find(CodeViewer)).toHaveProp(
+        'value',
+        JSON.stringify(
+          {
+            id: 9000,
+            name: "It's Over 9000!!!",
+            completed: true,
+            completed_at: null,
+            created_at: '2014-08-28T14:14:28.494Z',
+            updated_at: '2015-08-28T14:14:28.494Z',
+          },
+          null,
+          4,
+        ),
+      );
     });
   });
 });


### PR DESCRIPTION
Before this PR we were returning `null` if the response schema wasn't defined. Now we always show the response if there's at least a description, one header, a schema, or one example.

- addresses this issue https://github.com/stoplightio/studio-internal/issues/1410
- adds some tests so we don't regress again 🎉 