### PR TITLE
feat(demo): add CORS proxy functionality

### DIFF
--- a/demo/src/components/ElementsAPI.tsx
+++ b/demo/src/components/ElementsAPI.tsx
@@ -7,11 +7,16 @@ import React, { useContext } from 'react';
 import { GlobalContext } from '../context';
 
 export const ElementsAPI: React.FC = () => {
-  const state = useContext(GlobalContext);
+  const { apiDescriptionUrl } = useContext(GlobalContext);
+
+  const specUrlWithProxy =
+    apiDescriptionUrl && window.location.origin === 'https://elements-demo.stoplight.io'
+      ? `https://stoplight.io/cors-proxy/${apiDescriptionUrl}`
+      : apiDescriptionUrl;
 
   return (
     <Box flex={1} overflowY="hidden">
-      <API apiDescriptionUrl={state.apiDescriptionUrl} router="hash" />
+      <API apiDescriptionUrl={specUrlWithProxy} router="hash" />
     </Box>
   );
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "typescript": "^4.0.2"
   },
   "scripts": {
+    "demo": "yarn workspace @stoplight/elements-demo",
     "elements": "yarn workspace @stoplight/elements",
     "elements-core": "yarn workspace @stoplight/elements-core",
     "elements-utils": "yarn workspace @stoplight/elements-utils",


### PR DESCRIPTION
Closes #1039 

Unfortunately the enablers decided to enforce the origin on the proxy so it doesn't work from localhost, you have to trust your code-reading abilities with this.

![image](https://user-images.githubusercontent.com/543372/118816688-b842b100-b8b2-11eb-9690-f46608fc1b9e.png)
