### PR TITLE
fix: revert: "fix: resolve http operation refs against the root (#423)"

### DIFF
--- a/src/components/Docs/HttpOperation/index.tsx
+++ b/src/components/Docs/HttpOperation/index.tsx
@@ -1,15 +1,11 @@
-import { pointerToPath } from '@stoplight/json';
-import { SchemaTreeRefDereferenceFn } from '@stoplight/json-schema-viewer';
 import { withErrorBoundary } from '@stoplight/react-error-boundary';
 import { IHttpOperation } from '@stoplight/types';
 import { Classes } from '@stoplight/ui-kit';
 import cn from 'classnames';
-import { get } from 'lodash';
 import * as React from 'react';
 
 import { IDocsComponentProps } from '..';
 import { HttpMethodColors } from '../../../constants';
-import { InlineRefResolverContext } from '../../../containers/Provider';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { Request } from './Request';
 import { Responses } from './Responses';
@@ -19,33 +15,27 @@ export type HttpOperationProps = IDocsComponentProps<Partial<IHttpOperation>>;
 const HttpOperationComponent = React.memo<HttpOperationProps>(({ className, data }) => {
   const color = HttpMethodColors[data.method!] || 'gray';
 
-  const inlineRefResolver: SchemaTreeRefDereferenceFn = ({ pointer }) => {
-    return pointer ? get(data, pointerToPath(pointer)) : null;
-  };
-
   return (
-    <InlineRefResolverContext.Provider value={inlineRefResolver}>
-      <div className={cn('HttpOperation', className)}>
-        <h2 className={cn(Classes.HEADING, 'flex items-center mb-10')}>
-          <div
-            className={cn(`uppercase mr-5 font-semibold border rounded py-1 px-2`, `text-${color}`, `border-${color}`)}
-          >
-            {data.method || 'UNKNOWN'}
-          </div>
+    <div className={cn('HttpOperation', className)}>
+      <h2 className={cn(Classes.HEADING, 'flex items-center mb-10')}>
+        <div
+          className={cn(`uppercase mr-5 font-semibold border rounded py-1 px-2`, `text-${color}`, `border-${color}`)}
+        >
+          {data.method || 'UNKNOWN'}
+        </div>
 
-          {data.path && <div className="flex-1 font-medium text-gray-6 dark:text-gray-3">{data.path}</div>}
-        </h2>
+        {data.path && <div className="flex-1 font-medium text-gray-6 dark:text-gray-3">{data.path}</div>}
+      </h2>
 
-        <MarkdownViewer
-          className="HttpOperation__Description mb-10 ml-1"
-          markdown={data.description || '*No description.*'}
-        />
+      <MarkdownViewer
+        className="HttpOperation__Description mb-10 ml-1"
+        markdown={data.description || '*No description.*'}
+      />
 
-        <Request request={data.request} security={data.security} />
+      <Request request={data.request} security={data.security} />
 
-        {data.responses && <Responses responses={data.responses} />}
-      </div>
-    </InlineRefResolverContext.Provider>
+      {data.responses && <Responses responses={data.responses} />}
+    </div>
   );
 });
 HttpOperationComponent.displayName = 'HttpOperation.Component';


### PR DESCRIPTION
Fixes https://github.com/stoplightio/platform-internal/issues/2831

This reverts commit 8e6f1749f788188440d8b180d333bb623d9565da.
Unfortunately we need to revert this commit.
See https://github.com/stoplightio/platform-internal/issues/2831.
Studio supplies its own `InlineRefResolverContext` and the context added in 8e6f1749f788188440d8b180d333bb623d9565da overrides it.

See https://github.com/stoplightio/platform-internal/blob/v2/packages/studio/src/components/ReadPanel/ElementsRenderer.tsx#L86

I believe we'd need to do something similar for Docs.
Thoughts? @marbemac @XVincentX.
Fixing Studio is likely to be more difficult.