### PR TITLE
chore: update dependencies on master, too

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,21 @@ version: 1
 update_configs:
   - package_manager: 'javascript'
     directory: '/'
+    target_branch: v7
+    update_schedule: 'live'
+    version_requirement_updates: 'increase_versions'
+
+    commit_message:
+      prefix: 'fix'
+      prefix_development: 'fix'
+      include_scope: true
+
+    allowed_updates:
+      - match:
+          update_type: 'security'
+  - package_manager: 'javascript'
+    directory: '/'
+    target_branch: master
     update_schedule: 'live'
     version_requirement_updates: 'increase_versions'
 


### PR DESCRIPTION
I just noticed that @dependabot only acts on branch v7. This is dangerous because security updates don't get into master. This PR fixes that. I'm not sure if I should file this against v7 or master, but likely v7 as that is our default branch.