### PR TITLE
fix: incorrect lerna command in CirlcleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
           command: yarn --frozen-lockfile
       - run:
           name: run release script
-          command: yarn lerna publish --from-package --dist-tag beta --yes
+          command: yarn lerna publish from-package --dist-tag beta --yes
 workflows:
   version: 2
   test-and-release:


### PR DESCRIPTION
Recent failing of a workflow in CircleCI exposed an error in the config file. This PR addresses that, simply changing `--from-package`(which doesn't exist) to `from-package` (learn more at: https://github.com/lerna/lerna/tree/main/commands/publish#bump-from-package)