### PR TITLE
fix: always publish all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build": "yarn workspace @stoplight/elements build && yarn workspace @stoplight/elements-web-components build && yarn workspace @stoplight/elements-utils build",
     "build.docs": "yarn workspace @stoplight/elements build.docs && yarn workspace @stoplight/elements-web-components build.docs",
     "lint": "eslint 'packages/*/src/**/*.{ts,tsx}'",
-    "release": "lerna publish from-package --conventional-commits --yes",
+    "release": "lerna publish --force-publish --conventional-commits --yes",
     "release.docs": "yarn workspace @stoplight/elements release.docs",
     "type-check": "yarn workspaces run type-check",
     "test.prod": "yarn workspace @stoplight/elements test.prod && yarn workspace @stoplight/elements-utils test.prod",


### PR DESCRIPTION
Adds the `--force-publish` option: https://github.com/lerna/lerna/blob/master/commands/version/README.md#--force-publish

- maybe fixes https://github.com/stoplightio/elements/issues/587
- set root package.json back to "root" to maybe fix https://github.com/stoplightio/elements/pull/598#issuecomment-699066514