### PR TITLE
chore: remove Renovate config file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "config:base",
-    ":pinOnlyDevDependencies"
-  ]
-}


### PR DESCRIPTION
We don't need to keep this config file anymore, as we decided to bump the lockfile ourselves using CircleCI workflow: #1090 