### PR TITLE
fix: unsupported tags in API document

### DIFF
--- a/packages/elements/src/containers/API.tsx
+++ b/packages/elements/src/containers/API.tsx
@@ -95,7 +95,7 @@ const APIImpl: React.FC<APIProps> = props => {
     );
   }
 
-  if (!nodeData) {
+  if (!nodeData || !bundledDocument) {
     return <DocsSkeleton />;
   }
 
@@ -118,10 +118,10 @@ export function getToCFromOpenApiDocument(apiDescriptionDocument: unknown) {
 
   if (isOas3(apiDescriptionDocument)) {
     uriMap = computeOas3UriMap(apiDescriptionDocument);
-    documentTags = apiDescriptionDocument.tags?.map(tag => tag.name) || [];
+    documentTags = apiDescriptionDocument.tags?.map?.(tag => tag.name) || [];
   } else if (isOas2(apiDescriptionDocument)) {
     uriMap = computeOas2UriMap(apiDescriptionDocument);
-    documentTags = apiDescriptionDocument.tags?.map(tag => tag.name) || [];
+    documentTags = apiDescriptionDocument.tags?.map?.(tag => tag.name) || [];
   } else {
     console.error('Document type is unknown');
   }

--- a/packages/elements/src/hooks/useBundleRefsIntoDocument.ts
+++ b/packages/elements/src/hooks/useBundleRefsIntoDocument.ts
@@ -20,6 +20,8 @@ export function useBundleRefsIntoDocument(document: unknown, options?: Options) 
   const baseUrl = options?.baseUrl;
 
   React.useEffect(() => {
+    setBundledData(null);
+
     if (!isObject(document)) {
       setBundledData(document);
       return;
@@ -37,6 +39,7 @@ export function useBundleRefsIntoDocument(document: unknown, options?: Options) 
           setBundledData(reason.files.schema);
         } else {
           console.warn(`Could bundle: ${reason?.message ?? 'Unknown error'}`);
+          setBundledData(document);
         }
       });
 


### PR DESCRIPTION
I faced an issue today, where Storybook would crash if you opened `Box` document for the second time. (Open Storybook, go to `Box` in `API` component, switch to another document, and switch back to `Box`).

Elements don't handle tags in API document that are anything else than `array`. This partially addresses that, and at least stops them from crashing Elements.

We still need to figure error handling when users provide incorrect `tags` type

Thanks to @P0lip for debugging this with me and suggesting the solution