### PR TITLE
chore: get rid of WrapperComponent markdown component

### DIFF
--- a/packages/elements/src/context/Components.tsx
+++ b/packages/elements/src/context/Components.tsx
@@ -25,31 +25,28 @@ interface ComponentsProviderProps {
   value: Partial<IComponentMapping> | undefined;
 }
 
-const CodeComponent = (props: IComponentMappingProps<ICode>) => {
-  const { node } = props;
-  const { annotations } = node;
-  const nodeType = get(annotations, 'type') || node.meta;
-
-  if (['json_schema', 'http'].includes(nodeType)) {
-    return <WrapperComponent {...props} />;
-  }
-
-  const DefaultCode = defaultComponentMapping.code!;
-  return <DefaultCode {...props} />;
-};
-
-const WrapperComponent = ({ node, parent }: IComponentMappingProps<ICode<ICodeAnnotations>>) => {
+const CodeComponent = (props: IComponentMappingProps<ICode<ICodeAnnotations>>) => {
+  const { node, parent } = props;
   const { annotations, value } = node;
-
-  // TODO (CL): We need to resolve this value to support $ref's in Markdown
-  const parsedValue = useParsedValue(value);
   const nodeType = get(annotations, 'type') || node.meta;
 
-  if (nodeType === 'json_schema' && isJSONSchema(parsedValue)) {
+  const parsedValue = useParsedValue(value);
+
+  if (nodeType === 'json_schema') {
+    if (!isJSONSchema(parsedValue)) {
+      return null;
+    }
+
     return (
       <SchemaViewer title={annotations?.title} schema={parsedValue} examples={getExamplesFromSchema(parsedValue)} />
     );
-  } else if (nodeType === 'http' && isObject(parsedValue)) {
+  }
+
+  if (nodeType === 'http') {
+    if (!isObject(parsedValue)) {
+      return null;
+    }
+
     return (
       <HttpRequest
         className={cn('my-10', {
@@ -60,7 +57,8 @@ const WrapperComponent = ({ node, parent }: IComponentMappingProps<ICode<ICodeAn
     );
   }
 
-  return null;
+  const DefaultCode = defaultComponentMapping.code!;
+  return <DefaultCode {...props} />;
 };
 
 const defaultComponents: IComponentMapping = {


### PR DESCRIPTION
Part one of #273 

I separated this to make it easier to review on its own. 

In theory **this PR is designed to be pure refactoring, without any change in code behavior whatsoever**. I basically inlined `WrapperComponent`. 

Review it with an eye on this. If you think there is any valid circumstance under which the new code works differently than the old one, raise it please. If not, let's get this merged and I'll keep going.

The diff looks weird. It merges parts of `CodeComponent` and the old `WrapperComponent`. If you'd like to follow my way of thinking I would look at the old and the new code side-by-side and go through this process of thought:
1. What happens if `nodeType === 'json_schema'`
   1.1. What if `parsedValue` is an object
   1.2. What if it's not
2. What happens if `nodeType === 'http'`
   2.1. ...
3. What if neither?