### PR TITLE
feat: allow passing object parameters to web components

### DIFF
--- a/packages/elements-web-components/jest.config.js
+++ b/packages/elements-web-components/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: '@stoplight/scripts',
+  testEnvironment: 'jest-environment-jsdom-sixteen',
+  snapshotSerializers: ['enzyme-to-json/serializer'],
+  coveragePathIgnorePatterns: ['__tests__', '__fixtures__', '__stories__'],
+};

--- a/packages/elements-web-components/package.json
+++ b/packages/elements-web-components/package.json
@@ -20,7 +20,8 @@
     "build": "webpack && cp ../elements/dist/styles/elements.min.css ./dist",
     "build.docs": "build-storybook -c .storybook -o docs-auto",
     "storybook": "start-storybook",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "jest"
   },
   "devDependencies": {
     "@stoplight/elements": "beta",

--- a/packages/elements-web-components/src/__stories__/Api.ts
+++ b/packages/elements-web-components/src/__stories__/Api.ts
@@ -31,3 +31,9 @@ APIWithJSONProvidedDirectly.args = {
   apiDescriptionDocument: JSON.stringify(parse(zoomApiYaml), null, '  '),
 };
 APIWithJSONProvidedDirectly.storyName = 'API With JSON Provided Directly';
+
+export const APIWithJavaScriptObjectProvidedDirectly = Template.bind({});
+APIWithJavaScriptObjectProvidedDirectly.args = {
+  apiDescriptionDocument: parse(zoomApiYaml),
+};
+APIWithJavaScriptObjectProvidedDirectly.storyName = 'API With JavaScript Provided Directly';

--- a/packages/elements-web-components/src/__tests__/createElementClass.spec.tsx
+++ b/packages/elements-web-components/src/__tests__/createElementClass.spec.tsx
@@ -1,0 +1,108 @@
+import { createElementClass } from '@stoplight/elements-web-components/src/createElementClass';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+interface TestComponentProps {
+  text: string;
+  object: object;
+  textOrObject: string | object;
+}
+
+describe('createElementClass()', () => {
+  const TestComponent = ({ text, object, textOrObject }: TestComponentProps) => {
+    return (
+      <div>
+        <div id="text">{text}</div>
+        <div id="object">{JSON.stringify(object)}</div>
+        <div id="textOrObject">{typeof textOrObject === 'string' ? textOrObject : JSON.stringify(textOrObject)}</div>
+      </div>
+    );
+  };
+
+  const TestWebComponent = createElementClass(TestComponent, {
+    text: { type: 'string', defaultValue: 'default text' },
+    object: { type: 'object', defaultValue: {} },
+    textOrObject: { type: ['string', 'object'], defaultValue: '' },
+  });
+
+  window.customElements.define('test-web-component', TestWebComponent);
+
+  let testWebComponent: HTMLElement;
+
+  beforeEach(() => {
+    act(() => {
+      testWebComponent = document.createElement('test-web-component');
+      document.body.appendChild(testWebComponent);
+    });
+  });
+
+  it('does not set default property', () => {
+    expect((testWebComponent as any).text).toEqual(undefined);
+  });
+
+  it('does not set default attribute', () => {
+    expect(testWebComponent.getAttribute('text')).toEqual(null);
+  });
+
+  it('allows to set a property', () => {
+    (testWebComponent as any).text = 'some fun text';
+
+    expect((testWebComponent as any).text).toEqual('some fun text');
+  });
+
+  it('allows to set attribute', () => {
+    testWebComponent.setAttribute('text', 'some fun text');
+
+    expect(testWebComponent.getAttribute('text')).toEqual('some fun text');
+  });
+
+  it('displays default string value in React component', () => {
+    expect(testWebComponent.querySelector('#text')!.textContent).toEqual('default text');
+  });
+
+  it('displays default object value in React component', () => {
+    expect(testWebComponent.querySelector('#object')!.textContent).toEqual('{}');
+  });
+
+  it('allows to modify object property', () => {
+    (testWebComponent as any).object = { some: 'cool object' };
+
+    expect(testWebComponent.querySelector('#object')!.textContent).toEqual('{"some":"cool object"}');
+    expect((testWebComponent as any).object).toEqual({ some: 'cool object' });
+  });
+
+  it('allows to modify JSON attribute', () => {
+    testWebComponent.setAttribute('object', '{"some":"cool object"}');
+
+    expect(testWebComponent.querySelector('#object')!.textContent).toEqual('{"some":"cool object"}');
+    expect((testWebComponent as any).object).toEqual({ some: 'cool object' });
+  });
+
+  it('allows to set a string property', () => {
+    (testWebComponent as any).textOrObject = 'some string';
+
+    expect(testWebComponent.querySelector('#textOrObject')!.textContent).toEqual('some string');
+    expect((testWebComponent as any).textOrObject).toEqual('some string');
+  });
+
+  it('allows to set a string attribute', () => {
+    testWebComponent.setAttribute('text-or-object', 'some string');
+
+    expect((testWebComponent as any).textOrObject).toEqual('some string');
+    expect(testWebComponent.querySelector('#textOrObject')!.textContent).toEqual('some string');
+  });
+
+  it('allows to set an object attribute', () => {
+    testWebComponent.setAttribute('text-or-object', '{"some": "object"}');
+
+    expect((testWebComponent as any).textOrObject).toEqual({ some: 'object' });
+    expect(testWebComponent.querySelector('#textOrObject')!.textContent).toEqual('{"some":"object"}');
+  });
+
+  it('allows to set an object property', () => {
+    (testWebComponent as any).textOrObject = { some: 'object' };
+
+    expect((testWebComponent as any).textOrObject).toEqual({ some: 'object' });
+    expect(testWebComponent.querySelector('#textOrObject')!.textContent).toEqual('{"some":"object"}');
+  });
+});

--- a/packages/elements-web-components/src/components.ts
+++ b/packages/elements-web-components/src/components.ts
@@ -14,7 +14,7 @@ export const StoplightProjectElement = createElementClass(StoplightProject, {
 
 export const ApiElement = createElementClass(API, {
   apiDescriptionUrl: { type: 'string', defaultValue: '' },
-  apiDescriptionDocument: { type: 'string', defaultValue: '' },
+  apiDescriptionDocument: { type: ['string', 'object'], defaultValue: '' },
   basePath: { type: 'string' },
   router: { type: 'string' },
   layout: { type: 'string' },


### PR DESCRIPTION
This change allows to set object *and* string properties to a web component property.

In other words, it adds support for `string | object` type for web components - currently you cannot mix types for a single property.

This PR is *not ready* - unit test's are passing, but the storybook stories are not working (lol).