### PR TITLE
fix: unstuck headers

### DIFF
--- a/packages/elements/src/components/RequestMaker/Request/Headers.tsx
+++ b/packages/elements/src/components/RequestMaker/Request/Headers.tsx
@@ -21,7 +21,7 @@ export const RequestHeaders = observer<IRequestHeaders>(({ className }) => {
       className={cn('RequestMaker__RequestHeaders', className)}
       suggestRenderer={({ name, params, index, inFocus, setInFocus, handlerPropChange, onBlur }) => (
         <HeaderSuggest
-          key="name"
+          key={name}
           inputProps={{
             placeholder: 'Specify header name',
             autoFocus: inFocus.index === index && inFocus.prop === 'name',


### PR DESCRIPTION
Fixes https://github.com/stoplightio/platform-internal/issues/4821

Problem occurred in quite rare scenario and was due to how Suggest component works.
When switching operations, header names that are proper `HeaderField` objects (not queries) were keeping their previous values despite having new query from different operation.
This is fixed by making sure each parameter has the key property matching its name value.

Here's the spec file with such headers: https://github.com/stoplightio/platform-internal/files/5679987/Issue3.yaml.zip 