### PR TITLE
fix: bump markdown viewer to 4.3.1

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -53,7 +53,7 @@
     "@stoplight/json-schema-ref-parser": "^9.0.4",
     "@stoplight/json-schema-viewer": "^3.0.0-beta.28",
     "@stoplight/markdown": "^2.9.0",
-    "@stoplight/markdown-viewer": "^4.2.2",
+    "@stoplight/markdown-viewer": "^4.3.1",
     "@stoplight/path": "^1.3.2",
     "@stoplight/react-error-boundary": "^1.1.0",
     "@stoplight/tree-list": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3721,11 +3721,18 @@
     lodash "^4.17.19"
 
 "@stoplight/elements@beta":
-  version "6.0.0-beta.122"
-  resolved "https://registry.yarnpkg.com/@stoplight/elements/-/elements-6.0.0-beta.122.tgz#e9599f51cd101ed4abf7e17bbae709672b52fbb9"
-  integrity sha512-mcnAfNRPHrDrwnvJWv9youLAmjNPDxcwz67g5pgmkW1PhnsA5axOXi63FpiefS94uHJyE/a0nwOPurwKBZkLJQ==
+  version "6.0.0-beta.175"
+  resolved "https://registry.yarnpkg.com/@stoplight/elements/-/elements-6.0.0-beta.175.tgz#ac1c2715678a64e8ac5a565869903e906ae79d72"
+  integrity sha512-O4FqqZjPvlLHAOB8318V+rMICTvqaZwGs1iRbWbbcCIZWg1af3RM2715U8D0KJM1NDOJRMT3DjBNFsqekH7oBQ==
   dependencies:
-    "@stoplight/json" "^3.8.6"
+    "@fortawesome/fontawesome-svg-core" "^1.2.31"
+    "@fortawesome/free-solid-svg-icons" "^5.14.0"
+    "@fortawesome/react-fontawesome" "^0.1.11"
+    "@stoplight/elements-utils" beta
+    "@stoplight/http-spec" "^3.1.1"
+    "@stoplight/httpsnippet" "^1.2.1"
+    "@stoplight/json" "^3.9.0"
+    "@stoplight/json-schema-ref-parser" "^9.0.4"
     "@stoplight/json-schema-viewer" "^3.0.0-beta.28"
     "@stoplight/markdown" "^2.9.0"
     "@stoplight/markdown-viewer" "^4.2.2"
@@ -3733,7 +3740,7 @@
     "@stoplight/react-error-boundary" "^1.1.0"
     "@stoplight/tree-list" "^5.0.3"
     "@stoplight/types" "^11.9.0"
-    "@stoplight/ui-kit" "^3.0.0-beta.29"
+    "@stoplight/ui-kit" "^3.0.0-beta.37"
     "@stoplight/yaml" "^4.2.1"
     axios "^0.19.2"
     classnames "^2.2.6"
@@ -3741,18 +3748,20 @@
     fast-text-encoding "^1.0.1"
     fp-ts "^2.5.3"
     graphql "^14"
-    httpsnippet "github:stoplightio/httpsnippet#master"
     lodash "^4.17.19"
     mobx-react-lite "^1.5.2"
     object-hash "^2.0.3"
-    openapi-sampler "^1.0.0-beta.15"
+    openapi-sampler "^1.0.0-beta.16"
     parse-prefer-header "^1.0.0"
+    prop-types "^15.7.2"
     react-error-boundary "^1.2.5"
+    react-router-dom "^5.2.0"
+    react-router-hash-link "^2.1.0"
+    swr "^0.3.0"
     tslib "^1.12.0"
     type-is "^1.6.18"
     unist-util-select "^3.0.1"
     urijs "^1.19.2"
-    urql "^1.9.6"
 
 "@stoplight/eslint-config@^1.1.0":
   version "1.1.0"
@@ -3828,7 +3837,7 @@
     mobx-react-lite "^1.4.1"
     pluralize "^8.0.0"
 
-"@stoplight/json@^3.5.1", "@stoplight/json@^3.6", "@stoplight/json@^3.7.1", "@stoplight/json@^3.8.1", "@stoplight/json@^3.8.6", "@stoplight/json@^3.9.0":
+"@stoplight/json@^3.5.1", "@stoplight/json@^3.6", "@stoplight/json@^3.7.1", "@stoplight/json@^3.8.1", "@stoplight/json@^3.9.0":
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.9.0.tgz#ade6c5a75bfc55a464d81e902c53a8862c98b462"
   integrity sha512-jgEKIPMLbhaU5Nw9yw+VBw2OSfDxm8VQ/k5JNezAuDMjcmqCPz3rOQTVNOROStzi70l4DRxF7eBN9liYJq5Ojw==
@@ -3847,10 +3856,10 @@
     strict-event-emitter-types "^2.0.0"
     wolfy87-eventemitter "~5.2.8"
 
