### PR TITLE
fix: disable web-components storybook release

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build.docs": "yarn workspaces run build.docs",
     "lint": "eslint 'packages/*/src/**/*.{ts,tsx}'",
     "release": "lerna publish --conventional-commits --yes",
-    "release.docs": "yarn workspaces run release.docs",
+    "release.docs": "yarn workspace @stoplight/elements release.docs",
     "type-check": "yarn workspaces run type-check",
     "test.prod": "yarn workspace @stoplight/elements test.prod",
     "prepublishOnly": "yarn workspaces run build"


### PR DESCRIPTION
Quick fix to get the release working again.

Later down the line we do need to set up storybook publishing because it serves as documentation