### PR TITLE
fix: use value for effect running

### DIFF
--- a/packages/elements/src/hooks/useDereferencedData.ts
+++ b/packages/elements/src/hooks/useDereferencedData.ts
@@ -10,10 +10,11 @@ import { useParsedData } from './useParsedData';
  * @param type branch node snapshot type
  * @param data branch node snapshot data
  */
-export function useDereferencedData(type: NodeType, data: string) {
+export function useDereferencedData(type: NodeType, data: string | object) {
   const parsedData = useParsedData(type, data);
-
   const [dereferencedData, setDereferencedData] = React.useState(parsedData);
+
+  const key = type === NodeType.HttpOperation ? data['iid'] : parsedData;
 
   React.useEffect(() => {
     // Only dereference HTTP Operations
@@ -30,7 +31,7 @@ export function useDereferencedData(type: NodeType, data: string) {
         console.error(reason);
         setDereferencedData(parsedData);
       });
-  }, [parsedData, type]);
+  }, [parsedData, key, type]);
 
   return dereferencedData;
 }


### PR DESCRIPTION
This is required to make https://github.com/stoplightio/platform-internal/issues/4085 work

It seems like the effect dependencies are relying on the `parsedData`, which in theory should always be the same because of React.memo — it turns out this is not the case, and the documentation is clear on why:

> You may rely on useMemo as a performance optimization, not as a semantic guarantee.

That indeed does not work in all the cases, I was getting an infinite effect loop.

I have modified the code to use a value property in case it's an http operation; to be honest I do not know how to handle all the other use cases. If somebody has a better idea — be my guest.

P.S: Functional pitch: Immutable data structures would have prevent this.