### PR TITLE
fix: disappearing TryIt response

### DIFF
--- a/packages/elements/src/containers/TryIt.tsx
+++ b/packages/elements/src/containers/TryIt.tsx
@@ -58,7 +58,7 @@ export const TryIt = ({ className, node }: ITryItProps) => {
     return null;
   }
 
-  if (!nodeData) {
+  if (!nodeData || !mockUrlResult) {
     return <DocsSkeleton />;
   }
 


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/4980

The reason for that bug to occur is the rare case when `branchNodeMockUrl` request that finishes after the TryIt request is sent and receives response. This way once `branchNodeMockUrl` returns response it triggers rerendering of component and disappearance of previously receive TryIt response.

This PR makes TryIt wait for `branchNodeMockUrl` result the same way it does for `bundled-nodes` data.

Issue can be reproduced by adding a sleep function for http fetcher for `branchNodeMockUrl` request.