### PR TITLE
Feat: show format next to type

### DIFF
--- a/packages/elements/src/components/Docs/HttpOperation/Parameters.tsx
+++ b/packages/elements/src/components/Docs/HttpOperation/Parameters.tsx
@@ -190,9 +190,11 @@ const NumberValidations = ({ validations, className }: { validations: Dictionary
 
 const KeyValueValidations = ({ validations, className }: { validations: Dictionary<unknown>; className?: string }) => (
   <>
-    {keys(validations).map(key => {
-      return <KeyValueValidation key={key} name={key} value={validations[key]} className={className} />;
-    })}
+    {keys(validations)
+      .filter(validation => validation !== 'format')
+      .map(key => {
+        return <KeyValueValidation key={key} name={key} value={validations[key]} className={className} />;
+      })}
   </>
 );
 


### PR DESCRIPTION
This PR is a part of https://github.com/stoplightio/elements/issues/653 - it covers displaying property format next to its type. The next step will be doing the same thing for JSV.