### PR TITLE
chore: use ES modules as TypeScript output

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
   "exclude": ["**/__fixtures__/**", "**/__stories__/**", "**/__tests__/**"],
 
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ES2015",
     "noUnusedLocals": false,
     "esModuleInterop": true
   }


### PR DESCRIPTION
We talked briefly about this on Slack:

- CommonJS modules hide a lot of component names in DevTools, making it hard to debug component trees in platform, for example.
- I don't think there's any bundler that would does not accept ES modules (I used plain old ES2015 modules to be on the safe side), heck even Chrome has native support for it for 3 years now.
- Even though it can't really hurt because of the above, this is technically a breaking change, so it would be great to include it here before `beta` becomes `master`.

So this PR upgrades the module output to ES2015. Let me know what you think.