### PR TITLE
fix: nodeData can be unknown

### DIFF
--- a/src/components/TryIt/index.tsx
+++ b/src/components/TryIt/index.tsx
@@ -9,7 +9,7 @@ import { RequestEditor, RequestEndpoint, RequestMakerProvider, ResponseViewer } 
 
 export interface ITryItProps {
   nodeType: string;
-  nodeData: string;
+  nodeData: unknown;
   mockUrl?: string;
   className?: string;
 }


### PR DESCRIPTION
- needed for https://github.com/stoplightio/platform-internal/pull/3280

nodeData can possibly be a `string` or an `object` that we don't know the shape of. 

We're already attempting to parse if it's a string: https://github.com/stoplightio/elements/blob/bf5ed15416a9ba86cb4f07bbd684a80cee5a32d3/src/components/TryIt/index.tsx#L18

And ensuring the resulting data is an http operation: https://github.com/stoplightio/elements/blob/bf5ed15416a9ba86cb4f07bbd684a80cee5a32d3/src/components/TryIt/index.tsx#L21