### PR TITLE
Feat/display upgrade workspace screen

### DIFF
--- a/packages/elements-dev-portal/src/components/UpgradeToStarter/index.tsx
+++ b/packages/elements-dev-portal/src/components/UpgradeToStarter/index.tsx
@@ -1,0 +1,21 @@
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { Box, Flex, Icon } from '@stoplight/mosaic';
+import React from 'react';
+
+export const UpgradeToStarter = () => (
+  <Flex
+    as="a"
+    href="https://stoplight.io/pricing/"
+    justify="center"
+    alignItems="center"
+    w="full"
+    minH="screen"
+    color="muted"
+    flexDirection="col"
+  >
+    <Icon icon={faExclamationTriangle} size="4x" />
+    <Box pt={3}>
+      Please upgrade your Stoplight Workspace to the Starter Plan to use Elements Dev Portal in production.
+    </Box>
+  </Flex>
+);

--- a/packages/elements-dev-portal/src/components/UpgradeToStarter/index.tsx
+++ b/packages/elements-dev-portal/src/components/UpgradeToStarter/index.tsx
@@ -6,6 +6,8 @@ export const UpgradeToStarter = () => (
   <Flex
     as="a"
     href="https://stoplight.io/pricing/"
+    target="_blank"
+    rel="noreferrer noopener"
     justify="center"
     alignItems="center"
     w="full"

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -16,6 +16,7 @@ import { Loading } from '../components/Loading';
 import { NodeContent } from '../components/NodeContent';
 import { NotFound } from '../components/NotFound';
 import { TableOfContents } from '../components/TableOfContents';
+import { UpgradeToStarter } from '../components/UpgradeToStarter';
 import { useGetBranches } from '../hooks/useGetBranches';
 import { useGetNodeContent } from '../hooks/useGetNodeContent';
 import { useGetTableOfContents } from '../hooks/useGetTableOfContents';
@@ -44,7 +45,12 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({ projectId, hide
 
   const { data: tableOfContents, isFetched: isTocFetched } = useGetTableOfContents({ projectId, branchSlug });
   const { data: branches } = useGetBranches({ projectId });
-  const { data: node, isLoading: isLoadingNode } = useGetNodeContent({ nodeSlug, projectId, branchSlug });
+  const {
+    data: node,
+    isLoading: isLoadingNode,
+    isError,
+    error: nodeError,
+  } = useGetNodeContent({ nodeSlug, projectId, branchSlug });
 
   if (!nodeSlug && isTocFetched && tableOfContents?.items) {
     const firstNode = findFirstNode(tableOfContents.items);
@@ -56,6 +62,10 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({ projectId, hide
   let elem: JSX.Element;
   if (isLoadingNode || !isTocFetched) {
     elem = <Loading />;
+  } else if (isError) {
+    if ((nodeError as any).status === 402) {
+      elem = <UpgradeToStarter />;
+    }
   } else if (!node) {
     elem = <NotFound />;
   } else {

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -17,6 +17,7 @@ import { NodeContent } from '../components/NodeContent';
 import { NotFound } from '../components/NotFound';
 import { TableOfContents } from '../components/TableOfContents';
 import { UpgradeToStarter } from '../components/UpgradeToStarter';
+import { ResponseError } from '../handlers/getNodeContent';
 import { useGetBranches } from '../hooks/useGetBranches';
 import { useGetNodeContent } from '../hooks/useGetNodeContent';
 import { useGetTableOfContents } from '../hooks/useGetTableOfContents';
@@ -63,7 +64,7 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({ projectId, hide
   if (isLoadingNode || !isTocFetched) {
     elem = <Loading />;
   } else if (isError) {
-    if ((nodeError as any).status === 402) {
+    if (nodeError instanceof ResponseError && nodeError.code === 402) {
       elem = <UpgradeToStarter />;
     } else {
       elem = <NotFound />;

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -65,6 +65,8 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({ projectId, hide
   } else if (isError) {
     if ((nodeError as any).status === 402) {
       elem = <UpgradeToStarter />;
+    } else {
+      elem = <NotFound />;
     }
   } else if (!node) {
     elem = <NotFound />;

--- a/packages/elements-dev-portal/src/handlers/getNodeContent.ts
+++ b/packages/elements-dev-portal/src/handlers/getNodeContent.ts
@@ -21,7 +21,10 @@ export const getNodeContent = async ({
   const data = await response.json();
 
   if (!response.ok) {
-    throw new Error(data);
+    throw {
+      status: response.status,
+      data: data,
+    };
   }
 
   return data;

--- a/packages/elements-dev-portal/src/handlers/getNodeContent.ts
+++ b/packages/elements-dev-portal/src/handlers/getNodeContent.ts
@@ -5,7 +5,7 @@ export class ResponseError extends Error {
 
   constructor(message: string, responseCode: number) {
     super(message);
-    this.name = 'Response Error';
+    this.name = 'ResponseError';
     this.code = responseCode;
   }
 }

--- a/packages/elements-dev-portal/src/handlers/getNodeContent.ts
+++ b/packages/elements-dev-portal/src/handlers/getNodeContent.ts
@@ -1,5 +1,15 @@
 import { Node } from '../types';
 
+export class ResponseError extends Error {
+  code: number;
+
+  constructor(message: string, responseCode: number) {
+    super(message);
+    this.name = 'Response Error';
+    this.code = responseCode;
+  }
+}
+
 export const getNodeContent = async ({
   nodeSlug,
   projectId,
@@ -21,10 +31,7 @@ export const getNodeContent = async ({
   const data = await response.json();
 
   if (!response.ok) {
-    throw {
-      status: response.status,
-      data: data,
-    };
+    throw new ResponseError('Payment Required', response.status);
   }
 
   return data;


### PR DESCRIPTION
Resolves: #1285 

The screen is clickable and points users to [Stoplight Pricing Page](https://stoplight.io/pricing/)

**Screenshots**
<img width="1127" alt="Screenshot 2021-05-19 at 13 46 23" src="https://user-images.githubusercontent.com/58433203/118807451-9e9c6c00-b8a8-11eb-876d-6f388085a6d6.png">

**If you want to check it yourself:**

1. Change `getNodeContent.tsx`, `getBranches.tsx` and `getTableOfContents.tsx`
```ts
...const response = await fetch(`${platformUrl}/api/v1/projects/...

...const response = await fetch(`${platformUrl}/v1/projects/...
```
2. Run `prism mock services/elements/openapi.v1.json` from `platform-internal`
3. Run `yarn elements-dev-portal storybook` from Elements
4. Use url from Prism as `platformUrl`
5. Open an operation/article/model
