### PR TITLE
fix: showing examples menu when there is only one example

### DIFF
--- a/packages/elements/src/__fixtures__/operations/examples-request-body.ts
+++ b/packages/elements/src/__fixtures__/operations/examples-request-body.ts
@@ -68,4 +68,56 @@ export const examplesRequestBody: IHttpOperation = {
   },
 };
 
+export const singleExampleRequestBody: IHttpOperation = {
+  id: '?http-operation-id?',
+  iid: 'PUT_USERS',
+  method: 'put',
+  path: '/users',
+  summary: 'Put Users',
+  responses: [
+    {
+      code: '200',
+    },
+  ],
+  servers: [
+    {
+      url: 'https://todos.stoplight.io',
+    },
+  ],
+  request: {
+    body: {
+      contents: [
+        {
+          mediaType: 'application/json',
+          schema: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+              age: {
+                type: 'number',
+              },
+              trial: {
+                type: 'boolean',
+                readOnly: true,
+              },
+            },
+          },
+          examples: [
+            {
+              key: 'example-1',
+              value: {
+                name: 'Andrew',
+                age: 19,
+                trial: true,
+              },
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
 export default examplesRequestBody;

--- a/packages/elements/src/components/TryIt/RequestBody.tsx
+++ b/packages/elements/src/components/TryIt/RequestBody.tsx
@@ -19,7 +19,7 @@ export const RequestBody: React.FC<RequestBodyProps> = ({ examples, requestBody,
     <Panel defaultIsOpen>
       <Panel.Titlebar
         rightComponent={
-          examples.length > 0 && (
+          examples.length > 1 && (
             <Menu
               label="Examples"
               trigger={

--- a/packages/elements/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements/src/components/TryIt/TryIt.spec.tsx
@@ -6,7 +6,7 @@ import fetchMock from 'jest-fetch-mock';
 import * as React from 'react';
 
 import { httpOperation as base64FileUpload } from '../../__fixtures__/operations/base64-file-upload';
-import { examplesRequestBody } from '../../__fixtures__/operations/examples-request-body';
+import { examplesRequestBody, singleExampleRequestBody } from '../../__fixtures__/operations/examples-request-body';
 import { headWithRequestBody } from '../../__fixtures__/operations/head-todos';
 import { httpOperation as multipartFormdataOperation } from '../../__fixtures__/operations/multipart-formdata-post';
 import { httpOperation as sortedParameters } from '../../__fixtures__/operations/operation-parameters';
@@ -514,6 +514,25 @@ describe('TryIt', () => {
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalled());
         expect(JSON.parse(fetchMock.mock.calls[0]![1]!.body as string)).toEqual(json);
+      });
+    });
+
+    describe('when there is only one example provided', () => {
+      it('displays that only example body', () => {
+        render(<TryItWithPersistence httpOperation={singleExampleRequestBody} />);
+        expect(JSON.parse(screen.getByRole('textbox').textContent || '')).toEqual({
+          name: 'Andrew',
+          age: 19,
+          trial: true,
+        });
+      });
+
+      it('does not display select to choose examples', () => {
+        render(<TryItWithPersistence httpOperation={singleExampleRequestBody} />);
+
+        let examplesButton = screen.queryByRole('button', { name: 'Examples' });
+
+        expect(examplesButton).not.toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
Fixes #895 