### PR TITLE
test: fix useDereferencedHttpOperation tests

### DIFF
--- a/packages/elements/src/hooks/useDereferencedHttpOperation.spec.ts
+++ b/packages/elements/src/hooks/useDereferencedHttpOperation.spec.ts
@@ -34,21 +34,21 @@ describe('useDereferencedData', () => {
   it('provides the input value before dereferencing happens', () => {
     const input = simpleParsedNode;
     const { result } = renderHook(() => useDereferencedHttpOperation(input));
-    expect(result.current?.data).toEqual(input);
+    expect(result.current?.data).toEqual(input.data);
   });
 
   it('uses ref parser correctly', async () => {
     const input = simpleParsedNode;
     const { result, waitForNextUpdate } = renderHook(() => useDereferencedHttpOperation(simpleParsedNode));
     await waitForNextUpdate({ timeout: 300 });
-    expect(result.current?.data).toEqual({ ...input, __dereferenced: true });
+    expect(result.current?.data).toEqual({ ...input.data, __dereferenced: true });
   });
 
   it('handles dereferencing errors', async () => {
     const input: ParsedNode = { type: 'http_operation', data: { ...simpleHttpOperation, __error: true } as any };
     const { result, waitForNextUpdate } = renderHook(() => useDereferencedHttpOperation(input));
     await waitForNextUpdate({ timeout: 300 });
-    expect(result.current?.data).toEqual({ ...input, __errored: true });
+    expect(result.current?.data).toEqual({ ...input.data, __errored: true });
   });
 
   it('is not prone to race conditions', async () => {


### PR DESCRIPTION
v7-tip tests are broken again.

When I merged #838 it wasn't up to date with v7, ergo #848 wasn't included. The tests weren't ran, so we didn't catch it. 

This PR fixes the problem.

We should also make sure every other PR contains #848 before merging.