### PR TITLE
fix(elements-web-components): remove outdated example from README.md

### DIFF
--- a/packages/elements-web-components/README.md
+++ b/packages/elements-web-components/README.md
@@ -8,30 +8,6 @@ Elements is a collection of UI components for displaying beautiful developer doc
 
 For full documentation, visit [https://meta.stoplight.io/docs/elements](https://meta.stoplight.io/docs/elements).
 
-## Getting Started
-
-Include the Elements CSS stylesheet and JavaScript bundle within the `<head>` of your document.
-
-```html
-<link rel="stylesheet" href="https://unpkg.com/@stoplight/elements-web-components/dist/elements.min.css" />
-
-<script src="https://unpkg.com/@stoplight/elements-web-components/dist/elements.min.js"></script>
-```
-
-Then place one of the Elements components within the `<body>`.
-
-The [API component](https://meta.stoplight.io/docs/elements/components/API.md) displays API reference documentation for any OpenAPI v2 or v3 document.
-
-```html
-<elements-api apiDescriptionUrl="https://raw.githubusercontent.com/stoplightio/Public-APIs/master/reference/zoom/zoom.yaml"></elements-api>
-```
-
-The [Stoplight Project component](https://meta.stoplight.io/docs/elements/components/StoplightProject.md) displays the generated documentation for any Stoplight project.
-
-```html
-<elements-stoplight-project workspaceSlug="elements" projectSlug="studio-demo"></elements-stoplight-project>
-```
-
 ## Examples
 
 - [Angular Starter](https://github.com/stoplightio/elements-starter-angular)


### PR DESCRIPTION
As the title says.

It is outdated bc the URL is wrong. But anyhow, we don't want to maintain yet another piece of redundant documentation, just redirect them to the official site.