### PR TITLE
test: increase timeout to prevent errors

### DIFF
--- a/packages/elements/jest.config.js
+++ b/packages/elements/jest.config.js
@@ -8,4 +8,5 @@ module.exports = {
   moduleNameMapper: {
     '^@stoplight/elements-utils$': '<rootDir>/../elements-utils/src',
   },
+  testTimeout: 10000,
 };


### PR DESCRIPTION
This has the potential to resolve the spike at #1067 or at least provide clearer error messages.

**Important**

The timeout increase here is not a simple "let's give it more time" kind of bump. The problem I identified is that `testing-library`'s `waitFor` (and `findBy*`) timeout is 5 seconds, the same as Jest's default for timing out tests. This has the effect of running RTL-based continuations after the test env was torn down, leading to these ugly messages like

> ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down.

So at minimum, this should give us the real error messages (e.g. what `find*` actually times out).