### PR TITLE
fix: breaking layout on long request param string

### DIFF
--- a/packages/elements/src/components/Docs/HttpOperation/Parameters.tsx
+++ b/packages/elements/src/components/Docs/HttpOperation/Parameters.tsx
@@ -178,7 +178,7 @@ const NumberValidations = ({ validations, className }: { validations: Dictionary
       const sign = `${key.includes('min') ? '>' : '<'}${exclusive ? '' : '='}`;
 
       return (
-        <div key={key} className={cn('ml-2 text-sm bp3-running-text', className)}>
+        <div key={key} className={cn('ml-2 text-sm bp3-running-text break-all', className)}>
           <code>{`${sign} ${validations[key]}${suffix}`}</code>
         </div>
       );
@@ -214,7 +214,7 @@ const KeyValueValidation = ({
   }
   const validation = Array.isArray(value) ? value : [value];
   return (
-    <div className={cn('text-sm mt-2 bp3-running-text', className)}>
+    <div className={cn('text-sm mt-2 bp3-running-text break-all flex flex-wrap', className)}>
       {capitalize(name)}:
       {validation
         .filter(

--- a/packages/elements/src/styles/_HttpOperation.scss
+++ b/packages/elements/src/styles/_HttpOperation.scss
@@ -12,10 +12,4 @@
     font-size: 13px;
     line-height: 1.5;
   }
-  .bp3-running-text {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    word-break: break-word;
-  }
 }


### PR DESCRIPTION
Hopefully, this resolves stoplightio/platform-internal#4196 and stoplightio/platform-internal#3421

I've added a word wrap on \<code\> element which breaks a long bearer token without spaces:

<img width="352" alt="Screenshot 2020-10-14 at 16 10 59" src="https://user-images.githubusercontent.com/1868852/96001198-10569800-0e38-11eb-9311-6de566d430d1.png">

But since multiple \<code\> elements are treated as a single string, I have also added spacing between them so it doesn't break them in the middle of an element:

<img width="358" alt="Screenshot 2020-10-14 at 16 05 49" src="https://user-images.githubusercontent.com/1868852/96001448-53187000-0e38-11eb-8eac-f63530a867e3.png">
