### PR TITLE
fix: add default color for http methods

### DIFF
--- a/src/components/HttpOperation/Method.tsx
+++ b/src/components/HttpOperation/Method.tsx
@@ -11,7 +11,7 @@ export const Method: React.FunctionComponent<{
     <span
       className={cn(
         'HttpOperation__Method flex h-8 items-center mr-6 px-3 rounded text-white uppercase',
-        `bg-${HttpMethodColors[method]} dark:bg-${HttpMethodColors[method]}`,
+        `bg-${HttpMethodColors[method] || 'gray'} dark:bg-${HttpMethodColors[method]}`,
         className,
       )}
     >


### PR DESCRIPTION
Related Issue: https://github.com/stoplightio/studio/issues/406

* Adds default color of gray to any method not explicitly defined with a color here:

https://github.com/stoplightio/elements/blob/1d7d2d133d2e1f3648c311896f3a7a27b058f412/src/utils/http.ts#L10-L16

* Methods not defined are `Head`, `Options` and `Trace` so these will default to gray

![Screen Shot 2020-05-07 at 1 33 40 PM](https://user-images.githubusercontent.com/33187986/81331545-62181c80-9067-11ea-9c24-97ad68d6ebee.png)
