### PR TITLE
fix: make elements-dev-portal private

### DIFF
--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -2,6 +2,7 @@
   "name": "@stoplight/elements-dev-portal",
   "version": "1.0.0-alpha.1",
   "description": "UI components for composing beautiful developer documentation.",
+  "private": "true",
   "keywords": [],
   "sideEffects": [
     "web-components.min.js",


### PR DESCRIPTION
This PR makes `elements-dev-portal` private for now, which should prevent the unwanted release from `lerna`.