### PR TITLE
fix: publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "release.docs": "yarn workspace @stoplight/elements release.docs",
     "type-check": "yarn workspaces run type-check",
     "test.prod": "yarn workspace @stoplight/elements test.prod",
-    "prepublishOnly": "yarn workspaces run build"
+    "prepublishOnly": "yarn build"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
The last publish failed because the build configuration was off. 

The `prepublishOnly` hook previously did the same thing as the `build` script which made for consistent builds in CI, but as I changed the build script this was not reflected in the publish script.

This fix makes sure they'll always remain in sync by redirecting the prepublish to run the build script.