### PR TITLE
v6.0.0-beta.120

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [6.0.0](https://github.com/stoplightio/elements/compare/v6.0.0-beta.119...v6.0.0) (2020-08-07)
+# [6.0.0-beta.120](https://github.com/stoplightio/elements/compare/v6.0.0-beta.119...v6.0.0-beta.120) (2020-08-07)
 
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "6.0.0",
+  "version": "6.0.0-beta.120",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "6.0.0",
+  "version": "6.0.0-beta.120",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": false,

--- a/packages/web-components/CHANGELOG.md
+++ b/packages/web-components/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [6.0.0](https://github.com/stoplightio/elements/compare/v6.0.0-beta.119...v6.0.0) (2020-08-07)
+# [6.0.0-beta.120](https://github.com/stoplightio/elements/compare/v6.0.0-beta.119...v6.0.0-beta.120) (2020-08-07)
 
 
 ### Bug Fixes

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/web-components",
-  "version": "6.0.0",
+  "version": "6.0.0-beta.120",
   "main": "dist/bundle.js",
   "homepage": "https://github.com/stoplightio/elements",
   "bugs": "https://github.com/stoplightio/elements/issues",


### PR DESCRIPTION
For some reason CI published a v6.0.0 version. We are still investigating why, and how to get rid of it (fortunately it isn't "latest" but "beta", but still). 

This is an attempt to get back to publishing beta versions.


**Make sure you merge this with the commit message: "v6.0.0-beta.120"**