### PR TITLE
fix: enable scrolling for long heading lists

### DIFF
--- a/src/components/Page/Headings.tsx
+++ b/src/components/Page/Headings.tsx
@@ -64,7 +64,7 @@ export const PageHeadings: React.FC<IPageHeadings> = ({
   }
 
   return (
-    <div className={cn(`sticky top-0 pt-${padding} h-full px-4 overflow-auto`, className)}>
+    <div className={cn(`sticky top-0 pt-${padding} h-screen px-4 overflow-auto`, className)}>
       <div className="border-l border-gray-2 dark:border-lighten-4">{component}</div>
     </div>
   );


### PR DESCRIPTION
Additional fix for Issue: https://github.com/stoplightio/studio/issues/244

![scrollable-headings](https://user-images.githubusercontent.com/33187986/70660237-5f83d900-1c27-11ea-97fb-77529556f6bd.gif)
