### PR TITLE
fix: add default color for http methods

### DIFF
--- a/src/components/Docs/HttpOperation/Method.tsx
+++ b/src/components/Docs/HttpOperation/Method.tsx
@@ -11,7 +11,7 @@ export const Method: React.FunctionComponent<{
     <span
       className={cn(
         'HttpOperation__Method flex h-8 items-center mr-6 px-3 rounded text-white uppercase',
-        `bg-${HttpMethodColors[method]} dark:bg-${HttpMethodColors[method]}`,
+        `bg-${HttpMethodColors[method] || 'gray'} dark:bg-${HttpMethodColors[method]}`,
         className,
       )}
     >


### PR DESCRIPTION
Related Issue: https://github.com/stoplightio/studio/issues/406

* Adds default color of gray to any method not explicitly defined with a color here:

https://github.com/stoplightio/elements/blob/19d066a725cb15e2d63dc00e65ef68d9b5ee0020/src/constants.ts#L47-L53

* Methods not defined are `Head`, `Options` and `Trace` so these will default to gray

![Screen Shot 2020-05-07 at 1 41 35 PM](https://user-images.githubusercontent.com/33187986/81332475-c1c2f780-9068-11ea-9cea-1272de3fa6de.png)
