### PR TITLE
feat: add static html example

### DIFF
--- a/examples/static-html/index.html
+++ b/examples/static-html/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+
+    <title>HTML5 web-components example</title>
+
+    <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@beta/styles/elements.min.css" />
+
+    <script src="https://unpkg.com/@stoplight/web-components@beta/dist/bundle.js" defer></script>
+  </head>
+
+  <body>
+    <h1 class="text-center">Stoplight elements demo</h1>
+
+    <h2 class="text-center">Schema-viewer</h2>
+
+    <stoplight-component-schema-viewer
+      schema='{"type":"object","properties":{"firstName":{"type":"string"},"lastName":{"type":"string"}},"required":["firstName"]}'
+      title="JSON Schema Example"
+      className="m-5"></stoplight-component-schema-viewer>
+  </body>
+</html>


### PR DESCRIPTION
Adds Static HTML example on how to use Stoplight elements (web-components in this case).

Will add CRA and possibly Vue & Angular examples later on.