### PR TITLE
feat: combine and clean schema examples

### DIFF
--- a/src/components/Docs/HttpOperation/utils.ts
+++ b/src/components/Docs/HttpOperation/utils.ts
@@ -21,5 +21,5 @@ export function getExamplesFromSchema(data: unknown) {
         ...(isObject(data['examples']) && { ...data['examples'] }),
         ...('x-example' in data && { default: data['x-example'] }),
       }
-    : {};
+    : void 0;
 }


### PR DESCRIPTION
Addresses https://github.com/stoplightio/studio/issues/381

Updates handling standalone schema file examples.
@XVincentX I added support for `examples`, `x-examples` and `x-example` as `examples` support changes depending on JSON Schema version and there's no `example`. We can have it differently though. Let me know what you think. 