### PR TITLE
fix: publish the dist folder only

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "elements": "yarn workspace @stoplight/elements",
     "build": "yarn workspaces run build",
     "build.docs": "yarn workspaces run build.docs",
-    "release": "lerna publish --conventional-commits --yes",
+    "release": "lerna publish --conventional-commits --yes --contents dist",
     "release.docs": "yarn workspaces run release.docs",
     "type-check": "yarn workspaces run type-check",
     "test.prod": "yarn workspaces run test.prod"


### PR DESCRIPTION
Right now we publish the entire folder which is not what we intended to.
![image](https://user-images.githubusercontent.com/543372/88389311-89ed6580-cdb6-11ea-830d-fd939906e185.png)

This change supposedly forces lerna to publish a the `dist` folder only.