### PR TITLE
fix: TableOfContents link path quickfix

### DIFF
--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -24,7 +24,7 @@ export const TableOfContents: React.FunctionComponent<ITableOfContents> = ({ nod
       };
 
       return (
-        <Link key={item.href || item.id} parent={null} index={0} path={item.href} node={{ ...info, node: item.href }}>
+        <Link key={item.href || item.id} parent={null} index={0} path={item.to} node={{ ...info, node: item.href }}>
           <DefaultRow item={item} />
         </Link>
       );


### PR DESCRIPTION
Quickfix for stoplightio/platform-internal#2527

Quick-fix because AFAIK there are other other issues to be discovered in `components/TableOfContents` when we merge the typing improvements in our libraries:
https://github.com/stoplightio/ui-kit/pull/159
https://github.com/stoplightio/markdown-viewer/pull/49

Still, this is good enough to quickly get elements working in `ninja`, as that one is urgent. Tested in platform before moving it here.