### PR TITLE
chore: don't include scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: monday
       time: '03:00'
     commit-message:
-      prefix: "chore(examples)"
+      prefix: "chore"
       include: scope
     versioning-strategy: increase
   - package-ecosystem: npm
@@ -17,7 +17,7 @@ updates:
       day: monday
       time: '03:00'
     commit-message:
-      prefix: "chore(examples)"
+      prefix: "chore"
       include: scope
     versioning-strategy: increase
   - package-ecosystem: npm
@@ -27,7 +27,7 @@ updates:
       day: monday
       time: '03:00'
     commit-message:
-      prefix: "chore(examples)"
+      prefix: "chore"
       include: scope
     versioning-strategy: increase
 


### PR DESCRIPTION
Resolves #1140

As you can see, maintenance PRs have double scope now. This removes it.