### PR TITLE
fix: tryit header suggest

### DIFF
--- a/packages/elements/src/components/RequestMaker/Request/Headers.tsx
+++ b/packages/elements/src/components/RequestMaker/Request/Headers.tsx
@@ -19,9 +19,9 @@ export const RequestHeaders = observer<IRequestHeaders>(({ className }) => {
     <RequestParameters
       type="header"
       className={cn('RequestMaker__RequestHeaders', className)}
-      suggestRenderer={({ name, params, index, inFocus, setInFocus, handlerPropChange, onBlur }) => (
+      suggestRenderer={({ name, key, params, index, inFocus, setInFocus, handlerPropChange, onBlur }) => (
         <HeaderSuggest
-          key={name}
+          key={key}
           inputProps={{
             placeholder: 'Specify header name',
             autoFocus: inFocus.index === index && inFocus.prop === 'name',

--- a/packages/elements/src/components/RequestMaker/Request/Parameters.tsx
+++ b/packages/elements/src/components/RequestMaker/Request/Parameters.tsx
@@ -17,6 +17,7 @@ type PropChangeHandler = <T extends keyof IParam>(prop: T, index: number, value:
 
 interface ISuggestRendererOptions {
   name: string;
+  key: string;
   params: IParam[];
   index: number;
   inFocus: InFocus;
@@ -34,6 +35,7 @@ export const RequestParameters = observer<IRequestParameters>(({ type, className
   const [inFocus, setInFocus] = React.useState({ prop: 'name', index: -1 });
   const requestStore = useRequestMakerStore('request');
   const parameters: IParam[] = requestStore[`${type}Params`];
+  const operationKey = `${requestStore.method}:${requestStore.url}`;
 
   const handlerPropChange: PropChangeHandler = React.useCallback(
     (prop, index, value) => {
@@ -85,6 +87,7 @@ export const RequestParameters = observer<IRequestParameters>(({ type, className
               {suggestRenderer ? (
                 suggestRenderer({
                   name: param.name,
+                  key: operationKey,
                   params: parameters,
                   index,
                   inFocus,


### PR DESCRIPTION
Follow up of https://github.com/stoplightio/elements/pull/764
Fixes https://github.com/stoplightio/platform-internal/issues/4821

Previous PR fixed the issue but introduced another bug.
The problem here is the `Suggest` component keeps old value of `HeaderField` instead of using new `query` value after switching operation. 
Previous approach fixed that by adding `key` with param name, but since that value is changing with every character typed it triggers rerender and focus is lost.
The solution for that is using key which is unique for operation, but not a single param.

![Peek 2020-12-19 15-22](https://user-images.githubusercontent.com/14196079/102691653-46384400-420e-11eb-87e7-26ada1748bd3.gif)
