### PR TITLE
chore: on request sent/on response received

### DIFF
--- a/packages/elements/src/components/TryIt/index.tsx
+++ b/packages/elements/src/components/TryIt/index.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { useParsedValue } from '../../hooks/useParsedValue';
 import { useRequestMaker } from '../../hooks/useRequestMaker';
-import { onRequestSent, onResponseReceived } from '../../stores/request-maker';
+import { OnRequestSent, OnResponseReceived } from '../../stores/request-maker';
 import { isHttpOperation } from '../../utils/guards';
 import { RequestEditor, RequestEndpoint, RequestMakerProvider, ResponseViewer } from '../RequestMaker';
 
@@ -13,8 +13,8 @@ export interface ITryItProps {
   nodeData: unknown;
   mockUrl?: string;
   className?: string;
-  onRequestSent?: onRequestSent;
-  onResponseReceived?: onResponseReceived;
+  onRequestSent?: OnRequestSent;
+  onResponseReceived?: OnResponseReceived;
 }
 
 const TryItComponent = React.memo<ITryItProps>(

--- a/packages/elements/src/stores/request-maker/index.ts
+++ b/packages/elements/src/stores/request-maker/index.ts
@@ -31,8 +31,8 @@ export interface IRequestMakerStoreOptions {
   mockUrl?: string;
 }
 
-export type onRequestSent = (configs: { mockingEnabled: boolean }) => void;
-export type onResponseReceived = (configs: { mockingEnabled: boolean; responseStatus: number }) => void;
+export type OnRequestSent = (configs: { mockingEnabled: boolean }) => void;
+export type OnResponseReceived = (configs: { mockingEnabled: boolean; responseStatus: number }) => void;
 
 export class RequestMakerStore {
   @observable.ref
@@ -41,8 +41,8 @@ export class RequestMakerStore {
   @observable
   public isSending = false;
 
-  public onResponseReceived: onResponseReceived = () => {};
-  public onRequestSent: onRequestSent = () => {};
+  public onResponseReceived: OnResponseReceived = () => {};
+  public onRequestSent: OnRequestSent = () => {};
 
   @observable.ref
   public request = new RequestStore();


### PR DESCRIPTION
**Summary**

Added `onRequestSent` and `onResponseReceived` to the Try It component so that in platform-internal we can use it to perform event tracking.