### PR TITLE
chore: use typings for openapi-sampler

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -89,6 +89,7 @@
     "@types/jest": "25.2.1",
     "@types/lodash": "^4.14.149",
     "@types/object-hash": "^1.3.1",
+    "@types/openapi-sampler": "^1.0.0",
     "@types/parse-prefer-header": "^1.0.1",
     "@types/react": "16.9.34",
     "@types/react-dom": "16.x.x",

--- a/packages/elements/src/utils/getOperationData.ts
+++ b/packages/elements/src/utils/getOperationData.ts
@@ -1,10 +1,9 @@
 import { JSONSchema } from '@stoplight/prism-http';
 import { HttpMethod, IHttpOperation, IHttpParam } from '@stoplight/types';
 import { filter, flatten, get, has } from 'lodash';
+import { sample } from 'openapi-sampler';
 
 import { RequestStore } from '../stores/request-maker/request';
-
-const sampler = require('openapi-sampler');
 
 export function getOperationData(operation: Partial<IHttpOperation>): Partial<RequestStore> {
   const queryParams = getParamsFromOperation(operation, 'query');
@@ -75,7 +74,7 @@ function getBodyFromOperation(operation: Partial<IHttpOperation>) {
     const schema = get(operation, 'request.body.contents[0].schema');
 
     if (schema) {
-      return sampler.sample(schema, {}, operation);
+      return sample(schema, {}, operation);
     }
   } catch (e) {
     console.warn('Unable to create sample request body from schema', e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,6 +3606,11 @@
   resolved "https://registry.yarnpkg.com/@types/object-hash/-/object-hash-1.3.1.tgz#b8145122b230bad5a13cba52016e78c54dae6ed5"
   integrity sha512-xhLwbVGAXi/LJEowMjRY1anbF5sQWeuocVjaMrFYy4bOEpl79A4eIby3xlowbkXytUdbISwOZB+vQx9Y/n0p8A==
 
+"@types/openapi-sampler@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/openapi-sampler/-/openapi-sampler-1.0.0.tgz#0975f342e82a83b79bb529895fe3e465be8b7f1c"
+  integrity sha512-u2AojBhWiatFxI/ACLKmJBSXDoVLSky7UTkeV0ZTre2CszA0R+XDzON/OaRK31nbbWLpcQFsm++bwT2LmNVsgA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
I created the typings for openapi-sampler: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46154

Let's use that so our sampler method is not all `any` anymore.