### PR TITLE
fix: wrap parameter descriptions

### DIFF
--- a/packages/elements/src/components/Docs/HttpOperation/Parameters.tsx
+++ b/packages/elements/src/components/Docs/HttpOperation/Parameters.tsx
@@ -95,7 +95,7 @@ export const Parameter: React.FunctionComponent<IParameterProps> = ({ parameter,
         </div>
       </div>
 
-      {description && <div className="sl-truncate sl-w-full sl-text-muted sl-text-sm sl-my-2">{description}</div>}
+      {description && <div className="sl-w-full sl-text-muted sl-text-sm sl-my-2">{description}</div>}
 
       <div className="sl-text-sm">
         <Validations validations={validations} />

--- a/packages/elements/src/containers/API.stories.tsx
+++ b/packages/elements/src/containers/API.stories.tsx
@@ -26,27 +26,52 @@ export default {
 
 const Template: Story<APIProps> = args => <API {...args} />;
 
-export const TodosAPI = Template.bind({});
-TodosAPI.args = {
-  apiDescriptionUrl: 'https://petstore.swagger.io/v2/swagger.json',
-};
-TodosAPI.storyName = 'Simple API from URL';
-
 export const APIWithYamlProvidedDirectly = Template.bind({});
 APIWithYamlProvidedDirectly.args = {
   apiDescriptionDocument: zoomApiYaml,
 };
-APIWithYamlProvidedDirectly.storyName = 'Direct YAML Input';
+APIWithYamlProvidedDirectly.storyName = 'Direct YAML Input (Zoom)';
 
 export const APIWithJSONProvidedDirectly = Template.bind({});
 APIWithJSONProvidedDirectly.args = {
   apiDescriptionDocument: JSON.stringify(parse(zoomApiYaml), null, '  '),
 };
-APIWithJSONProvidedDirectly.storyName = 'Direct JSON Input';
+APIWithJSONProvidedDirectly.storyName = 'Direct JSON Input (Zoom)';
 
 export const APIWithoutDescription = Template.bind({});
 APIWithoutDescription.args = {
   apiDescriptionDocument: simpleApiWithoutDescription,
 };
-
 APIWithoutDescription.storyName = 'API Without Description';
+
+export const Petstore = Template.bind({});
+Petstore.args = {
+  apiDescriptionUrl: 'https://petstore.swagger.io/v2/swagger.json',
+};
+Petstore.storyName = 'Swagger Petstore v2';
+
+export const Box = Template.bind({});
+Box.args = {
+  apiDescriptionUrl: 'https://raw.githubusercontent.com/box/box-openapi/main/content/openapi.yml',
+};
+Box.storyName = 'Box';
+
+export const DigitalOcean = Template.bind({});
+DigitalOcean.args = {
+  apiDescriptionUrl:
+    'https://raw.githubusercontent.com/digitalocean/openapi/main/specification/DigitalOcean-public.v2.yaml',
+};
+DigitalOcean.storyName = 'DigitalOcean';
+
+export const Github = Template.bind({});
+Github.args = {
+  apiDescriptionUrl:
+    'https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/ghes-3.0/ghes-3.0.json',
+};
+Github.storyName = 'GitHub';
+
+export const Instagram = Template.bind({});
+Instagram.args = {
+  apiDescriptionUrl: 'https://api.apis.guru/v2/specs/instagram.com/1.0.0/swagger.yaml',
+};
+Instagram.storyName = 'Instagram';


### PR DESCRIPTION
As confusing as it sounds, `sl-truncate` actually forces `white-space: nowrap;`. It makes some sense as `text-overflow: ellipsis` doesn't make much sense without a fixed-width, but still, we keep walking on this mine. I certainly do.

Of course this doesn't exactly make for a great user experience: 
![image](https://user-images.githubusercontent.com/543372/114372209-95213500-9b81-11eb-8f1c-002b368f830e.png)

Fortunately this has been fixed in JSV as well, so I just had to implement it for params. After:
![image](https://user-images.githubusercontent.com/543372/114372389-c863c400-9b81-11eb-95ac-6cca25261f2a.png)



I also added a few example APIs so we can test against them. (I picked the same ones Marc chose for the demo project, so the two are in sync).