### PR TITLE
feat: export RequestBodyProps interface

### DIFF
--- a/packages/elements/src/components/TryIt/RequestBody.tsx
+++ b/packages/elements/src/components/TryIt/RequestBody.tsx
@@ -4,7 +4,7 @@ import { CodeEditor } from '@stoplight/mosaic-code-editor';
 import { INodeExample, INodeExternalExample } from '@stoplight/types';
 import * as React from 'react';
 
-interface RequestBodyProps {
+export interface RequestBodyProps {
   examples: ReadonlyArray<INodeExample | INodeExternalExample>;
   requestBody: string;
   onChange: (newRequestBody: string) => void;


### PR DESCRIPTION
Without this export, I'm getting errors when trying to embed `Try It` in `platform-internal`

```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.
```