### PR TITLE
fix: demo depending on old elements version

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "7.0.0-beta.1",
+    "@stoplight/elements": "7.0.0-beta.2",
     "@stoplight/mosaic": "1.0.0-beta.47",
     "history": "^5.0.0",
     "react": "16.14.0",


### PR DESCRIPTION
For some reason https://github.com/stoplightio/elements/pull/1207 did not update demo's elements constraint.

For this reason current `main` generates a significant lockfile diff when running `yarn` on it. This fixes that.