### PR TITLE
feat: readOnly writeOnly schemas

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -51,7 +51,7 @@
     "@stoplight/httpsnippet": "^1.2.1",
     "@stoplight/json": "^3.9.0",
     "@stoplight/json-schema-ref-parser": "^9.0.4",
-    "@stoplight/json-schema-viewer": "^3.0.0-beta.28",
+    "@stoplight/json-schema-viewer": "^3.0.0-beta.32",
     "@stoplight/markdown": "^2.9.0",
     "@stoplight/markdown-viewer": "^4.3.1",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/src/components/Docs/HttpOperation/Body.tsx
+++ b/packages/elements/src/components/Docs/HttpOperation/Body.tsx
@@ -30,7 +30,7 @@ export const Body = ({ body, className }: IBodyProps) => {
 
       {body.description && <MarkdownViewer className="mt-6" markdown={body.description} />}
 
-      {isJSONSchema(schema) && <SchemaViewer className="mt-6" schema={schema} examples={examples} />}
+      {isJSONSchema(schema) && <SchemaViewer className="mt-6" schema={schema} examples={examples} viewMode="write" />}
     </div>
   );
 };

--- a/packages/elements/src/components/Docs/HttpOperation/Responses.tsx
+++ b/packages/elements/src/components/Docs/HttpOperation/Responses.tsx
@@ -89,7 +89,7 @@ export const Response = ({ className, response }: IResponseProps) => {
 
       <Parameters className="mb-6" title="Headers" parameterType="header" parameters={response.headers} />
 
-      {content?.schema && <SchemaViewer schema={content.schema} examples={examples} forceShowTabs />}
+      {content?.schema && <SchemaViewer schema={content.schema} examples={examples} viewMode="read" forceShowTabs />}
     </div>
   );
 };

--- a/packages/elements/src/components/SchemaViewer/index.tsx
+++ b/packages/elements/src/components/SchemaViewer/index.tsx
@@ -1,7 +1,7 @@
 import { Classes, Intent, Popover, PopoverInteractionKind, Tag } from '@blueprintjs/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { safeStringify } from '@stoplight/json';
-import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
+import { JsonSchemaViewer, ViewMode } from '@stoplight/json-schema-viewer';
 import { CLASSNAMES } from '@stoplight/markdown-viewer';
 import { JSONSchema } from '@stoplight/prism-http';
 import { Dictionary, NodeType } from '@stoplight/types';
@@ -25,6 +25,7 @@ export interface ISchemaViewerProps {
   examples?: Dictionary<string>;
   className?: string;
   forceShowTabs?: boolean;
+  viewMode?: ViewMode;
 }
 
 const JSV_MAX_ROWS = 20;
@@ -36,6 +37,7 @@ export const SchemaViewer = ({
   examples,
   errors,
   maxRows = JSV_MAX_ROWS,
+  viewMode,
   forceShowTabs,
 }: ISchemaViewerProps) => {
   const [selectedIndex, setSelectedIndex] = React.useState(0);
@@ -55,6 +57,7 @@ export const SchemaViewer = ({
           className={jsvClassName}
           schema={schema as JSONSchema4}
           maxRows={maxRows}
+          viewMode={viewMode}
           shouldResolveEagerly
         />
       </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3814,6 +3814,15 @@
     json-schema-compare "^0.2.2"
     lodash "^4.17.4"
 
+"@stoplight/json-schema-merge-allof@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-merge-allof/-/json-schema-merge-allof-0.7.2.tgz#a9f4d95b4a95e943afa567c695a1d4a2add9b74a"
+  integrity sha512-fVS5GqYBlxZfX1fA9+ULiny8VaCR3O62p3BHYd7+30rf378pVW6UPPydeB5AXs5U621LJKYdrGyndpOdTJ5dFA==
+  dependencies:
+    compute-lcm "^1.1.0"
+    json-schema-compare "^0.2.2"
+    lodash "^4.17.4"
+
 "@stoplight/json-schema-ref-parser@^9.0.4":
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/@stoplight/json-schema-ref-parser/-/json-schema-ref-parser-9.0.4.tgz#e369b135101d66ff24262c2cfdaf20a482669058"
@@ -3830,6 +3839,20 @@
   dependencies:
     "@stoplight/json" "^3.5.1"
     "@stoplight/json-schema-merge-allof" "^0.7.1"
+    "@stoplight/react-error-boundary" "^1.0.0"
+    "@stoplight/tree-list" "^5.0.3"
+    classnames "^2.2.6"
+    lodash "^4.17.15"
+    mobx-react-lite "^1.4.1"
+    pluralize "^8.0.0"
+
+"@stoplight/json-schema-viewer@^3.0.0-beta.32":
+  version "3.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-3.0.0-beta.32.tgz#6404804d3865def7898cdc85c89c888cd29391a2"
+  integrity sha512-4RnHH5FjSq1PgKvNuwfptqGI6cu8I9QNvkck/trCiGMAH7LGZcmEP1O9BYKhM4S9003TNCld7KcEGog1tEGHMQ==
+  dependencies:
+    "@stoplight/json" "^3.5.1"
+    "@stoplight/json-schema-merge-allof" "^0.7.2"
     "@stoplight/react-error-boundary" "^1.0.0"
     "@stoplight/tree-list" "^5.0.3"
     classnames "^2.2.6"


### PR DESCRIPTION
Closes https://github.com/stoplightio/elements/issues/634

Adds support for `readOnly` `writeOnly` properties in schemas when used with HTTP Operation requests and responses.

This PR generally bumps JSV. The main feature is [here](https://github.com/stoplightio/json-schema-viewer/pull/83).