### PR TITLE
chore: examples location

### DIFF
--- a/examples/angular/src/app/stoplight-project/stoplight-project.component.ts
+++ b/examples/angular/src/app/stoplight-project/stoplight-project.component.ts
@@ -7,7 +7,7 @@ import { environment } from '../../environments/environment';
   templateUrl: './stoplight-project.component.html',
 })
 export class StoplightProjectComponent {
-  workspaceSlug = 'elements';
+  workspaceSlug = 'elements-examples';
   projectSlug = 'studio-demo';
   basePath = environment.basePath ? `${environment.basePath}/stoplight-project` : 'stoplight-project';
 }

--- a/examples/react-cra/README.md
+++ b/examples/react-cra/README.md
@@ -18,7 +18,7 @@
 
 ### Stoplight Project
 
-This component allows embedding documentation that is connected to a Stoplight workspace. In this example, we are referring to [elements.stoplight.io](https://elements.stoplight.io) workspace - [studio-demo](https://elements.stoplight.io/docs/studio-demo) project to be more precise.
+This component allows embedding documentation that is connected to a Stoplight workspace. In this example, we are referring to [elements-examples.stoplight.io](https://elements-examples.stoplight.io) workspace - [studio-demo](https://elements-examples.stoplight.io/docs/studio-demo) project to be more precise.
 
 ### Stoplight API
 

--- a/examples/react-cra/src/components/StoplightProject.tsx
+++ b/examples/react-cra/src/components/StoplightProject.tsx
@@ -4,5 +4,5 @@ import { StoplightProject } from '@stoplight/elements-dev-portal';
 import React from 'react';
 
 export const StoplightProjectDocs: React.FC = () => {
-  return <StoplightProject basePath="stoplight-project" workspaceSlug="elements" projectSlug="studio-demo" />;
+  return <StoplightProject basePath="stoplight-project" workspaceSlug="elements-examples" projectSlug="studio-demo" />;
 };

--- a/examples/react-gatsby/src/pages/stoplight-project-demo.tsx
+++ b/examples/react-gatsby/src/pages/stoplight-project-demo.tsx
@@ -10,7 +10,7 @@ const StoplightProjectPage = () => {
       <SEO title="Stoplight Elements" />
 
       <StoplightProject
-        workspaceSlug="elements"
+        workspaceSlug="elements-examples"
         projectSlug="studio-demo"
         basePath="stoplight-project"
         router={typeof window === 'undefined' ? 'memory' : 'history'}

--- a/packages/elements-core/src/components/Docs/HttpService/__tests__/index.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/__tests__/index.spec.tsx
@@ -59,7 +59,7 @@ describe('HttpService', () => {
 
   it('displays mock server url when embedded in Stoplight Project', async () => {
     render(
-      <Provider host="https://stoplight.io" showMocking project="studio-demo" workspace="elements">
+      <Provider host="https://stoplight.io" showMocking project="studio-demo" workspace="elements-examples">
         <ServerInfo servers={httpService.servers} mockUrl="https://foo.stoplight.io/prism/123" />
       </Provider>,
     );

--- a/packages/elements-core/src/containers/TableOfContents.stories.tsx
+++ b/packages/elements-core/src/containers/TableOfContents.stories.tsx
@@ -59,6 +59,6 @@ const TocStoryContainer: React.FC<any> = props => {
 export const TocStory: Story<ITableOfContents<{}>> = args => <TocStoryContainer {...args} />;
 TocStory.storyName = 'TableOfContents';
 TocStory.args = {
-  workspaceSlug: 'elements',
+  workspaceSlug: 'elements-examples',
   projectSlug: 'studio-demo',
 };

--- a/packages/elements-dev-portal/src/containers/StoplightProject.stories.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.stories.tsx
@@ -23,13 +23,13 @@ export default {
 export const Playground: Story<StoplightProjectProps> = args => <StoplightProject {...args} />;
 Playground.storyName = 'Studio Demo';
 Playground.args = {
-  workspaceSlug: 'elements',
+  workspaceSlug: 'elements-examples',
   projectSlug: 'studio-demo',
 };
 
 export const PublicApis: Story<StoplightProjectProps> = args => <StoplightProject {...args} />;
 PublicApis.storyName = 'Public APIs';
 PublicApis.args = {
-  workspaceSlug: 'elements',
+  workspaceSlug: 'elements-examples',
   projectSlug: 'public-apis',
 };


### PR DESCRIPTION
Fixes: https://github.com/stoplightio/elements/issues/855

I've created `elements-examples` workspace (as `elements-demo` is taken by demo app) and pointed all our examples and docs there. All checked and point to right workspace.