### PR TITLE
fix: display readable error message for network error

### DIFF
--- a/packages/elements/src/components/TryIt/TryIt.tsx
+++ b/packages/elements/src/components/TryIt/TryIt.tsx
@@ -60,7 +60,6 @@ interface ErrorState {
  * Displays the TryIt component for a given IHttpOperation.
  * Relies on jotai, needs to be wrapped in a PersistenceContextProvider
  */
-
 export const TryIt: React.FC<TryItProps> = ({
   httpOperation,
   showMocking,


### PR DESCRIPTION
Fixes #915 

This one does few changes around how are we handle errors in TryIt:
There are two `fetch` API functions that can throw:
   - `fetch` itself, in which case I wrap it in custom `NetworkError`, simply to make an elegant check in React component (with instanceof). Errors like 404... etc. don't throw, hence there is a pretty good chance that only network errors will throw in that way. Even MDN article mentions that: 
![Screenshot from 2021-03-31 13-27-21](https://user-images.githubusercontent.com/7916523/113137467-ded65b00-9224-11eb-97f2-dbb99c55dd28.png)
   - `response.text()` *might* also throw I think. I purposefully place it as a separate error type (not NetworkError), because by this point request already completed successfully. Furthermore, the browser might have some useful message why exactly the response can't be decoded.
   - larger try-catch block also will catch any errors from request generation - this was the case so far and it is not changed.

I hope this is not confusing :joy: 

I tested in on Firefox and Chrome so far. 

**Please test on any browser that you have available (IE, Safari, Edge)!!!!!!!**

Test 3 cases:
- click "send" after disconnecting from network
- click "send" after changing URL to something stupid, like removing "p" from "stoplight.io" url
- a CORS-"closed" API of course (making request at https://google.com should be ok) ;)
