### PR TITLE
docs: update elements README

### DIFF
--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -1,40 +1,15 @@
+[![npm](https://img.shields.io/npm/v/@stoplight/elements/beta?style=flat-square)](https://www.npmjs.com/package/@stoplight/elements)
+[![docs](https://img.shields.io/badge/API%20Docs-site-green.svg?style=flat-square)](https://meta.stoplight.io/docs/elements)
+[![license](https://img.shields.io/npm/l/@stoplight/elements?style=flat-square)](./LICENSE)
+
 # @stoplight/elements
 
 Elements is a collection of UI components for displaying beautiful developer documentation using an OpenAPI document or a Stoplight project.
 
 ## Documentation
 
-For full documentation, visit [https://meta.stoplight.io/docs/elements](https://meta.stoplight.io/docs/elements).
+Visit our **[Documentation Site](https://meta.stoplight.io/docs/elements)** for guides and documentation.
 
-## Getting Started
-
-Install the Elements library and peer dependencies.
-
-```bash
-yarn add @stoplight/elements @stoplight/prism-http mobx
-```
-
-Import the CSS file and choose one of the Elements components to use.
-
-The [API component](https://meta.stoplight.io/docs/elements/components/API.md) displays API reference documentation for any OpenAPI v2 or v3 document.
-
-```jsx
-import { API } from '@stoplight/elements';
-import '@stoplight/elements/styles/elements.min.css';
-
-<API 
-  apiDescriptionUrl="https://raw.githubusercontent.com/stoplightio/Public-APIs/master/reference/zoom/zoom.yaml"
-/>
-```
-
-The [Stoplight Project component](https://meta.stoplight.io/docs/elements/components/StoplightProject.md) displays the generated documentation for any Stoplight project.
-
-```jsx
-import { StoplightProject } from '@stoplight/elements';
-import '@stoplight/elements/styles/elements.min.css';
-
-<StoplightProject workspaceSlug="elements" projectSlug="studio-demo" />
-```
 
 ## Examples
 
@@ -47,6 +22,6 @@ Elements is developed and maintained by [Stoplight](https://stoplight.io).
 
 ## License
 
-Licensed under the Apache License, Copyright © 2020-present Stoplight.
+Licensed under the Apache 2.0 License, Copyright © 2020-present Stoplight.
 
-See [LICENSE](LICENSE.md) for more information.
+See [LICENSE](LICENSE) for more information.


### PR DESCRIPTION
Removes documentation from the README of elements, leaves the link to the site only. One less place to maintain, there's already way too many of those.

Adds some nice badges. I wanted to also add the Github stars one but we only have two, and even those two are me and @lottamus, so... 😢 

Corrects a dead link to the LICENCE file.