### PR TITLE
feat: visually differentiate examples from schema

### DIFF
--- a/packages/elements/src/components/SchemaViewer/index.tsx
+++ b/packages/elements/src/components/SchemaViewer/index.tsx
@@ -75,7 +75,9 @@ export const SchemaViewer = ({
         <SimpleTab>Schema</SimpleTab>
 
         {map(examples, (_, key) => (
-          <SimpleTab key={key}>{key === 'default' ? 'Example' : key}</SimpleTab>
+          <SimpleTab key={key}>
+            <span className="font-normal italic">{key === 'default' ? 'Example' : key}</span>
+          </SimpleTab>
         ))}
       </SimpleTabList>
 


### PR DESCRIPTION
Slight UI improvement:

Before: Schema and examples are not any different visually, as if _Schema_ was just another example. There is also too much emphasis IMO.

![image](https://user-images.githubusercontent.com/543372/91867853-5da9ec00-ec74-11ea-8455-cf4b57a24f1f.png)

After: Schema is highlighted, the examples are not emphasized.

![image](https://user-images.githubusercontent.com/543372/91867793-51259380-ec74-11ea-8fe7-6eed09481b6c.png)