### PR TITLE
feat(with-router): react to basePath changes

### DIFF
--- a/packages/elements/src/hoc/withRouter.tsx
+++ b/packages/elements/src/hoc/withRouter.tsx
@@ -9,9 +9,10 @@ export function withRouter<T>(
   WrappedComponent: React.ComponentType<T & RoutingProps>,
 ): React.ComponentType<T & RoutingProps> {
   const WithRouter = (props: T & RoutingProps) => {
-    const { Router, routerProps } = useRouter(props.router ?? 'history', props.basePath ?? '/');
+    const basePath = props.basePath ?? '/';
+    const { Router, routerProps } = useRouter(props.router ?? 'history', basePath);
     return (
-      <Router {...routerProps}>
+      <Router {...routerProps} key={basePath}>
         <Route path="/">
           <WrappedComponent {...props} />
         </Route>


### PR DESCRIPTION
Bit of a hack but makes Angular usage nicer. Resolves #582 

React-router does not support a dynamically set `basePath`:
https://github.com/ReactTraining/history/issues/644
https://stackoverflow.com/questions/55007809/dynamic-basename-with-browserrouter-in-react-router-dom

So we fake it with a key. 

This is of course hitting it with a hammer and will mean losing all state, but let's think about the actual usecase:
Customers are building their documentation sites. They won't be looking for dynamically updatable `basePath`s. (If they do, we'll say it's not supported.) What they are looking for is to be able to set basePath from the angular data model, which happens right after mounting. See issue #582.