### PR TITLE
fix: hide vertical scrolling

### DIFF
--- a/packages/elements/src/styles/_RequestMaker.scss
+++ b/packages/elements/src/styles/_RequestMaker.scss
@@ -10,10 +10,9 @@
   .#{$ns}-tab-list {
     z-index: 10;
     bottom: -1px;
-    padding: 0 0.5rem;
+    padding: 0 0.5rem 1px;
     align-items: center;
     overflow-x: auto;
-    overflow-y: hidden;
   }
 
   .#{$ns}-tab {


### PR DESCRIPTION
This PR hides vertical scrolling on Firefox, on MacOS, for the TryIt component's table header