### PR TITLE
fix: leverage dividers for first level when computing TOC

### DIFF
--- a/src/hooks/useComputeToc.tsx
+++ b/src/hooks/useComputeToc.tsx
@@ -52,23 +52,24 @@ export function computeToc(branchNodes: IBranchNode[], icons: NodeIconMapping): 
         const folderName = pathToItem[pathIndex];
         if (!folders.includes(`${folderName}/${pathIndex}`)) {
           folders.push(`${folderName}/${pathIndex}`);
+
+          const id = `${nodeIndex}-${pathIndex}`;
+          const name = folderName
+            .split('-')
+            .map((item) => upperFirst(item))
+            .join(' ');
+
           if (Number(pathIndex) === 0) {
             contents.push({
-              id: `${nodeIndex}-${pathIndex}`,
-              name: folderName
-                .split('-')
-                .map((item) => upperFirst(item))
-                .join(' '),
+              id,
+              name,
               depth: 0,
               type: 'divider',
             });
           } else {
             contents.push({
-              id: `${nodeIndex}-${pathIndex}`,
-              name: folderName
-                .split('-')
-                .map((item) => upperFirst(item))
-                .join(' '),
+              id,
+              name,
               depth: Number(pathIndex) - 1,
               type: 'group',
               icon: icons.group,
@@ -80,7 +81,7 @@ export function computeToc(branchNodes: IBranchNode[], icons: NodeIconMapping): 
       contents.push({
         id: branchNode.id,
         name: branchNode.snapshot.name,
-        depth: parts.length - 2,
+        depth: Math.max(parts.length - 2, 0),
         type: 'item',
         icon: icons[branchNode.snapshot.type] || icons.item,
         href: branchNode.node.uri,


### PR DESCRIPTION
Basically makes what would be the first article nested folder a divider instead of a folder.

This `computeToc` implementation needs to be cleaned up a bunch and tested IMHO, but that's out of scope for this PR :).

Instead of this:

<img width="495" alt="Screen Shot 2020-05-12 at 1 24 23 AM" src="https://user-images.githubusercontent.com/847542/81645558-65a4fe00-93ef-11ea-9044-56036d728874.png">

Leverage dividers to reduce nesting by one, which usually results in a nicer experience:

<img width="351" alt="Screen Shot 2020-05-12 at 1 24 37 AM" src="https://user-images.githubusercontent.com/847542/81645590-705f9300-93ef-11ea-9127-38de9a1c5614.png">

It's rare to actually need everything collapsed up top on first level.

This is currently yalc'd into https://github.com/stoplightio/platform-internal/pull/2454.