### PR TITLE
chore: add alias for type-check command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - run: yarn
-      - run: yarn tsc --noEmit
+      - run: yarn type-check
       - run: yarn test.prod
   release:
     docker:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "test": "jest",
     "test.prod": "yarn lint && yarn test --coverage --maxWorkers=2",
     "test.update": "yarn test --updateSnapshot",
-    "test.watch": "yarn test --watch"
+    "test.watch": "yarn test --watch",
+    "type-check": "tsc --noEmit"
   },
   "peerDependencies": {
     "@stoplight/prism-http": "^4.0.0-beta.19",


### PR DESCRIPTION
This is a very trivial change, but will be required for the monorepo refactoring. And anything that decreases the complexity of that even so slightly is welcome IMO.