### PR TITLE
Add @stoplightio/void-crew to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # @lottamus will be requested for
 # review when someone opens a pull request.
-*       @lottamus @marcelltoth
+*       @lottamus @stoplightio/void-crew


### PR DESCRIPTION
Marcell is blocked right now because @lottamus is the only other person who can approve PRs. It seems reasonable to open the flood gates so that anyone on Void Crew can approve PRs.