### PR TITLE
fix: oauth 2.0 () when scopes empty

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@
         
 ## Intro
 
-TBD
+Elements is an open-source project, and we love contributions. If you're familiar with TypeScript and Jest then dive right in, see how far you can get, and talk to us in [Discussions](https://github.com/stoplightio/elements/discussions) or start a draft PR if you get stuck.
 
 ## Testing
 

--- a/examples/bootstrap/index.html
+++ b/examples/bootstrap/index.html
@@ -12,7 +12,7 @@
     <!-- Elements: Web Component -->
     <script src="https://unpkg.com/@stoplight/elements@beta/web-components.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@beta/styles/elements.min.css">
-    
+
     <!-- Twitter Bootstrap -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <!-- Twitter Bootstrap: Sticky Footer Example -->

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.spec.tsx
@@ -19,14 +19,14 @@ Wondering what this `unmount()` thingy in some of the tests is all about?
 
 The reason is that an asynchronous action in TryIt component - resolving
 a Promise coming from `buildHarRequest()` call - causes an async update to
-React state, which then causes an `act(...)` warning in the tests which are 
+React state, which then causes an `act(...)` warning in the tests which are
 synchronous.
 
-If you see an unwarranted `act(...)` warning when writing a synchronous test, 
+If you see an unwarranted `act(...)` warning when writing a synchronous test,
 use the same method to mitigate the issue. Don't do it mindlessly though!
 Sometimes `act(...)` warning is warranted.
 
-If `buildHarRequest` is no longer asynchronous, or it dissapeared from the codebase,
+If `buildHarRequest` is no longer asynchronous, or it disappeared from the codebase,
 you can attempt to remove manual `unmount()` calls.
 */
 
@@ -66,6 +66,51 @@ describe('HttpOperation', () => {
       expect(bearerBadge).toBeInTheDocument();
       expect(oidcBadge).toBeInTheDocument();
       expect(oauthBadge).toBeInTheDocument();
+
+      unmount();
+    });
+
+    it('displays scopes in badge when present', () => {
+      const security = [
+        [
+          {
+            key: 'oauth2WithScopes',
+            type: 'oauth2' as const,
+            description: 'foo',
+            flows: {
+              implicit: {
+                scopes: {
+                  'write:pets': 'modify pets in your account',
+                  'read:pets': 'read your pets',
+                },
+                refreshUrl: 'http://refreshUrl.com',
+                authorizationUrl: 'http://authorizationUrl.com',
+              },
+            },
+          },
+          {
+            key: 'oauth2WithEmptyScopes',
+            type: 'oauth2' as const,
+            description: 'foo',
+            flows: {
+              authorizationCode: {
+                scopes: {},
+                refreshUrl: 'http://refreshUrl.com',
+                tokenUrl: 'http://tokenUrl.com',
+                authorizationUrl: 'http://authorizationUrl.com',
+              },
+            },
+          },
+        ],
+      ];
+
+      const { unmount } = render(<HttpOperation data={{ ...httpOperation, security }} />);
+
+      const oauth2Badge = getSecurityBadge(/^OAuth 2.0 \(write:pets, read:pets\)$/i);
+      const oauth2WithEmptyScopesBadge = getSecurityBadge(/^OAuth 2.0$/i);
+
+      expect(oauth2Badge).toBeInTheDocument();
+      expect(oauth2WithEmptyScopesBadge).toBeInTheDocument();
 
       unmount();
     });

--- a/packages/elements-core/src/utils/oas/security.ts
+++ b/packages/elements-core/src/utils/oas/security.ts
@@ -16,10 +16,11 @@ export function getReadableSecurityName(securityScheme: HttpSecurityScheme, incl
     case 'http':
       return `${capitalize(securityScheme.scheme)} Auth`;
     case 'oauth2':
-      if (!includeScope) return 'OAuth 2.0';
-
       const scopes = uniq(flatMap(keys(securityScheme.flows), getOauthScopeMapper(securityScheme)));
-      return `OAuth 2.0 (${scopes.join(', ')})`;
+      if (includeScope && scopes.length > 1) {
+        return `OAuth 2.0 (${scopes.join(', ')})`;
+      }
+      return 'OAuth 2.0';
     case 'openIdConnect':
       return 'OpenID Connect';
     case 'mutualTLS':

--- a/yarn.lock
+++ b/yarn.lock
@@ -16197,6 +16197,13 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
+
 nanoid@^3.1.20, nanoid@^3.1.23:
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"


### PR DESCRIPTION
I noticed this working with the Calendly description.

**Before**

<img width="370" alt="image" src="https://user-images.githubusercontent.com/67381/117959558-0df7e600-b314-11eb-8c5e-01ce6d86a7d3.png">

https://elements-demo.stoplight.io/?spec=https://stoplight.io/api/v1/projects/calendly/api-docs/nodes/reference/calendly-api/openapi.yaml?branch=production#/operations/getUser

**After**

<img width="286" alt="image" src="https://user-images.githubusercontent.com/67381/117959741-3849a380-b314-11eb-8e87-5e44ef8aa55a.png">

https://deploy-preview-1208--stoplight-elements-demo.netlify.app/?spec=https://stoplight.io/api/v1/projects/calendly/api-docs/nodes/reference/calendly-api/openapi.yaml?branch=production#/operations/getUser