### PR TITLE
fix: codegen boundary

### DIFF
--- a/src/components/RequestMaker/Request/CodeGenerator.tsx
+++ b/src/components/RequestMaker/Request/CodeGenerator.tsx
@@ -81,7 +81,6 @@ export const CodeGenerator: React.FunctionComponent<ICodeGeneratorProps> = ({ cl
           }
           position={Position.BOTTOM}
           minimal={true}
-          boundary={'window'}
           usePortal={false}
         >
           <Button rightIcon="caret-down" text={currentLanguage.text} />


### PR DESCRIPTION
Fixes an issue where the codegen popover is hidden behind tabs

**Before**

<img width="1117" alt="Screen Shot 2020-05-14 at 10 48 42 PM" src="https://user-images.githubusercontent.com/7423098/82009572-4eefe880-9635-11ea-9617-03929f0f51a1.png">

**After**

<img width="1101" alt="Screen Shot 2020-05-14 at 10 49 31 PM" src="https://user-images.githubusercontent.com/7423098/82009575-50b9ac00-9635-11ea-8502-f3bb622d0f02.png">
