### PR TITLE
fix(docs): make badges margin even

### DIFF
--- a/packages/elements/src/components/Docs/HttpOperation/Badges.tsx
+++ b/packages/elements/src/components/Docs/HttpOperation/Badges.tsx
@@ -13,7 +13,7 @@ export const Badge: React.FC<{
   className?: string;
   children: string;
 }> = ({ icon, className, children }) => (
-  <Tag role="badge" className={cs('text-md p-1 font-semibold mt-1', className)} round aria-label={children}>
+  <Tag role="badge" className={cs('text-md p-1 font-semibold mt-1 mx-1', className)} round aria-label={children}>
     {icon && <FontAwesomeIcon className="mr-2" icon={icon} />}
     <span>{children}</span>
   </Tag>
@@ -34,7 +34,7 @@ export const SecurityBadge: React.FC<{ scheme: HttpSecurityScheme; httpServiceUr
   httpServiceUri,
 }) => {
   const badge = (
-    <Badge icon={faLock} className="bg-gray-6 mx-1 max-w-xs truncate">
+    <Badge icon={faLock} className="bg-gray-6 max-w-xs truncate">
       {getReadableSecurityName(scheme, true)}
     </Badge>
   );


### PR DESCRIPTION
Resolves: #943 

## Before
![image](https://user-images.githubusercontent.com/58433203/112640200-66952180-8e41-11eb-89fd-908973f27e3e.png)

## After
![Screenshot 2021-03-26 at 14 42 16](https://user-images.githubusercontent.com/58433203/112640279-790f5b00-8e41-11eb-8119-ceffc7e9416f.png)
