### PR TITLE
fix: double render of Markdown

### DIFF
--- a/packages/elements/src/components/MarkdownViewer/index.tsx
+++ b/packages/elements/src/components/MarkdownViewer/index.tsx
@@ -6,9 +6,9 @@ import { useComponents } from '../../context/Components';
 /**
  * Wraps @stoplight/markdown-viewer and passes in custom components from the context provider
  */
-export const MarkdownViewer = (props: IMarkdownViewerProps) => {
+export const MarkdownViewer = React.memo((props: IMarkdownViewerProps) => {
   const components = useComponents();
 
   return <MarkdownViewerComponent {...props} components={components} />;
-};
+});
 MarkdownViewer.displayName = 'MarkdownViewer';


### PR DESCRIPTION
*Update: I'm now quite confident this fixes the flakiness. I've re-run the e2e tests in platform-internal using a yalced version of this 4 times and the Dereferencing - Export test hasn't failed once.*

I've diagnosed the root cause of the flaky Dereferencing - Export e2e test to the fact that the Element's ParsedDocs component double-renders the MarkdownViewer component. The second render is triggered by setting the `container` ref that's used to compute the container width that controls the responsive article header design.

This change fixed it for me. Because Studio creates a new markdown AST for each change, shallow memoization does not create a problem for the Studio Preview usage of the MarkdownViewer either.

# Before: MarkdownViewer is re-rendered on the next React frame
![2021-02-18 15 48 44](https://user-images.githubusercontent.com/587740/108419770-f1f71380-7200-11eb-8033-e6f5f9c347ad.gif)


# After: memoized MarkdownViewer is not re-rendered
![2021-02-18 15 43 55](https://user-images.githubusercontent.com/587740/108419582-b2c8c280-7200-11eb-8c48-f2c68b8c17ed.gif)
