### PR TITLE
fix: request maker losing state inside MD viewer

### DIFF
--- a/src/components/HttpRequest/index.tsx
+++ b/src/components/HttpRequest/index.tsx
@@ -13,7 +13,7 @@ export interface IHttpRequestProps extends IErrorBoundary {
 
 const HttpRequestComponent = React.memo<IHttpRequestProps>(({ value, className }) => {
   const { result } = useResolver<IHttpRequest>('http', value);
-  const store = useRequestMaker(result);
+  const store = useRequestMaker(result, true);
 
   return (
     <div className={cn('RequestMaker', className)}>


### PR DESCRIPTION
Fixes problem mentioned in https://github.com/stoplightio/platform-internal/issues/1155

Because the hook was not using the cache, we ended up with many different instances of the request-maker store. The request was actually sent, but the results did not show up for the said reason.

Debugging this was a little confusing for a reason, that is detailed in a separate issue here: https://github.com/stoplightio/elements/issues/273

Also AFAIK we are still on v4 in `platform-internal` so I'll have to cherry-pick, right? (The issue was not a regression.)