### PR TITLE
fix(elements-utils): package.json main

### DIFF
--- a/packages/elements-utils/package.json
+++ b/packages/elements-utils/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/stoplightio/elements"
   },
   "license": "Apache-2.0",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "files": [
     "**/*"
   ],


### PR DESCRIPTION
As we're currently publishing whole package with `src` and `dist` we should point to correct file.