### PR TITLE
fix: better error handling

### DIFF
--- a/packages/elements/src/containers/Provider.tsx
+++ b/packages/elements/src/containers/Provider.tsx
@@ -10,7 +10,7 @@ export interface IProvider extends IActiveInfo {
 }
 
 export interface IActiveInfo {
-  host?: string;
+  host: string;
   workspace: string;
   project: string;
   branch?: string;


### PR DESCRIPTION
Required for stoplightio/platform-internal#4686

Technically the bug is not here, the problem is that platform passes `""` as `platformUrl` (instead of the actual `appUrl`) which makes elements do a relative-URL lookup. Which fails of course. `authToken` is also missing.

What this PR does is it fixes error handling. Error handling didn't work because the request does succeed: it reaches the SPA entry point and receives some HTML.

This is a bit opinionated and will fail in case we ever return a string or a number from an API endpoint directly. I don't think this is ever the case nor do I see a more solid solution. WDYT?