### PR TITLE
feat: do not show "required" for path parameters

### DIFF
--- a/src/components/Docs/HttpOperation/Parameters.tsx
+++ b/src/components/Docs/HttpOperation/Parameters.tsx
@@ -122,14 +122,16 @@ export const Parameter: React.FunctionComponent<IParameterProps> = ({ parameter,
       <div className="flex items-center">
         <div className="font-medium font-mono">{parameter.name}</div>
         <div className={cn('ml-2 text-sm', PropertyTypeColors[type])}>{type}</div>
-        <div
-          className={cn('ml-2 text-sm', {
-            'text-danger': parameter.required,
-            'opacity-50': !parameter.required,
-          })}
-        >
-          {parameter.required ? 'required' : 'optional'}
-        </div>
+        {parameterType !== 'path' && (
+          <div
+            className={cn('ml-2 text-sm', {
+              'text-danger': parameter.required,
+              'opacity-50': !parameter.required,
+            })}
+          >
+            {parameter.required ? 'required' : 'optional'}
+          </div>
+        )}
         <NumberValidations validations={numberValidations} />
       </div>
 


### PR DESCRIPTION
Resolves - when `elements` is bumped - stoplightio/platform-internal#3110

The spectral request would / will be a separate feature. This hides the required/optional marking on the parameter display.

![image](https://user-images.githubusercontent.com/543372/86937984-2e797180-c140-11ea-8774-4c99b6923ba7.png)
