### PR TITLE
fix: break long paths

### DIFF
--- a/src/components/Docs/HttpOperation/index.tsx
+++ b/src/components/Docs/HttpOperation/index.tsx
@@ -24,7 +24,7 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(({ className, data
           {data.method || 'UNKNOWN'}
         </div>
 
-        {data.path && <div className="flex-1 font-medium text-gray-6 dark:text-gray-3">{data.path}</div>}
+        {data.path && <div className="flex-1 font-medium text-gray-6 dark:text-gray-3 break-all">{data.path}</div>}
       </h2>
 
       <MarkdownViewer


### PR DESCRIPTION
Open to suggestions on a better way to handle long paths, but they're super important, so we cannot truncate (ellipsis) them unfortunately

**Before**

<img width="1465" alt="Screen Shot 2020-07-15 at 9 02 54 AM" src="https://user-images.githubusercontent.com/7423098/87554854-4ab66a80-c67a-11ea-8dec-331850fad9d4.png">

**After**

<img width="1475" alt="Screen Shot 2020-07-15 at 9 02 04 AM" src="https://user-images.githubusercontent.com/7423098/87554866-4db15b00-c67a-11ea-9ce6-ff0109e16d7b.png">
