### PR TITLE
fix: remove baseURL path before sending to prism

### DIFF
--- a/src/stores/request-maker/index.ts
+++ b/src/stores/request-maker/index.ts
@@ -283,8 +283,11 @@ export class RequestMakerStore {
 
     let store: ResponseStore;
     try {
-      const url = new URI(this.request.url);
-      const response = await this.prism.request(url.resource(), this.request.toPrism());
+      const requestUrl = new URI(this.request.url);
+      const baseUrl = new URI(this.request.baseUrl);
+      const url = requestUrl.resource().replace(baseUrl.resource(), '/');
+
+      const response = await this.prism.request(url, this.request.toPrism());
       store = ResponseStore.fromMockObjectResponse({ ...response, violations: response.violations.output });
     } catch (err) {
       store = ResponseStore.fromError(err);


### PR DESCRIPTION
This PR will make sure that, before the request is sent to Prism — the base URL's path gets removed because Prism is not aware of it at all.