### PR TITLE
chore(codeowners): add Phil to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence,
 # @lottamus will be requested for
 # review when someone opens a pull request.
-*       @lottamus @stoplightio/void-crew
+*       @philsturgeon @stoplightio/void-crew


### PR DESCRIPTION
As discussed in the meeting, Phil will sign off all Product-related PRs in addition to an engineer. 