### PR TITLE
Chore: bump markdown-viewer to 4.3.3

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -52,7 +52,7 @@
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-viewer": "^3.0.0-beta.33",
     "@stoplight/markdown": "^2.10.0",
-    "@stoplight/markdown-viewer": "^4.3.2",
+    "@stoplight/markdown-viewer": "^4.3.3",
     "@stoplight/path": "^1.3.2",
     "@stoplight/react-error-boundary": "^1.1.0",
     "@stoplight/tree-list": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3842,13 +3842,13 @@
     strict-event-emitter-types "^2.0.0"
     wolfy87-eventemitter "~5.2.8"
 
-"@stoplight/markdown-viewer@^4.3.2":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-4.3.2.tgz#8a746fc731df15f884edfc7e1e6c831b84a2cad7"
-  integrity sha512-sNmZSzHKuWh19Kfd90vAjQkupL93UGUq1ZnKZDi6a5RroDD3MYcc5su/MrTsvTwXwTda8y1z2tMogBDujzlE1w==
+"@stoplight/markdown-viewer@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-4.3.3.tgz#57e65b6599057d37b21689a45f7cc107217c2189"
+  integrity sha512-+xrz9YYdYrzlcTF9oyp2Jw4n5bt4GxoDRKI2BeWib8hcBddnhW8q7YhU2RKZhkLLCKyi2Pk4YKE28nMgvery+w==
   dependencies:
     "@stoplight/json" "^3.6"
-    "@stoplight/markdown" "^2.9.1"
+    "@stoplight/markdown" "^2.11.0"
     "@stoplight/react-error-boundary" "^1.0.0"
     classnames "^2"
     dompurify "^2.0.11"
@@ -3857,10 +3857,10 @@
     remark-slug "^6.0.0"
     unified "^9.0.0"
 
-"@stoplight/markdown@^2.10.0", "@stoplight/markdown@^2.9.1":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/markdown/-/markdown-2.10.0.tgz#b8cf098a8c76a0342bf89637a978ea2047576ce4"
-  integrity sha512-UdvFMtcxCY4RoU7e/9Bbhbe4G1ej4vBni/NQl7+cU0UrcI3Bz6jzxeweF9q6vsF7716+cX1u95tduyRk2zVWEQ==
+"@stoplight/markdown@^2.10.0", "@stoplight/markdown@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/markdown/-/markdown-2.11.0.tgz#a4736be93200d0d74dbbdba6d5c302308f77257e"
+  integrity sha512-EPUzoEPl1vC0V9PwC47XRYCcmhXCOpJ0JfPZsn2uFYX5I4gchJU6bXJ+03u/8ZwzPMpqvmU7/y/UvEEGkrKzkg==
   dependencies:
     "@stoplight/yaml" "^4.0.2"
     lodash "^4.17.15"


### PR DESCRIPTION
Follow up to https://github.com/stoplightio/markdown-viewer/pull/75
A part of https://github.com/stoplightio/platform-internal/issues/5188