### PR TITLE
fix: allow openapi-sampler to resolve $refs

### DIFF
--- a/src/__fixtures__/operations/bundled-parameter.ts
+++ b/src/__fixtures__/operations/bundled-parameter.ts
@@ -1,0 +1,116 @@
+export const httpOperation = {
+  id: '?http-operation-id?',
+  iid: 'POST_todos',
+  description: 'This creates a Todo object.\n\nTesting `inline code`.',
+  method: 'post',
+  path: '/todos',
+  summary: 'Create Todo',
+  responses: [
+    {
+      code: '201',
+      description: '',
+      headers: [],
+      contents: [
+        {
+          mediaType: 'application/json',
+          schema: {
+            title: 'Todo Full',
+            allOf: [
+              {
+                title: 'Todo Partial',
+                type: 'object',
+                properties: { name: { type: 'string' }, completed: { type: ['boolean', 'null'] } },
+                required: ['name', 'completed'],
+                'x-tags': ['Todos'],
+              },
+              {
+                type: 'object',
+                properties: {
+                  id: { type: 'integer', minimum: 0, maximum: 1000000 },
+                  completed_at: { type: ['string', 'null'], format: 'date-time' },
+                  created_at: { type: 'string', format: 'date-time' },
+                  updated_at: { type: 'string', format: 'date-time' },
+                  user: {
+                    title: 'User',
+                    type: 'object',
+                    properties: {
+                      name: { type: 'string', description: "The user's full name." },
+                      age: { type: 'number', minimum: 0, maximum: 150 },
+                    },
+                    required: ['name', 'age'],
+                    'x-tags': ['Todos'],
+                  },
+                },
+                required: ['id', 'user'],
+              },
+            ],
+            'x-tags': ['Todos'],
+          },
+          examples: [
+            {
+              key: 'application/json',
+              value: {
+                id: 9000,
+                name: "It's Over 9000!!!",
+                completed: null,
+                completed_at: null,
+                created_at: '2014-08-28T14:14:28.494Z',
+                updated_at: '2014-08-28T14:14:28.494Z',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  servers: [{ url: 'https://todos.stoplight.io' }, { url: 'http://todos.stoplight.io' }],
+  request: {
+    body: {
+      contents: [
+        {
+          mediaType: 'application/json',
+          schema: {
+            $ref: '#/__bundled__/paths/~1todos/post/responses/201/schema/allOf/0',
+            example: { name: "my todo's name", completed: false },
+          },
+          examples: [{ key: 'default', value: { name: "my todo's name", completed: false } }],
+        },
+      ],
+    },
+  },
+  tags: [{ name: 'Todos' }],
+  security: [
+    [
+      {
+        type: 'apiKey',
+        name: 'apikey',
+        in: 'query',
+        description: "Use `?apikey=123` to authenticate requests. It's super secure.",
+        key: 'apikey',
+      },
+    ],
+  ],
+  __bundled__: {
+    paths: {
+      '/todos': {
+        post: {
+          responses: {
+            '201': {
+              schema: {
+                allOf: [
+                  {
+                    title: 'Todo Partial',
+                    type: 'object',
+                    properties: { name: { type: 'string' }, completed: { type: ['boolean', 'null'] } },
+                    required: ['name', 'completed'],
+                    'x-tags': ['Todos'],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/__stories__/components/TryIt.tsx
+++ b/src/__stories__/components/TryIt.tsx
@@ -1,0 +1,27 @@
+import { object, text, withKnobs } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs/react';
+import { storiesOf } from '@storybook/react';
+import cn from 'classnames';
+import * as React from 'react';
+
+import { httpOperation } from '../../__fixtures__/operations/bundled-parameter';
+import { TryIt } from '../../components/TryIt';
+import { Provider } from '../../containers/Provider';
+
+const article = require('../../__fixtures__/articles/kitchen-sink.md').default;
+
+export const darkMode = () => boolean('dark mode', false);
+export const mockUrl = () => text('mockUrl', '');
+export const nodeData = () => object('nodeData', httpOperation);
+
+storiesOf('components/TryIt', module)
+  .addDecorator(withKnobs({ escapeHTML: false }))
+  .add('Playground', () => {
+    return (
+      <div className={cn('p-10', { 'bp3-dark bg-gray-8': darkMode() })}>
+        <Provider host="http://stoplight-local.com:8080" workspace="chris" project="studio-demo">
+          <TryIt nodeType="http_operation" nodeData={nodeData()} mockUrl={mockUrl()} />
+        </Provider>
+      </div>
+    );
+  });

--- a/src/__stories__/index.ts
+++ b/src/__stories__/index.ts
@@ -1,3 +1,4 @@
 import './components/Dependencies';
 import './components/Docs';
 import './components/TableOfContents';
+import './components/TryIt';

--- a/src/utils/getOperationData.ts
+++ b/src/utils/getOperationData.ts
@@ -75,7 +75,7 @@ function getBodyFromOperation(operation: Partial<IHttpOperation>) {
     const schema = get(operation, 'request.body.contents[0].schema');
 
     if (schema) {
-      return sampler.sample(schema);
+      return sampler.sample(schema, {}, operation);
     }
   } catch (e) {
     console.warn('Unable to create sample request body from schema', e);


### PR DESCRIPTION
Since we're bundling $refs now, we need to pass the full operation into openapi-sampler so it can resolve them.


![image](https://user-images.githubusercontent.com/7423098/85643986-50acc300-b65b-11ea-812b-23c484e963c2.png)



**Before**

<img width="1680" alt="Screen Shot 2020-06-24 at 8 40 52 PM" src="https://user-images.githubusercontent.com/7423098/85643938-3246c780-b65b-11ea-99a1-4e0fdeda578a.png">

**After**

<img width="1680" alt="Screen Shot 2020-06-24 at 8 40 36 PM" src="https://user-images.githubusercontent.com/7423098/85643944-35da4e80-b65b-11ea-82a5-6773155fee4c.png">
