### PR TITLE
fix: resolve http operation refs against the root http operation object

### DIFF
--- a/src/components/Docs/HttpOperation/index.tsx
+++ b/src/components/Docs/HttpOperation/index.tsx
@@ -1,11 +1,15 @@
+import { pointerToPath } from '@stoplight/json';
+import { SchemaTreeRefDereferenceFn } from '@stoplight/json-schema-viewer';
 import { withErrorBoundary } from '@stoplight/react-error-boundary';
 import { IHttpOperation } from '@stoplight/types';
 import { Classes } from '@stoplight/ui-kit';
 import cn from 'classnames';
+import { get } from 'lodash';
 import * as React from 'react';
 
 import { IDocsComponentProps } from '..';
 import { HttpMethodColors } from '../../../constants';
+import { InlineRefResolverContext } from '../../../containers/Provider';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { Request } from './Request';
 import { Responses } from './Responses';
@@ -15,27 +19,33 @@ export type HttpOperationProps = IDocsComponentProps<Partial<IHttpOperation>>;
 const HttpOperationComponent = React.memo<HttpOperationProps>(({ className, data }) => {
   const color = HttpMethodColors[data.method!] || 'gray';
 
+  const inlineRefResolver: SchemaTreeRefDereferenceFn = ({ pointer }) => {
+    return pointer ? get(data, pointerToPath(pointer)) : null;
+  };
+
   return (
-    <div className={cn('HttpOperation', className)}>
-      <h2 className={cn(Classes.HEADING, 'flex items-center mb-10')}>
-        <div
-          className={cn(`uppercase mr-5 font-semibold border rounded py-1 px-2`, `text-${color}`, `border-${color}`)}
-        >
-          {data.method || 'UNKNOWN'}
-        </div>
+    <InlineRefResolverContext.Provider value={inlineRefResolver}>
+      <div className={cn('HttpOperation', className)}>
+        <h2 className={cn(Classes.HEADING, 'flex items-center mb-10')}>
+          <div
+            className={cn(`uppercase mr-5 font-semibold border rounded py-1 px-2`, `text-${color}`, `border-${color}`)}
+          >
+            {data.method || 'UNKNOWN'}
+          </div>
 
-        {data.path && <div className="flex-1 font-medium text-gray-6 dark:text-gray-3">{data.path}</div>}
-      </h2>
+          {data.path && <div className="flex-1 font-medium text-gray-6 dark:text-gray-3">{data.path}</div>}
+        </h2>
 
-      <MarkdownViewer
-        className="HttpOperation__Description mb-10 ml-1"
-        markdown={data.description || '*No description.*'}
-      />
+        <MarkdownViewer
+          className="HttpOperation__Description mb-10 ml-1"
+          markdown={data.description || '*No description.*'}
+        />
 
-      <Request request={data.request} security={data.security} />
+        <Request request={data.request} security={data.security} />
 
-      {data.responses && <Responses responses={data.responses} />}
-    </div>
+        {data.responses && <Responses responses={data.responses} />}
+      </div>
+    </InlineRefResolverContext.Provider>
   );
 });
 HttpOperationComponent.displayName = 'HttpOperation.Component';


### PR DESCRIPTION
We render the json schema viewer in a couple of spots for http operation - request body, and responses.

We just pass the specific schema for the response/request into the schema viewer, so if that schema has $refs pointing to local properties, the dereferencing will fail.

For example, if the HTTP operation object looks something like this:

```json
{
  "responses": [
    {
      "status": 200,
      "schema": {
        "$ref": "#/shared/user"
      }
    }
  ],

  "shared": {
    "user": {
      "name": "marc"
    }
  }
}
```

Only the `responses.schema` object is passed into the json schema viewer. Obviously with only that information, it cannot resolve the local pointer to `shared.user`. So this PR passes a custom ref resolver in that looks the local data up on the root http operation object.