### PR TITLE
chore: move ‘send’ button to more visible area

### DIFF
--- a/packages/elements/src/components/RequestMaker/Request/Editor.tsx
+++ b/packages/elements/src/components/RequestMaker/Request/Editor.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { useRequestMakerStore } from '../../../hooks/useRequestMakerStore';
 import { getEnabledParams } from '../../../utils/params';
 import { TabTitle } from '../TabTitle';
+import { RequestSend } from '.';
 import { RequestBody } from './Body';
 import { CodeGenerator } from './CodeGenerator';
 import { RequestHeaders } from './Headers';
@@ -134,6 +135,7 @@ export const RequestEditor = observer<RequestEditorProps>(({ tabs = defaultAvail
 
         <Tabs.Expander />
       </Tabs>
+      <RequestSend className="my-3 ml-2" />
     </div>
   );
 });

--- a/packages/elements/src/components/RequestMaker/Request/Endpoint.tsx
+++ b/packages/elements/src/components/RequestMaker/Request/Endpoint.tsx
@@ -9,7 +9,6 @@ import URI from 'urijs';
 import { useRequestMakerStore } from '../../../hooks/useRequestMakerStore';
 import { highlightText } from '../../../utils/highlightText';
 import { RequestMethod } from './Method';
-import { RequestSend } from './Send';
 
 const ServerSuggest = Suggest.ofType<string>();
 
@@ -126,7 +125,6 @@ export const RequestEndpoint = observer<{
         }}
         large
       />
-      {!showServerSuggestor && <RequestSend />}
     </div>
   );
 });

--- a/packages/elements/src/components/RequestMaker/__tests__/RequestEditor.spec.tsx
+++ b/packages/elements/src/components/RequestMaker/__tests__/RequestEditor.spec.tsx
@@ -1,11 +1,13 @@
 import 'jest-enzyme';
 
+import { Button, ButtonGroup } from '@stoplight/ui-kit';
 import { mount, ReactWrapper } from 'enzyme';
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 
 import { RequestMakerProvider } from '../../../hooks/useRequestMakerStore';
 import { RequestMakerStore } from '../../../stores/request-maker';
+import { RequestSend } from '../Request';
 import { RequestEditor } from '../Request/Editor';
 import { TabTitle } from '../TabTitle';
 
@@ -66,5 +68,25 @@ describe('RequestSend component', () => {
     wrapper.update();
 
     expect(wrapper.findWhere(c => c.is(TabTitle) && c.prop('title') === 'Body')).toHaveProp('count', 1);
+  });
+
+  it('runs mock() when isMockEnabled is true', () => {
+    const rmStore = new RequestMakerStore({
+      operation: { method: 'get', path: '/path' },
+    });
+    rmStore.request.shouldMock = true;
+    const spy = jest.spyOn(rmStore, 'mock');
+
+    wrapper = mount(
+      <RequestMakerProvider value={rmStore}>
+        <RequestEditor />
+      </RequestMakerProvider>,
+    );
+
+    wrapper.find(RequestSend).find(ButtonGroup).find(Button).first().simulate('click');
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    spy.mockRestore();
   });
 });

--- a/packages/elements/src/components/RequestMaker/__tests__/RequestEndpoint.spec.tsx
+++ b/packages/elements/src/components/RequestMaker/__tests__/RequestEndpoint.spec.tsx
@@ -1,6 +1,6 @@
 import 'jest-enzyme';
 
-import { Button, ButtonGroup, InputGroup } from '@stoplight/ui-kit';
+import { InputGroup } from '@stoplight/ui-kit';
 import { Suggest } from '@stoplight/ui-kit/Select';
 import { mount, ReactWrapper } from 'enzyme';
 import * as React from 'react';
@@ -9,7 +9,6 @@ import { operation } from '../__fixtures__/http';
 import { RequestMakerProvider } from '../../../hooks/useRequestMakerStore';
 import { RequestMakerStore } from '../../../stores/request-maker';
 import { RequestStore } from '../../../stores/request-maker/request';
-import { RequestSend } from '../Request';
 import { RequestEndpoint } from '../Request/Endpoint';
 
 describe('RequestEndpoint component', () => {
@@ -100,25 +99,5 @@ describe('RequestEndpoint component', () => {
 
     expect(store.request.url).toEqual('/test');
     expect(sendSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('runs mock() when isMockEnabled is true', () => {
-    const rmStore = new RequestMakerStore({
-      operation: { method: 'get', path: '/path' },
-    });
-    rmStore.request.shouldMock = true;
-    const spy = jest.spyOn(rmStore, 'mock');
-
-    wrapper = mount(
-      <RequestMakerProvider value={rmStore}>
-        <RequestEndpoint />
-      </RequestMakerProvider>,
-    );
-
-    wrapper.find(RequestSend).find(ButtonGroup).find(Button).first().simulate('click');
-
-    expect(spy).toHaveBeenCalledTimes(1);
-
-    spy.mockRestore();
   });
 });

--- a/packages/elements/src/components/TryIt/index.tsx
+++ b/packages/elements/src/components/TryIt/index.tsx
@@ -7,7 +7,6 @@ import { OnRequestSent, OnResponseReceived } from '../../stores/request-maker';
 import { createRequestMakerStore } from '../../utils/createRequestMakerStore';
 import { isHttpOperation } from '../../utils/guards';
 import { RequestEditor, RequestEndpoint, RequestMakerProvider, ResponseViewer } from '../RequestMaker';
-import { RequestSend } from '../RequestMaker/Request/Send';
 
 export interface ITryItProps {
   nodeType: string;
@@ -43,7 +42,6 @@ const TryItComponent = React.memo<ITryItProps>(
           <RequestEndpoint className="rounded" />
 
           <RequestEditor className="mt-10 border-t rounded" />
-          <RequestSend className="mt-10" />
 
           <ResponseViewer className="mt-10 border-t rounded" />
         </RequestMakerProvider>


### PR DESCRIPTION
This PR moves 'Send' button underneath `<RequestEditor />` so that it's more easily viewable from the Try It Out tab within platform.

We (Growth team) know that there are lots of changes to the Request Maker coming down the pike with the Elements reboot, but in the meantime, we'd like to experiment to see if having that 'Send' button in a more noticeable place results in more people utilizing the feature. 

Please see more context [here](https://www.notion.so/stoplight/9fd5223159844d79b500c84cd34fe976?v=b40e0520f4f942ca81936b9247b65121&p=1eebda3727494cc7ad559563bbcdc767).

<img width="648" alt="Screen Shot 2020-12-18 at 11 32 25 AM" src="https://user-images.githubusercontent.com/47359669/102643335-bb2f4f00-4124-11eb-8b5b-e31ff1f2a34e.png">

Before:
<img width="1411" alt="Screen Shot 2020-12-18 at 11 33 42 AM" src="https://user-images.githubusercontent.com/47359669/102643546-0cd7d980-4125-11eb-80aa-98a1aba193f4.png">


After:
<img width="1408" alt="Screen Shot 2020-12-18 at 11 36 00 AM" src="https://user-images.githubusercontent.com/47359669/102643760-59231980-4125-11eb-93c2-69bf43ea54a2.png">
