### PR TITLE
fix(request-maker): try it crash when request schema contains circular references

### DIFF
--- a/packages/elements/src/stores/request-maker/index.ts
+++ b/packages/elements/src/stores/request-maker/index.ts
@@ -50,10 +50,10 @@ export class RequestMakerStore {
   @observable.ref
   public response = ResponseStore.createEmpty();
 
-  @observable
+  @observable.ref
   private _originalOperation?: Partial<IHttpOperation>;
 
-  @observable
+  @observable.ref
   private _originalRequest?: Partial<IHttpRequest>;
 
   constructor(options?: IRequestMakerStoreOptions) {


### PR DESCRIPTION
Will solve stoplightio/platform-internal#4529

For those that are interested:

MobX cannot handle circular references in a sense that it cannot wrap an object with circular refs into an `observable`.

For this and other reasons we were not deeply wrapping the request and response stores. (See `@observable.ref` above `new RequestStore`.)

But we have this `_originalRequest` which serves as some backup to hold the original state of the request maker. We forgot to mark `_originalRequest` as `@observable.ref` which meant that when we make the backup MobX will try to wrap the backup value into an `observable`, failing miserably of course.