### PR TITLE
feat: add scss to core build

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.0.0-beta.5",
+  "version": "7.0.0-beta.6",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**"

--- a/scripts/build-styles.js
+++ b/scripts/build-styles.js
@@ -13,6 +13,18 @@ const outputFileName = 'styles.min.css';
 const sourcePackagePath = resolve(__dirname, '..', 'packages', sourcePackageName);
 const destinationPackagePath = resolve(__dirname, '..', 'packages', packageName);
 
+// copy scss styles only for core package
+if (packageName === sourcePackageName) {
+  ncp(resolve(sourcePackagePath, 'src', 'styles'), resolve(destinationPackagePath, 'dist', 'styles'), err => {
+    if (err) {
+      return console.error(err);
+    }
+    console.log('Done copying.');
+  });
+}
+
+console.log('Compiling SCSS...');
+
 const outFile = resolve(destinationPackagePath, 'dist', outputFileName);
 render(
   {


### PR DESCRIPTION
Add scss to elements-core build. Elements and elements-dev-portal are left with just css