### PR TITLE
fix: request sample standalone language

### DIFF
--- a/packages/elements/src/components/RequestSamples/RequestSamples.tsx
+++ b/packages/elements/src/components/RequestSamples/RequestSamples.tsx
@@ -41,7 +41,7 @@ export const RequestSamples = React.memo<RequestSamplesProps>(({ request }) => {
 
     const [language, library] = value.split(' / ');
     setSelectedLanguage(language);
-    setSelectedLibrary(library);
+    setSelectedLibrary(library || '');
   };
 
   return (
@@ -51,7 +51,7 @@ export const RequestSamples = React.memo<RequestSamplesProps>(({ request }) => {
         <Select
           onChange={handleSelectClick}
           options={selectOptions}
-          value={`${selectedLanguage} / ${selectedLibrary}`}
+          value={selectedLibrary ? `${selectedLanguage} / ${selectedLibrary}` : selectedLanguage}
         />
       </Panel.Titlebar>
       <Panel.Content p={0}>

--- a/packages/elements/src/components/RequestSamples/__tests__/RequestSamples.test.tsx
+++ b/packages/elements/src/components/RequestSamples/__tests__/RequestSamples.test.tsx
@@ -76,4 +76,14 @@ describe('RequestSend', () => {
 
     expect(secondLangSelector).toHaveValue('JavaScript / Fetch');
   });
+
+  it('switches to language with no library', () => {
+    const { container } = render(<RequestSamples request={sampleRequest} />);
+    const langSelector = screen.getByRole('combobox');
+    const objcOption = screen.getByRole('option', { name: /obj-c/i });
+    userEvent.selectOptions(langSelector, objcOption);
+
+    expect(langSelector).toHaveValue('Obj-C');
+    expect(container).toHaveTextContent('#import <Foundation/Foundation.h>');
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/stoplightio/elements/issues/906

Initially I planned to allow setting library as `undefined` but empty string makes handling atoms easier as it doesn't require creating a generic type for `persistAtom` function.