### PR TITLE
Fix(toc): missing caret icon in web components

### DIFF
--- a/packages/elements-web-components/package.json
+++ b/packages/elements-web-components/package.json
@@ -23,6 +23,9 @@
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.31",
+    "@fortawesome/free-solid-svg-icons": "^5.14.0",
+    "@fortawesome/react-fontawesome": "^0.1.11",
     "@stoplight/elements": "beta",
     "@stoplight/json": "^3.9.0",
     "@stoplight/types": "^11.9.0",

--- a/packages/elements-web-components/src/index.ts
+++ b/packages/elements-web-components/src/index.ts
@@ -1,4 +1,10 @@
+import { dom, library } from '@fortawesome/fontawesome-svg-core';
+import { faChevronDown, faChevronRight, faCube } from '@fortawesome/free-solid-svg-icons';
+
 import { ApiElement, StoplightProjectElement } from './components';
+
+library.add(faChevronDown, faChevronRight, faCube);
 
 window.customElements.define('elements-stoplight-project', StoplightProjectElement);
 window.customElements.define('elements-api', ApiElement);
+dom.watch();


### PR DESCRIPTION
Resolves: #987 


## Before
<img src="https://user-images.githubusercontent.com/58433203/114388920-9e67cd00-9b94-11eb-95b9-909c51e2745f.png" width="300" />

## After
<img src="https://user-images.githubusercontent.com/58433203/114389912-e20f0680-9b95-11eb-9602-685fb4fe6bf9.png" width="300" />