### PR TITLE
fix: inbound dependencies UI polish

### DIFF
--- a/src/components/Dependencies/Inbound.tsx
+++ b/src/components/Dependencies/Inbound.tsx
@@ -7,7 +7,7 @@ import { findKey, groupBy, sortBy, toUpper } from 'lodash';
 import * as React from 'react';
 
 import { IGraphNode, INodeGraph, INodeInfo } from '../../types';
-import { NodeTypeIcons } from '../../utils/node';
+import { NodeTypeIcons, NodeTypePrettyName } from '../../utils/node';
 import { GoToRef } from './GoToRef';
 
 export interface IOutboundDependencies {
@@ -47,14 +47,14 @@ export const InboundDependencies: React.FC<IOutboundDependencies> = ({ graph, cl
           title={
             <div className="flex items-center">
               <Icon className="mr-2" icon={NodeTypeIcons[NodeType.Model]} iconSize={14} />
-              Models {nodesByType[NodeType.Model]?.length ? <>({nodesByType[NodeType.Model].length})</> : '(0)'}
+              Models {nodesByType[NodeType.Model]?.length ? <>({nodesByType[NodeType.Model].length})</> : <>(0)</>}
             </div>
           }
           panel={
             nodesByType[NodeType.Model]?.length ? (
               <DependencyTable className={`InboundDependencies__DependencyTable`} nodes={nodesByType[NodeType.Model]} />
             ) : (
-              <div>There are no models that depend on this {node.type}</div>
+              <div>There are no models that depend on this {NodeTypePrettyName[node.type]}</div>
             )
           }
           panelClassName="w-full overflow-auto"
@@ -66,7 +66,7 @@ export const InboundDependencies: React.FC<IOutboundDependencies> = ({ graph, cl
             <div className="flex items-center">
               <Icon className="mr-2" icon={NodeTypeIcons[NodeType.HttpService]} iconSize={14} />
               APIs{' '}
-              {nodesByType[NodeType.HttpService]?.length ? <>({nodesByType[NodeType.HttpService].length})</> : '(0)'}
+              {nodesByType[NodeType.HttpService]?.length ? <>({nodesByType[NodeType.HttpService].length})</> : <>(0)</>}
             </div>
           }
           panel={
@@ -76,7 +76,7 @@ export const InboundDependencies: React.FC<IOutboundDependencies> = ({ graph, cl
                 nodes={nodesByType[NodeType.HttpService]}
               />
             ) : (
-              <div>There are no services that depend on this {node.type}</div>
+              <div>There are no services that depend on this {NodeTypePrettyName[node.type]}</div>
             )
           }
           panelClassName="w-full overflow-auto"
@@ -87,11 +87,11 @@ export const InboundDependencies: React.FC<IOutboundDependencies> = ({ graph, cl
           title={
             <div className="flex items-center">
               <Icon className="mr-2" icon={NodeTypeIcons[NodeType.HttpOperation]} iconSize={14} />
-              HTTP Operations{' '}
+              Endpoints{' '}
               {nodesByType[NodeType.HttpOperation]?.length ? (
                 <>({nodesByType[NodeType.HttpOperation].length})</>
               ) : (
-                '(0)'
+                <>(0)</>
               )}
             </div>
           }
@@ -102,7 +102,7 @@ export const InboundDependencies: React.FC<IOutboundDependencies> = ({ graph, cl
                 nodes={nodesByType[NodeType.HttpOperation]}
               />
             ) : (
-              <div>There are no operations that depend on this {node.type}</div>
+              <div>There are no endpoints that depend on this {NodeTypePrettyName[node.type]}</div>
             )
           }
           panelClassName="w-full overflow-auto"
@@ -113,7 +113,8 @@ export const InboundDependencies: React.FC<IOutboundDependencies> = ({ graph, cl
           title={
             <div className="flex items-center">
               <Icon className="mr-2" icon={NodeTypeIcons[NodeType.Article]} iconSize={14} />
-              Articles {nodesByType[NodeType.Article]?.length ? <>({nodesByType[NodeType.Article].length})</> : '(0)'}
+              Articles{' '}
+              {nodesByType[NodeType.Article]?.length ? <>({nodesByType[NodeType.Article].length})</> : <>(0)</>}
             </div>
           }
           panel={
@@ -123,7 +124,7 @@ export const InboundDependencies: React.FC<IOutboundDependencies> = ({ graph, cl
                 nodes={nodesByType[NodeType.Article]}
               />
             ) : (
-              <div>There are no articles that depend on this {node.type}</div>
+              <div>There are no articles that depend on this {NodeTypePrettyName[node.type]}</div>
             )
           }
           panelClassName="w-full overflow-auto"


### PR DESCRIPTION
Related Issue: https://github.com/stoplightio/platform-internal/issues/1999

* Does not disable menu items on Inbound Dependencies table
* Renders "There are no {nodeType}s that depend on this {node.type}" if no inbound dependencies
* Renders "0" next to node type name if there are no edges

![Screen Shot 2020-04-20 at 1 19 54 PM](https://user-images.githubusercontent.com/33187986/79785562-a8e8e100-8309-11ea-915c-83d109294c13.png)
