### PR TITLE
fix: add deprecation notice to repo and NPM package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Stoplight is actively working on a new, updated version 6, that is easier to use
 
 *Stoplight Elements v6* is **currently in beta**. If you would like to try it out now, check out our latest beta release.
 
-[![npm (tag)](https://img.shields.io/npm/v/@stoplight/elements/beta?style=flat-square)](https://www.npmjs.com/package/@stoplight/elements/v/beta)
-[![npm (tag)](https://img.shields.io/npm/v/@stoplight/elements-web-components/beta?style=flat-square)](https://www.npmjs.com/package/@stoplight/elements-web-components/v/beta)
+[![npm (tag)](https://img.shields.io/npm/v/@stoplight/elements/beta?style=flat-square&label=elements)](https://www.npmjs.com/package/@stoplight/elements/v/beta)
+[![npm (tag)](https://img.shields.io/npm/v/@stoplight/elements-web-components/beta?style=flat-square&label=elements-web-components)](https://www.npmjs.com/package/@stoplight/elements-web-components/v/beta)
 [![docs site](https://img.shields.io/badge/API%20Docs-site-green.svg?style=flat-square)](https://meta.stoplight.io/docs/elements)
 
 


### PR DESCRIPTION
## Problem statement

@rossmcdonald noted that we are still advertising Elements v5 on NPM as the latest release, even though it's broken on Platform v5.

See conversation here: https://stoplight-internal.slack.com/archives/C01D80M6EHX/p1604595177001200

## Solution

This PR adds a deprecation notice to the README. It is a _fix_ which means it will trigger a build and release (assuming CI is set up right, I haven't touched this version of elements before). This means the README should get pushed out to NPM.

## Further considerations

1. @marbemac mentioned we could start thinking about doing a limited public release, where we cut `v6` as is now, without openly advertising it. This still locks us to semver changes though.

2. What if we tagged our beta releases as `latest` for now? I think that also has the effect of showing the new version by default on NPM, while still versioning as `beta`. Having the old one as `latest` doesn't add much value if it's broken after all, does it?