### PR TITLE
chore: initial commit various mock visibility

### DIFF
--- a/packages/elements/src/components/Docs/HttpService/index.tsx
+++ b/packages/elements/src/components/Docs/HttpService/index.tsx
@@ -13,7 +13,7 @@ import { HttpSecuritySchemes } from '../HttpSecuritySchemes';
 
 export type HttpServiceProps = IDocsComponentProps<Partial<IHttpService>>;
 
-const HttpServiceComponent = React.memo<HttpServiceProps>(({ className, data }) => {
+const HttpServiceComponent = React.memo<HttpServiceProps>(({ className, data, mockUrl }) => {
   return (
     <div className={cn('HttpService MarkdownViewer', className)}>
       {data.name !== void 0 && <h1 className={Classes.HEADING}>{data.name}</h1>}
@@ -72,6 +72,14 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(({ className, data }) 
               </a>
             </div>
           ))}
+          {mockUrl && (
+            <div className="MarkdownViewer flex items-center flex-1 mt-4">
+              <div className="mr-2">Mock Server</div>
+              <a href={mockUrl} target="_blank" rel="noopener noreferrer">
+                {mockUrl}
+              </a>
+            </div>
+          )}
         </div>
       ) : null}
 

--- a/packages/elements/src/components/Docs/index.tsx
+++ b/packages/elements/src/components/Docs/index.tsx
@@ -15,17 +15,20 @@ interface IBaseDocsProps {
 export interface IDocsProps extends IBaseDocsProps {
   nodeData: unknown;
   headless?: boolean;
+  mockUrl?: string;
 }
 
 export interface IParsedDocsProps<T = unknown> extends IBaseDocsProps {
   nodeData: T;
   headless?: boolean;
+  mockUrl?: string;
 }
 
 export interface IDocsComponentProps<T = unknown> {
   data: T;
   className?: string;
   headless?: boolean;
+  mockUrl?: string;
 }
 
 const UnsupportedNodeType = () => {
@@ -43,18 +46,20 @@ export const NodeTypeComponent: Dictionary<React.ComponentType<IDocsComponentPro
   [NodeType.Unknown]: UnsupportedNodeType,
 };
 
-export const Docs = React.memo<IDocsProps>(({ nodeType, nodeData, className, headless }) => {
+export const Docs = React.memo<IDocsProps>(({ nodeType, nodeData, className, headless, mockUrl }) => {
   const parsedData = useParsedData(nodeType, nodeData);
 
-  return <ParsedDocs className={className} nodeData={parsedData} nodeType={nodeType} headless={headless} />;
+  return (
+    <ParsedDocs className={className} nodeData={parsedData} nodeType={nodeType} headless={headless} mockUrl={mockUrl} />
+  );
 });
 
-export const ParsedDocs: React.FC<IParsedDocsProps> = ({ nodeType, nodeData, className, headless }) => {
+export const ParsedDocs: React.FC<IParsedDocsProps> = ({ nodeType, nodeData, className, headless, mockUrl }) => {
   const Component = NodeTypeComponent[nodeType];
 
   if (!Component) return null;
 
-  return <Component className={className} data={nodeData} headless={headless} />;
+  return <Component className={className} data={nodeData} headless={headless} mockUrl={mockUrl} />;
 };
 
 export { DocsSkeleton } from './Skeleton';

--- a/packages/elements/src/components/RequestMaker/Request/Mocking.tsx
+++ b/packages/elements/src/components/RequestMaker/Request/Mocking.tsx
@@ -1,5 +1,19 @@
-import { Button, HTMLSelect, Menu, MenuDivider, MenuItem, Popover, Position, Switch } from '@stoplight/ui-kit';
+import { faCopy } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { safeStringify } from '@stoplight/json';
+import {
+  Button,
+  FormInput,
+  HTMLSelect,
+  Menu,
+  MenuDivider,
+  MenuItem,
+  Popover,
+  Position,
+  Switch,
+} from '@stoplight/ui-kit';
 import cn from 'classnames';
+import copy from 'copy-to-clipboard';
 import { observer } from 'mobx-react-lite';
 import * as React from 'react';
 
@@ -57,14 +71,32 @@ export const Mocking = observer(() => {
         title="Mocking"
         description={
           <div>
+            {store.isMockEnabled && (
+              <FormInput
+                className="pb-2"
+                readOnly
+                type="text"
+                value={store.request.url}
+                dir="auto"
+                rightElement={
+                  <Popover
+                    content={<div className="p-3 text-center w-64">The copied link is the mock URL structure.</div>}
+                  >
+                    <Button
+                      intent="primary"
+                      minimal
+                      onClick={() => {
+                        copy(safeStringify(store.request.url, undefined, 2) || '');
+                      }}
+                      icon={<FontAwesomeIcon icon={faCopy} className="mr-2" />}
+                    />
+                  </Popover>
+                }
+              />
+            )}
             <div>
-              Enable mocking to send requests to a simulated API. You can choose to receive a specific response code and
-              example or have one dynamically generated for you based on this operation's response schema.
-            </div>
-
-            <div className="mt-2">
-              For more information on mocking,{' '}
-              <a href="https://meta.stoplight.io/docs/prism/docs/guides/01-mocking.md">check out the docs</a>
+              Enable mocking to send requests to a simulated API. For more information on mocking,{' '}
+              <a href="https://meta.stoplight.io/docs/prism/docs/guides/01-mocking.md">check out the docs.</a>
             </div>
           </div>
         }
@@ -103,9 +135,8 @@ export const Mocking = observer(() => {
           description={
             <div>
               <div>
-                By default, an appropriate response will be returned based on the request input. If you would like to
-                receive a specific response, you can choose one of the defined codes and examples using the dropdown to
-                the right and a <code>Prefer</code> header will be configured for you.
+                By default, an appropriate response will be returned based on the request input. Use the dropdown to the
+                right to receive a specific response.
               </div>
             </div>
           }
@@ -188,9 +219,8 @@ export const Mocking = observer(() => {
           description={
             <div>
               <div>
-                By default, mocked responses are statically generated. If you would like to receive a dynamically
-                generated response, you can choose the <code>dynamic</code> option using the dropdown to the right and a{' '}
-                <code>Prefer</code> headed will be configured for you.
+                By default, mocked responses are statically generated. Use the dropdown to the right to receive a
+                dynamic response.
               </div>
             </div>
           }

--- a/packages/elements/src/containers/Docs.tsx
+++ b/packages/elements/src/containers/Docs.tsx
@@ -7,32 +7,44 @@ import * as React from 'react';
 import { DocsSkeleton, ParsedDocs } from '../components/Docs';
 import { InlineRefResolverProvider } from '../context/InlineRefResolver';
 import { useParsedData } from '../hooks/useParsedData';
-import { usePlatformApi } from '../hooks/usePlatformApi';
+import { useActionsApi, usePlatformApi } from '../hooks/usePlatformApi';
 import { BundledBranchNode } from '../types';
 import { ActiveInfoContext } from './Provider';
+import { MockUrlResult } from './TryIt';
 
 export interface IDocsProps {
   className?: string;
   node?: string;
 }
 
-const DocsPopup = React.memo<{ nodeType: NodeType; nodeData: unknown; className?: string }>(
-  ({ nodeType, nodeData, className }) => {
+const DocsPopup = React.memo<{ nodeType: NodeType; nodeData: unknown; mockUrl?: string; className?: string }>(
+  ({ nodeType, nodeData, mockUrl, className }) => {
     const document = useParsedData(nodeType, nodeData);
+
     return (
       <InlineRefResolverProvider document={document}>
-        <ParsedDocs className={className} nodeType={nodeType} nodeData={document} />
+        <ParsedDocs className={className} nodeType={nodeType} nodeData={document} mockUrl={mockUrl} />
       </InlineRefResolverProvider>
     );
   },
 );
 
 const bundledNodesUri = 'api/v1/projects/{workspaceSlug}/{projectSlug}/bundled-nodes/{uri}';
+const mockActionsUrl = 'api/actions/branchNodeMockUrl';
 
 export const Docs = ({ className, node }: IDocsProps) => {
   const info = React.useContext(ActiveInfoContext);
 
   const { data: result, error } = usePlatformApi<BundledBranchNode>(bundledNodesUri, {
+    platformUrl: info.host,
+    workspaceSlug: info.workspace,
+    projectSlug: info.project,
+    branchSlug: info.branch,
+    nodeUri: node,
+    authToken: info.authToken,
+  });
+
+  const { data: mockUrlResult } = useActionsApi<MockUrlResult>(mockActionsUrl, {
     platformUrl: info.host,
     workspaceSlug: info.workspace,
     projectSlug: info.project,
@@ -57,5 +69,12 @@ export const Docs = ({ className, node }: IDocsProps) => {
     return <DocsSkeleton />;
   }
 
-  return <DocsPopup nodeType={result.type} nodeData={result.data} className={className} />;
+  return (
+    <DocsPopup
+      nodeType={result.type}
+      nodeData={result.data}
+      mockUrl={mockUrlResult?.servicePath}
+      className={className}
+    />
+  );
 };

--- a/packages/elements/src/containers/TryIt.tsx
+++ b/packages/elements/src/containers/TryIt.tsx
@@ -14,7 +14,7 @@ export interface ITryItProps {
   node?: string;
 }
 
-type MockUrlResult = { servicePath: string; operationPath?: string; id: number };
+export type MockUrlResult = { servicePath: string; operationPath?: string; id: number };
 
 const bundledNodesUri = 'api/v1/projects/{workspaceSlug}/{projectSlug}/bundled-nodes/{uri}';
 const mockActionsUrl = 'api/actions/branchNodeMockUrl';


### PR DESCRIPTION
This PR addresses the following [Notion card](https://www.notion.so/stoplight/9fd5223159844d79b500c84cd34fe976?v=b40e0520f4f942ca81936b9247b65121&p=c1431459b5c84f25b112a73ada822889)

1. Adds mock server URL to the project overview in docs
2. Reduces the text inside the RequestMaker Mock tab
3. If mocking is enabled in Mock tab, adds ability to also copy mock url from Mock tab (this is in addition to the pre-existing option to copy from the Send button dropdown menu)

<img width="538" alt="Screen Shot 2020-12-30 at 11 31 18 AM" src="https://user-images.githubusercontent.com/47359669/103370537-ad69ba00-4a92-11eb-9284-74e3c51a4973.png">

<img width="644" alt="Screen Shot 2020-12-30 at 11 28 01 AM" src="https://user-images.githubusercontent.com/47359669/103370453-78f5fe00-4a92-11eb-9b68-937e53c08772.png">
