### PR TITLE
fix: use uri.resource()

### DIFF
--- a/src/stores/request-maker/index.ts
+++ b/src/stores/request-maker/index.ts
@@ -284,7 +284,7 @@ export class RequestMakerStore {
     let store: ResponseStore;
     try {
       const url = new URI(this.request.url);
-      const response = await this.prism.request(`${url.path()}${url.query()}`, this.request.toPrism());
+      const response = await this.prism.request(url.resource(), this.request.toPrism());
       store = ResponseStore.fromMockObjectResponse({ ...response, violations: response.violations.output });
     } catch (err) {
       store = ResponseStore.fromError(err);


### PR DESCRIPTION
The constructed URL was missing the `?` for query parameters.

Instead of constructing the URL by hand, we can use the [resource](https://medialize.github.io/URI.js/docs.html#accessors-resource) accessor returning path, query and fragment.