### PR TITLE
fix: pass data correctly to DocsComponent

### DIFF
--- a/src/containers/Docs.tsx
+++ b/src/containers/Docs.tsx
@@ -14,7 +14,7 @@ export interface IDocsProps {
 export const Docs = ({ className, node }: IDocsProps) => {
   const info = React.useContext(ActiveInfoContext);
 
-  const [{ data: result, fetching }] = useQuery<ElementsBranchNode>({
+  const [{ data: result, fetching }] = useQuery({
     query: elementsBranchNode,
     variables: {
       workspaceSlug: info.workspace,
@@ -26,6 +26,11 @@ export const Docs = ({ className, node }: IDocsProps) => {
   if (fetching || !result) {
     return <DocsSkeleton />;
   }
-
-  return <DocsComponent className={className} nodeType={result.type} nodeData={result.data} />;
+  return (
+    <DocsComponent
+      className={className}
+      nodeType={result.elementsBranchNode.type}
+      nodeData={result.elementsBranchNode.data}
+    />
+  );
 };


### PR DESCRIPTION
#3031

We weren't passing the correct data to the `DocsComponent` in `DocsContainer`.

The data structure for the query response actually looks like:
```
{
   elementsBranchNode: 
      {
         data: {...},
         type: "http_operation"
      }
}
```

When you add a type to `useQuery<type>()` it incorrectly says the type of the `data` prop on response is `type` when it's actually `{queryName: type}`.

So had to remove the type from `useQuery` and use the actual structure to pass data correctly like `result.queryName.prop`.

**Before**
Empty Dependency pop up
![image](https://user-images.githubusercontent.com/33431856/84691811-622ef600-af0a-11ea-8cb1-2bc6b7df7436.png)

**After**
Dependency pop up correctly populated
![image](https://user-images.githubusercontent.com/33431856/84691865-7d9a0100-af0a-11ea-9738-2c03d40a21d9.png)
