### PR TITLE
chore: eleminate dynamic arbitrary icon properties

### DIFF
--- a/packages/elements/src/components/Docs/HttpOperation/Parameters.tsx
+++ b/packages/elements/src/components/Docs/HttpOperation/Parameters.tsx
@@ -1,6 +1,6 @@
 import { PropertyTypeColors } from '@stoplight/json-schema-viewer';
 import { Dictionary, HttpParamStyles, IHttpParam, Primitive } from '@stoplight/types';
-import { FAIconProp, Tag } from '@stoplight/ui-kit';
+import { Tag } from '@stoplight/ui-kit';
 import cn from 'classnames';
 import { capitalize, get, isEmpty, keys, omit, omitBy, pick, pickBy, sortBy } from 'lodash';
 import * as React from 'react';
@@ -16,7 +16,6 @@ export interface IParametersProps {
   parameterType: ParameterType;
   parameters?: IHttpParam[];
   className?: string;
-  icon?: FAIconProp;
 }
 
 const numberValidationNames = [
@@ -52,14 +51,13 @@ export const Parameters: React.FunctionComponent<IParametersProps> = ({
   parameterType,
   title,
   className,
-  icon,
 }) => {
   const resolveRef = React.useContext(InlineRefResolverContext);
   if (!parameters || !parameters.length) return null;
 
   return (
     <div className={cn('HttpOperation__Parameters', className)}>
-      {title && <SectionTitle title={title} icon={icon} />}
+      {title && <SectionTitle title={title} />}
 
       {sortBy(parameters, ['required', 'name']).map((parameter, index) => {
         const resolvedSchema =

--- a/packages/elements/src/components/Docs/HttpOperation/SectionTitle.tsx
+++ b/packages/elements/src/components/Docs/HttpOperation/SectionTitle.tsx
@@ -1,14 +1,12 @@
-import { FAIcon, FAIconProp } from '@stoplight/ui-kit';
 import cn from 'classnames';
 import * as React from 'react';
 
 export interface ISectionTitle {
   title: string;
   className?: string;
-  icon?: FAIconProp;
 }
 
-export const SectionTitle: React.FunctionComponent<ISectionTitle> = ({ title, className, icon }) => {
+export const SectionTitle: React.FunctionComponent<ISectionTitle> = ({ title, className }) => {
   return (
     <div
       className={cn(
@@ -16,8 +14,6 @@ export const SectionTitle: React.FunctionComponent<ISectionTitle> = ({ title, cl
         className,
       )}
     >
-      {icon && <FAIcon icon={icon} className="mr-2 text-gray-6 dark:text-gray-5" />}
-
       {title}
     </div>
   );


### PR DESCRIPTION
prerequisite for #525 - eliminates the one place where we support setting an arbitrary FontAwesome icon, which we don't even take advantage of. This way we can ship Elements with a fixed subset of SVG icons.