### PR TITLE
fix: update page headers overflow to auto

### DIFF
--- a/src/components/Page/Headings.tsx
+++ b/src/components/Page/Headings.tsx
@@ -24,7 +24,7 @@ export const PageHeadings: React.FC<IPageHeadings> = ({
   if (!headings || !headings.length) return null;
 
   const component = (
-    <div style={{ maxHeight: '85vh', overflow: 'scroll' }}>
+    <div style={{ maxHeight: '85vh', overflow: 'auto' }}>
       {title && (
         <div
           className="py-2 text-gray-5 dark:text-gray-6 font-medium text-sm flex items-center"


### PR DESCRIPTION
* Removes `overflow-scroll` and updates it to `overflow-auto` in `PageHeadings` component