### PR TITLE
fix(request-maker): update link to Mocking docs

### DIFF
--- a/packages/elements/src/components/RequestMaker/Request/Mocking.tsx
+++ b/packages/elements/src/components/RequestMaker/Request/Mocking.tsx
@@ -64,9 +64,7 @@ export const Mocking = observer(() => {
 
             <div className="mt-2">
               For more information on mocking,{' '}
-              <a href="https://stoplight.io/p/docs/gh/stoplightio/prism/docs/guides/01-mocking.md">
-                check out the docs
-              </a>
+              <a href="https://meta.stoplight.io/docs/prism/docs/guides/01-mocking.md">check out the docs</a>
             </div>
           </div>
         }


### PR DESCRIPTION
link be broken.

<img width="497" alt="image" src="https://user-images.githubusercontent.com/587740/93903289-767f4d80-fcc6-11ea-8e1b-860d39d81bdc.png">

https://stoplight-internal.slack.com/archives/C6K3X6N00/p1600787931010400?thread_ts=1600787878.010000&cid=C6K3X6N00