### PR TITLE
chore: demo -> elements dependency

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "*",
+    "@stoplight/elements": "7.0.0-beta.1",
     "@stoplight/mosaic": "1.0.0-beta.47",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,56 +3827,6 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@stoplight/elements-utils@^6.1.18":
-  version "6.1.18"
-  resolved "https://registry.yarnpkg.com/@stoplight/elements-utils/-/elements-utils-6.1.18.tgz#020926123e6df8bf26833558d8c2f4b927921cb9"
-  integrity sha512-THyGi9mqFxlF1PKz065XW391VaI+joiC9VPiU4AHORbe3euOsMvFN4C9xcXNfgnfPuuh8b23S1jvrlvepkwStQ==
-  dependencies:
-    lodash "^4.17.19"
-
-"@stoplight/elements@*":
-  version "6.1.18"
-  resolved "https://registry.yarnpkg.com/@stoplight/elements/-/elements-6.1.18.tgz#b87677a139d33115a4766c548211ad987d12d564"
-  integrity sha512-yjPzXVQfQc1ezN+JofuwBwSeFVjBhTPOlX9W0M31snZjFIXeO7sn4rYqRCZNcMEPGdYgJD/9wFdGx189vehrBg==
-  dependencies:
-    "@fortawesome/fontawesome-svg-core" "^1.2.31"
-    "@fortawesome/free-solid-svg-icons" "^5.14.0"
-    "@fortawesome/react-fontawesome" "^0.1.11"
-    "@stoplight/elements-utils" "^6.1.18"
-    "@stoplight/http-spec" "^3.1.1"
-    "@stoplight/json" "^3.9.0"
-    "@stoplight/json-schema-ref-parser" "^9.0.5"
-    "@stoplight/json-schema-viewer" "^3.0.0-beta.33"
-    "@stoplight/markdown" "^2.10.0"
-    "@stoplight/markdown-viewer" "^4.3.4"
-    "@stoplight/path" "^1.3.2"
-    "@stoplight/react-error-boundary" "^1.1.0"
-    "@stoplight/tree-list" "^5.0.3"
-    "@stoplight/types" "^11.9.0"
-    "@stoplight/ui-kit" "^3.0.0-beta.39"
-    "@stoplight/yaml" "^4.2.1"
-    axios "^0.21.1"
-    classnames "^2.2.6"
-    copy-to-clipboard "^3.3.1"
-    fast-text-encoding "^1.0.1"
-    fp-ts "^2.5.3"
-    graphql "^14"
-    httpsnippet "^1.24.0"
-    lodash "^4.17.19"
-    mobx-react-lite "^1.5.2"
-    object-hash "^2.0.3"
-    openapi-sampler "^1.0.0-beta.16"
-    parse-prefer-header "^1.0.0"
-    prop-types "^15.7.2"
-    react-error-boundary "^1.2.5"
-    react-router-dom "^5.2.0"
-    react-router-hash-link "^2.1.0"
-    swr "^0.3.0"
-    tslib "^1.12.0"
-    type-is "^1.6.18"
-    unist-util-select "^3.0.1"
-    urijs "^1.19.6"
-
 "@stoplight/eslint-config@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@stoplight/eslint-config/-/eslint-config-2.0.0.tgz#1e4afc9854113dc0f226402b5ec46fb4ddb939f0"
@@ -3884,7 +3834,7 @@
   dependencies:
     eslint-config-prettier "^7.1.0"
 
-"@stoplight/http-spec@^3.1.1", "@stoplight/http-spec@^3.2.6":
+"@stoplight/http-spec@^3.2.6":
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/@stoplight/http-spec/-/http-spec-3.5.0.tgz#5ca42e076fc0975ed4d9cece2956619b5254f711"
   integrity sha512-4fsMBFcXf4M3Z00A6ver/TwDnv/F1qGudr7eAxCD/bi0SGzZiiT7X93BDso92nwwcJ3dXAH9/nML9cbfKiPouQ==
@@ -3902,7 +3852,7 @@
     type-is "^1.6.18"
     urijs "~1.19.2"
 
-"@stoplight/json-schema-merge-allof@^0.7.2", "@stoplight/json-schema-merge-allof@^0.7.5":
+"@stoplight/json-schema-merge-allof@^0.7.5":
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/@stoplight/json-schema-merge-allof/-/json-schema-merge-allof-0.7.6.tgz#39efac12a497ed29a06ae48e0141885634a045a4"
   integrity sha512-xLbJC2VOd9AxO1VvvgyP/mWOqZbeg6mLpYzlzU4egDTTIrTsSqtv+yFakpPciuuMlOmJU/KzZK9C5AbMgE+VgQ==
@@ -3934,20 +3884,6 @@
     "@stoplight/lifecycle" "^2.3.2"
     magic-error "^0.0.0"
 
-"@stoplight/json-schema-viewer@^3.0.0-beta.33":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-3.1.1.tgz#2623bda53f5be48b7218654dfb973eef2a854f9f"
-  integrity sha512-i0q+K9i3H3RA8qQFxYcy521oLVyHooY13zqy99PSTbO0PSJDXRt4ZU0X/W78IuceiDNnTXZ7Lvm1M3YwUFD4RA==
-  dependencies:
-    "@stoplight/json" "^3.5.1"
-    "@stoplight/json-schema-merge-allof" "^0.7.2"
-    "@stoplight/react-error-boundary" "^1.0.0"
-    "@stoplight/tree-list" "^5.0.3"
-    classnames "^2.2.6"
-    lodash "^4.17.15"
-    mobx-react-lite "^1.4.1"
-    pluralize "^8.0.0"
-
 "@stoplight/json-schema-viewer@^4.0.0-beta.14":
   version "4.0.0-beta.14"
   resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.0.0-beta.14.tgz#f6f6ec3cccd94d04ee86269c86ab2ae35553c3ce"
