### PR TITLE
fix: show Example instead of default

### DIFF
--- a/packages/elements/src/components/SchemaViewer/index.tsx
+++ b/packages/elements/src/components/SchemaViewer/index.tsx
@@ -75,7 +75,7 @@ export const SchemaViewer = ({
         <SimpleTab>Schema</SimpleTab>
 
         {map(examples, (_, key) => (
-          <SimpleTab key={key}>{key}</SimpleTab>
+          <SimpleTab key={key}>{key === 'default' ? 'Example' : key}</SimpleTab>
         ))}
       </SimpleTabList>
 


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/3986. We'll need to update Elements in Platform before we can close that issue though