### PR TITLE
fix: use es modules in the actual build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,7 +8,6 @@
   ],
   "compilerOptions": {
     "outDir": "dist",
-    "moduleResolution": "node",
-    "module": "commonjs"
+    "moduleResolution": "node"
   }
 }


### PR DESCRIPTION
Alright. So it turns out my [last PR on the subject](https://github.com/stoplightio/elements/pull/339) wasn't really working as intended. 😑 

Our `tsconfig.build.json` also contains a `module` directive that overrides the one I modified in `tsconfig.json`.

This PR fixes that.