### PR TITLE
Fix(Try It): limit request body usage for specific methods

### DIFF
--- a/packages/elements/src/components/TryIt/TryIt.tsx
+++ b/packages/elements/src/components/TryIt/TryIt.tsx
@@ -88,14 +88,15 @@ export const TryIt: React.FC<TryItProps> = ({ httpOperation, showMocking, mockUr
     try {
       setLoading(true);
       const mockData = getMockData(mockUrl, httpOperation, mockingOptions);
-      const hasRequestBody =
-        httpOperation.method.toUpperCase() === 'PUT' ||
-        httpOperation.method.toUpperCase() === 'POST' ||
-        httpOperation.method.toUpperCase() === 'PATCH';
+      const shouldIncludeBody = ['PUT', 'POST', 'PATCH'].includes(httpOperation.method.toUpperCase());
       const request = await buildFetchRequest({
         parameterValues: parameterValuesWithDefaults,
         httpOperation,
-        bodyInput: hasRequestBody ? (formDataState.isFormDataBody ? bodyParameterValues : textRequestBody) : undefined,
+        bodyInput: shouldIncludeBody
+          ? formDataState.isFormDataBody
+            ? bodyParameterValues
+            : textRequestBody
+          : undefined,
         mockData,
       });
       const response = await fetch(...request);


### PR DESCRIPTION
I've faced an issue where I couldn't send a request using `Try It`, because we are currently attaching request body to each `fetch()` call.

Current behaviour:
<img width="636" alt="Screenshot 2021-02-04 at 16 34 04" src="https://user-images.githubusercontent.com/58433203/106915845-ce16d680-6706-11eb-9593-1c39f495617f.png">

After this fix:
<img width="595" alt="Screenshot 2021-02-04 at 16 34 45" src="https://user-images.githubusercontent.com/58433203/106915921-e5ee5a80-6706-11eb-99e0-b59c7b2f5449.png">


This should fix it.