### PR TITLE
fix: export search container

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './containers/Hub';
 export * from './containers/Page';
 export * from './containers/Provider';
+export * from './containers/Search';
 export * from './containers/TableOfContents';


### PR DESCRIPTION
We've been exporting all containers from the root index file, but looks like we were missing the search container 😬 