@@ -3961,7 +3897,7 @@
     classnames "^2.2.6"
     lodash "^4.17.19"
 
-"@stoplight/json@^3.10.0", "@stoplight/json@^3.10.2", "@stoplight/json@^3.5.1", "@stoplight/json@^3.6", "@stoplight/json@^3.9.0":
+"@stoplight/json@^3.10.0", "@stoplight/json@^3.10.2", "@stoplight/json@^3.6":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/@stoplight/json/-/json-3.12.0.tgz#26c8d32da78eac6a760ba2c9cca6ae717dc417b4"
   integrity sha512-c0bvFOGICk8QWIat72Td2GG6Bdvq/6O2jQcDZ8rEjh56YOdC/YPn1S8ihKu3AntJCtvqC9eTfadWBqkNK9HAjw==
@@ -3979,7 +3915,7 @@
   dependencies:
     wolfy87-eventemitter "~5.2.8"
 
-"@stoplight/markdown-viewer@^4.3.3", "@stoplight/markdown-viewer@^4.3.4":
+"@stoplight/markdown-viewer@^4.3.3":
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-4.3.4.tgz#9b5e04ff7b90fb7d1e172c07c140d5466763a7d1"
   integrity sha512-yIhjUckgHhsKGs2bLeQvYo1KgU4hbGfIYmwSwzSu648DSn3kxq5igAlujUf+K5ntK4kXpab3MjrbOojmb5OsIA==
@@ -11055,11 +10991,6 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-fp-ts@^2.5.3:
-  version "2.10.4"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.10.4.tgz#f81f34b1c15b3255d65cdbb39508ebb42922aa0c"
-  integrity sha512-vMTB5zNc9PnE20q145PNbkiL9P9WegwmKVOFloi/NfHnPdAlcob6I3AKqlH/9u3k3/M/GOftZhcJdBrb+NtnDA==
-
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -11796,13 +11727,6 @@ graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
-
-graphql@^14:
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
-  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
-  dependencies:
-    iterall "^1.2.2"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -13558,11 +13482,6 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-iterall@^1.2.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
-  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
-
 iterate-iterator@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
@@ -14974,11 +14893,6 @@ lodash._root@~3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
   integrity sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=
 
-lodash.camelcase@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
-
 lodash.capitalize@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
@@ -15977,7 +15891,7 @@ mkdirp@*, mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   dependencies:
     minimist "^1.2.5"
 
-mobx-react-lite@^1.4.1, mobx-react-lite@^1.5.2:
+mobx-react-lite@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz#c4395b0568b9cb16f07669d8869cc4efa1b8656d"
   integrity sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg==
@@ -16918,11 +16832,6 @@ object-hash@^1.3.1:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
 
-object-hash@^2.0.3:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
-  integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
-
 object-inspect@^1.7.0, object-inspect@^1.9.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.2.tgz#b6385a3e2b7cae0b5eafcf90cddf85d128767f30"
@@ -17065,7 +16974,7 @@ open@^7.0.2, open@^7.0.3:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-openapi-sampler@^1.0.0-beta.16, openapi-sampler@^1.0.0-beta.18:
+openapi-sampler@^1.0.0-beta.18:
   version "1.0.0-beta.18"
   resolved "https://registry.yarnpkg.com/openapi-sampler/-/openapi-sampler-1.0.0-beta.18.tgz#9e0845616a669e048860625ea5c10d0f554f1b53"
   integrity sha512-nG/0kvvSY5FbrU5A+Dbp1xTQN++7pKIh87/atryZlxrzDuok5Y6TCbpxO1jYqpUKLycE4ReKGHCywezngG6xtQ==
@@ -17617,13 +17526,6 @@ parse-path@^4.0.0:
     qs "^6.9.4"
     query-string "^6.13.8"
 
-parse-prefer-header@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/parse-prefer-header/-/parse-prefer-header-1.0.0.tgz#75aeb73766bb6531dde063ee023876ead49648f7"
-  integrity sha1-da63N2a7ZTHd4GPuAjh26tSWSPc=
-  dependencies:
-    lodash.camelcase "^4.3.0"
-
 parse-url@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-5.0.2.tgz#856a3be1fcdf78dc93fc8b3791f169072d898b59"
@@ -17912,11 +17814,6 @@ please-upgrade-node@^3.2.0:
   integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
   dependencies:
     semver-compare "^1.0.0"
-
-pluralize@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
-  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
 pn@^1.1.0:
   version "1.1.0"
@@ -18693,11 +18590,6 @@ react-element-to-jsx-string@^14.3.2:
   dependencies:
     "@base2/pretty-print-object" "1.0.0"
     is-plain-object "3.0.1"
-
-react-error-boundary@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-1.2.5.tgz#a362cb799d2e58ff8f114f7c4bc25677ce4e4149"
-  integrity sha512-5CPSeLJA2igJNppAgFRwnTL9aK3ojenk65enNzhVyoxYNbHpIJXnChUO7+4vPhkncRA9wvQMXq6Azp2XeXd+iQ==
 
 react-error-overlay@^6.0.9:
   version "6.0.9"


### PR DESCRIPTION
Fixes the way `demo` is referencing `elements`. This change makes lerna recognize the relationship which in turn makes the lockfile a bit cleaner. Not much else to gain, but nothing to lose either.

cc @philsturgeon 