### PR TITLE
fix: openapi-sampler crash takes down RequestMaker

### DIFF
--- a/src/utils/__tests__/getOperationData.spec.ts
+++ b/src/utils/__tests__/getOperationData.spec.ts
@@ -89,4 +89,26 @@ describe('getOperationData()', () => {
       queryParams: [],
     });
   });
+
+  it('should handle invalid ref', () => {
+    expect(
+      getOperationData({
+        request: {
+          body: {
+            contents: [
+              {
+                mediaType: 'application/json',
+                schema: {
+                  $ref: 'https://nonexistent.external.ref',
+                },
+              },
+            ],
+          },
+        },
+      }),
+    ).toMatchObject({
+      method: 'get',
+      body: '',
+    });
+  });
 });

--- a/src/utils/getOperationData.ts
+++ b/src/utils/getOperationData.ts
@@ -44,7 +44,7 @@ export function getOperationData(operation: Partial<IHttpOperation>): Partial<Re
     }
   }
 
-  const body = getBodyFromOperation(operation);
+  const body = getBodyFromOperation(operation) || '';
 
   return {
     publicServers: operation.servers || [],
@@ -71,11 +71,16 @@ function getParamsFromOperation(operation: Partial<IHttpOperation>, type: 'query
 }
 
 function getBodyFromOperation(operation: Partial<IHttpOperation>) {
-  const schema = get(operation, 'request.body.contents[0].schema');
+  try {
+    const schema = get(operation, 'request.body.contents[0].schema');
 
-  if (schema) {
-    return sampler.sample(schema);
+    if (schema) {
+      return sampler.sample(schema);
+    }
+  } catch (e) {
+    console.warn('Unable to create sample request body from schema', e);
+    return undefined;
   }
 
-  return '';
+  return undefined;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7528,7 +7528,7 @@ fork-ts-checker-webpack-plugin@1.5.0:
     tapable "^1.0.0"
     worker-rpc "^0.1.0"
 
-form-data@3.0.0:
+form-data@^3:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
   integrity sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==
@@ -8467,7 +8467,7 @@ https-proxy-agent@^5.0.0:
     commander "^2.9.0"
     debug "^2.2.0"
     event-stream "3.3.4"
-    form-data "^3"
+    form-data "3.0.0"
     fs-readfile-promise "^2.0.1"
     fs-writefile-promise "^1.0.3"
     har-validator "^5.0.0"


### PR DESCRIPTION
Kind of a cherry-pick of f9266e6e (#378) for v1

Per @rossmcdonald's request:
> This fix only applied to v2, correct? Any way we could get this change in v1 as well?

_Originally posted by @rossmcdonald in https://github.com/stoplightio/platform-internal/issues/2313#issuecomment-655731827_

