### PR TITLE
fix(elements-utils): export functions

### DIFF
--- a/packages/elements-utils/src/index.ts
+++ b/packages/elements-utils/src/index.ts
@@ -1,2 +1,2 @@
-export { generateToC, injectHttpOperationsAndModels } from './toc/toc';
+export { generateToC, injectHttpOperationsAndModels } from './toc';
 export * from './toc/types';

--- a/packages/elements-utils/src/toc/index.ts
+++ b/packages/elements-utils/src/toc/index.ts
@@ -1,0 +1,1 @@
+export * from './toc';


### PR DESCRIPTION
`injectHttpOperationsAndModels`is needed to enable injecting nodes in `public-apis` and `studio`