-"@stoplight/markdown-viewer@^4.2.2":
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-4.2.2.tgz#b2c6a2fcc3adfe33fa3fe76d10af56205c227bf0"
-  integrity sha512-wzTXCOUkP9AFGvreXf4jCDgWKI3mk5b7vDfwvd+k2zqP3TdYVFmMhkqTjlvxIFl8DODxXzfng5DiedO4j9hyuQ==
+"@stoplight/markdown-viewer@^4.2.2", "@stoplight/markdown-viewer@^4.3.1":
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-4.3.1.tgz#61a2d79f6520d0d73654cf9b8f5848d0ea0daae3"
+  integrity sha512-Nj8shF+USr6oznmly7C1c5n+gCdNkMp+bOI84br5eYfEWD6SfK1GjEHR78Cq+pUrlUhGQn68FjJE8/4dXRKD4w==
   dependencies:
     "@stoplight/json" "^3.6"
     "@stoplight/markdown" "^2.9.1"
@@ -4014,7 +4023,7 @@
     "@types/json-schema" "^7.0.4"
     utility-types "^3.10.0"
 
-"@stoplight/ui-kit@^3.0.0-beta.29", "@stoplight/ui-kit@^3.0.0-beta.37":
+"@stoplight/ui-kit@^3.0.0-beta.37":
   version "3.0.0-beta.37"
   resolved "https://registry.yarnpkg.com/@stoplight/ui-kit/-/ui-kit-3.0.0-beta.37.tgz#7666f15e7a4b1f719308d3b3878bbb265c748ff2"
   integrity sha512-xtn7M595JwTCkg/kbUHz2TJqpqFCcLxHfqSC8SM3LS0Jg7S0abWUZbZgNNL5oJQ5cmFg3MGmZ2K29bApSsfuxw==
@@ -6031,13 +6040,6 @@
   integrity sha512-k5PiZdB4vklUpUX4NBncn5RBKty8G3ihTY+hqJsCdMuD0v4jofI5xuqwnVcWxfv6iTm2P/dfEa2wMUnsUY8ODw==
   dependencies:
     eslint-visitor-keys "^1.1.0"
-
-"@urql/core@^1.10.8":
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-1.10.8.tgz#bf9ca3baf3722293fade7481cd29c1f5049b9208"
-  integrity sha512-lScBVB7N4aij3SXtIMrRo+rcYJavi/Y53YSuhj4/bGhlxogSq+4nbd3UjnUXer2hIfaTEi0egLnqjE5cW5WQVQ==
-  dependencies:
-    wonka "^4.0.9"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -12174,21 +12176,6 @@ https-proxy-agent@^5.0.0:
   dependencies:
     agent-base "6"
     debug "4"
-
-"httpsnippet@github:stoplightio/httpsnippet#master":
-  version "1.21.0"
-  resolved "https://codeload.github.com/stoplightio/httpsnippet/tar.gz/74790e451c0837cecb2fa873281537337ea52372"
-  dependencies:
-    chalk "^1.1.1"
-    commander "^2.9.0"
-    debug "^2.2.0"
-    event-stream "3.3.4"
-    form-data "^3.0.0"
-    fs-readfile-promise "^2.0.1"
-    fs-writefile-promise "^1.0.3"
-    har-validator "^5.0.0"
-    pinkie-promise "^2.0.0"
-    stringify-object "^3.3.0"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -21420,14 +21407,6 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-urql@^1.9.6:
-  version "1.9.6"
-  resolved "https://registry.yarnpkg.com/urql/-/urql-1.9.6.tgz#88590f1f54774190adbdd468457ee7779a60f2e5"
-  integrity sha512-n4RTViR0KuNlcz97pYBQ7ojZzEzhCYgylhhmhE2hOhlvb+bqEdt83ZymmtSnhw9Qi17Xc/GgSjE7itYw385JCA==
-  dependencies:
-    "@urql/core" "^1.10.8"
-    wonka "^4.0.9"
-
 use-callback-ref@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.1.tgz#898759ccb9e14be6c7a860abafa3ffbd826c89bb"
@@ -21992,11 +21971,6 @@ wolfy87-eventemitter@~5.2.8:
   version "5.2.9"
   resolved "https://registry.yarnpkg.com/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.9.tgz#e879f770b30fbb6512a8afbb330c388591099c2a"
   integrity sha512-P+6vtWyuDw+MB01X7UeF8TaHBvbCovf4HPEMF/SV7BdDc1SMTiBy13SRD71lQh4ExFTG1d/WNzDGDCyOKSMblw==
-
-wonka@^4.0.9:
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.9.tgz#b21d93621e1d5f3b45ca96d99d03711c7c1f7c55"
-  integrity sha512-he7Nn1254ToUN03zLbJok6QxKdRJd46/QHm8nUcJNViXQnCutCuUgAbZvzoxrX+VXzGb4sCFolC4XhkHsmvdaA==
 
 word-wrap@^1.0.3, word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
For the future - remember that `elements-web-components` package depends on `elements` package, which gets reflected in `yarn.lock` file. Old `elements` version kept the old `markdown-viewer` version as dependency. Bumping `elements` in `elements-web-components` was necessary to leave only one `markdown-viewer` version in `yarn.lock`.

Closes #573