### PR TITLE
fix: toc row data

### DIFF
--- a/packages/elements/src/components/TableOfContents/index.tsx
+++ b/packages/elements/src/components/TableOfContents/index.tsx
@@ -35,7 +35,7 @@ const ElementsTocRow: RowComponentType<TableOfContentsLinkWithId> = props => {
       parent={null}
       index={0}
       path={[item.to]}
-      node={{ ...info, data: item, type: 'link', children: [], url: item.to }}
+      node={{ ...info, node: item.to, data: item, type: 'link', children: [], url: item.to }}
     >
       <DefaultRow {...props} item={item} />
     </Link>


### PR DESCRIPTION
We need to pass item object to be able to add `isSelected` prop in platform.
@marcelltoth was that `node` prop used anywhere? Any idea behind that? It seems redundant to me.