### PR TITLE
test: fix sloppy tests

### DIFF
--- a/packages/elements/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements/src/components/TryIt/TryIt.spec.tsx
@@ -344,13 +344,7 @@ describe('TryIt', () => {
         clickSend();
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-        expect(fetchMock).toBeCalledWith(
-          'https://todos.stoplight.io/users',
-          expect.objectContaining({
-            method: 'patch',
-            body: JSON.stringify({ name: 'Andrew', age: 19, trial: true }),
-          }),
-        );
+        expect(fetchMock.mock.calls[0]![1]!.body).toEqual(expect.stringMatching(/{.*}/));
       });
     });
 
@@ -361,13 +355,7 @@ describe('TryIt', () => {
         clickSend();
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-        expect(fetchMock).toBeCalledWith(
-          'https://todos.stoplight.io/users',
-          expect.objectContaining({
-            method: 'head',
-            body: undefined,
-          }),
-        );
+        expect(typeof fetchMock.mock.calls[0]![1]!.body).not.toBe('string');
       });
     });
 
@@ -432,20 +420,16 @@ describe('TryIt', () => {
       });
 
       it('sends a request with request body from example', async () => {
+        const jsonString = '{"name":"Andrew","age":19,"trial":true}';
+
         render(<TryItWithPersistence httpOperation={examplesRequestBody} />);
 
-        expect(screen.getByRole('textbox')).toHaveTextContent('{"name":"Andrew","age":19,"trial":true}');
+        expect(screen.getByRole('textbox')).toHaveTextContent(jsonString);
 
         clickSend();
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
-        expect(fetchMock).toBeCalledWith(
-          'https://todos.stoplight.io/users',
-          expect.objectContaining({
-            method: 'post',
-            body: JSON.stringify({ name: 'Andrew', age: 19, trial: true }),
-          }),
-        );
+        expect(fetchMock.mock.calls[0]![1]!.body).toEqual(jsonString);
       });
     });
   });


### PR DESCRIPTION
@mmiask correctly observed that **some tests were failing on the tip of v7**.

These failures were likely introduced before #848 was merged and #848 was not up to date at the time of merge, hence the error. What's more interesting is **why** these tests were failing. They were because `TryIt` changed a little.

This is a **good thing** because we have don't have a bug.

This is a **bad thing** because we could have written the tests in a way that avoids the need for such change.

I think there are three learning opportunities here:
1. `expect.objectContaining` disallows extra properties in nested objects. **Not good.** At least not for what we were using it for.
2. When testing, let's make sure we **assert exactly what is being tested** in that test. Not *less* but not *more* either. This was the case of asserting more (because of the `objectContaining` issue above), and it caused more fragile tests as a consequence.
3. `toHaveBeenCalledWith` is nice to look at but rarely accurate. `.mock.calls[x][y]!` is much uglier, but usually **you can write better assertions with it**. And it's worth it. Think about it like this: You use it -> you write the perfect assertion -> you don't have to look at it again 😉 