### PR TITLE
release: v7.0.0-alpha.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/elements-utils/package.json
+++ b/packages/elements-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-utils",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.3",
   "homepage": "https://github.com/stoplightio/elements",
   "bugs": "https://github.com/stoplightio/elements/issues",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/elements-web-components/package.json
+++ b/packages/elements-web-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-web-components",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.3",
   "main": "dist/elements.min.js",
   "homepage": "https://github.com/stoplightio/elements",
   "bugs": "https://github.com/stoplightio/elements/issues",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": false,
@@ -42,7 +42,6 @@
     "react-dom": ">=16.8"
   },
   "dependencies": {
-    "openapi-sampler": "^1.0.0-beta.18",
     "@fortawesome/fontawesome-svg-core": "^1.2.31",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
@@ -54,8 +53,8 @@
     "@stoplight/markdown": "^2.10.0",
     "@stoplight/markdown-viewer": "^4.3.3",
     "@stoplight/mosaic": "1.0.0-beta.22",
-    "@stoplight/mosaic-code-viewer": "1.0.0-beta.20",
     "@stoplight/mosaic-code-editor": "1.0.0-beta.22",
+    "@stoplight/mosaic-code-viewer": "1.0.0-beta.20",
     "@stoplight/path": "^1.3.2",
     "@stoplight/react-error-boundary": "^1.1.0",
     "@stoplight/tree-list": "^5.0.3",
@@ -69,6 +68,7 @@
     "jotai": "^0.12.4",
     "lodash": "^4.17.19",
     "nanoid": "^3.1.20",
+    "openapi-sampler": "^1.0.0-beta.18",
     "prop-types": "^15.7.2",
     "react-router-dom": "^5.2.0",
     "react-router-hash-link": "^2.1.0",
@@ -78,7 +78,6 @@
     "urijs": "^1.19.4"
   },
   "devDependencies": {
-    "@types/openapi-sampler": "^1.0.0",
     "@stoplight/scripts": "8.2.3",
     "@storybook/addon-docs": "^6.1.15",
     "@storybook/addon-essentials": "^6.1.15",
@@ -95,6 +94,7 @@
     "@types/har-format": "^1.2.5",
     "@types/httpsnippet": "^1.23.0",
     "@types/lodash": "^4.14.149",
+    "@types/openapi-sampler": "^1.0.0",
     "@types/prop-types": "^15.7.3",
     "@types/react": "16.9.34",
     "@types/react-router-dom": "^5.1.5",


### PR DESCRIPTION
I don't think we updated versions in `package.json` when releasing v7 alpha to npm. I suggest doing that from now on.

Additional info: this PR does not release Elements, it only bumps the version. The release process is being handled manually by running a script.