### PR TITLE
fix: use branch for http queries

### DIFF
--- a/packages/elements/src/containers/Docs.tsx
+++ b/packages/elements/src/containers/Docs.tsx
@@ -40,6 +40,7 @@ export const Docs = ({ className, node }: IDocsProps) => {
     platformUrl: info.host,
     workspaceSlug: info.workspace,
     projectSlug: info.project,
+    branchSlug: info.branch,
     nodeUri: node,
     authToken: info.authToken,
   });

--- a/packages/elements/src/containers/TableOfContents.tsx
+++ b/packages/elements/src/containers/TableOfContents.tsx
@@ -34,6 +34,7 @@ export function TableOfContents<E>({
     platformUrl,
     workspaceSlug,
     projectSlug,
+    branchSlug,
     authToken,
   });
 

--- a/packages/elements/src/containers/TryIt.tsx
+++ b/packages/elements/src/containers/TryIt.tsx
@@ -32,6 +32,7 @@ export const TryIt = ({ className, node }: ITryItProps) => {
     platformUrl: info.host,
     workspaceSlug: info.workspace,
     projectSlug: info.project,
+    branchSlug: info.branch,
     nodeUri,
     authToken: info.authToken,
   });
@@ -40,6 +41,7 @@ export const TryIt = ({ className, node }: ITryItProps) => {
     platformUrl: info.host,
     workspaceSlug: info.workspace,
     projectSlug: info.project,
+    branchSlug: info.branch,
     nodeUri,
     authToken: info.authToken,
   });


### PR DESCRIPTION
Branch should be present as query param. I was pretty sure it was there already but appears it's missing.

Could be verified with storybook and `StoplightProject`