### PR TITLE
feat: internal badge

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
@@ -1,4 +1,4 @@
-import { faExclamationCircle, faLock, IconDefinition } from '@fortawesome/free-solid-svg-icons';
+import { faExclamationCircle, faEye, faLock, IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { HttpSecurityScheme } from '@stoplight/types';
 import { Position, Tag, Tooltip } from '@stoplight/ui-kit';
@@ -37,8 +37,11 @@ export const DeprecatedBadge: React.FC = () => (
 );
 
 export const InternalBadge: React.FC = () => (
-  <Tooltip position={Position.BOTTOM_LEFT} content="This operation has been marked as internal.">
-    <Badge icon={faLock} className="sl-bg-danger sl-ml-0 ">
+  <Tooltip
+    position={Position.BOTTOM_LEFT}
+    content="This endpoint/model is marked as internal and won't be visible in public docs."
+  >
+    <Badge icon={faEye} className="sl-bg-danger sl-ml-0 ">
       Internal
     </Badge>
   </Tooltip>

--- a/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
@@ -36,10 +36,10 @@ export const DeprecatedBadge: React.FC = () => (
   </Tooltip>
 );
 
-export const InternalBadge: React.FC = () => (
+export const InternalBadge: React.FC<{ isHttpService?: boolean }> = ({ isHttpService }) => (
   <Tooltip
     position={Position.BOTTOM_LEFT}
-    content="This endpoint/model is marked as internal and won't be visible in public docs."
+    content={`This ${isHttpService ? 'operation' : 'model'} is marked as internal and won't be visible in public docs.`}
   >
     <Badge icon={faEye} className="sl-bg-danger sl-ml-0 ">
       Internal

--- a/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
@@ -19,8 +19,10 @@ export const Badge: React.FC<{
     round
     aria-label={children}
   >
-    {icon && <FontAwesomeIcon className="mr-2" icon={icon} />}
-    <span>{children}</span>
+    <span className="flex items-center">
+      {icon && <FontAwesomeIcon className="mr-2" icon={icon} />}
+      {children}
+    </span>
   </Tag>
 );
 export const DeprecatedBadge: React.FC = () => (
@@ -30,6 +32,14 @@ export const DeprecatedBadge: React.FC = () => (
   >
     <Badge icon={faExclamationCircle} className="sl-bg-warning sl-ml-0">
       Deprecated
+    </Badge>
+  </Tooltip>
+);
+
+export const InternalBadge: React.FC = () => (
+  <Tooltip position={Position.BOTTOM_LEFT} content="This operation has been marked as internal.">
+    <Badge icon={faLock} className="sl-bg-danger sl-ml-0 ">
+      Internal
     </Badge>
   </Tooltip>
 );

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -45,7 +45,7 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
               {sortBy(securitySchemes, 'type').map((scheme, i) => (
                 <SecurityBadge key={i} scheme={scheme} httpServiceUri={httpServiceUri} />
               ))}
-              {isInternal && <InternalBadge />}
+              {isInternal && <InternalBadge isHttpService />}
             </HStack>
           )}
 

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -10,7 +10,7 @@ import { getServiceUriFromOperation } from '../../../utils/oas/security';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { TryItWithRequestSamples } from '../../TryIt';
 import { DocsComponentProps } from '..';
-import { DeprecatedBadge, SecurityBadge } from './Badges';
+import { DeprecatedBadge, InternalBadge, SecurityBadge } from './Badges';
 import { Request } from './Request';
 import { Responses } from './Responses';
 
@@ -20,6 +20,7 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
   ({ className, data, headless, uri, hideTryIt, hideTryItPanel }) => {
     const mocking = React.useContext(MockingContext);
     const isDeprecated = !!data.deprecated;
+    const isInternal = !!data.internal;
 
     const [responseMediaType, setResponseMediaType] = React.useState('');
     const [responseStatusCode, setResponseStatusCode] = React.useState('');
@@ -29,7 +30,7 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
 
     const securitySchemes = flatten(data.security);
 
-    const hasBadges = isDeprecated || securitySchemes.length > 0;
+    const hasBadges = isDeprecated || securitySchemes.length > 0 || isInternal;
 
     if (!headless)
       return (
@@ -44,6 +45,7 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
               {sortBy(securitySchemes, 'type').map((scheme, i) => (
                 <SecurityBadge key={i} scheme={scheme} httpServiceUri={httpServiceUri} />
               ))}
+              {isInternal && <InternalBadge />}
             </HStack>
           )}
 

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -20,7 +20,7 @@ const ModelComponent: React.FC<ModelProps> = ({ data, className, headless }) => 
 
       {isInternal && (
         <HStack spacing={2} mt={3} mb={12}>
-          {isInternal && <InternalBadge />}
+          <InternalBadge />
         </HStack>
       )}
       <SchemaAndDescription schema={data} description={data.description} />

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -1,3 +1,4 @@
+import { HStack } from '@stoplight/mosaic';
 import { withErrorBoundary } from '@stoplight/react-error-boundary';
 import { Classes } from '@stoplight/ui-kit';
 import cn from 'classnames';
@@ -6,14 +7,22 @@ import * as React from 'react';
 
 import { SchemaAndDescription } from '../../SchemaAndDescription';
 import { DocsComponentProps } from '..';
+import { InternalBadge } from '../HttpOperation/Badges';
 
 export type ModelProps = DocsComponentProps<JSONSchema7>;
 
 const ModelComponent: React.FC<ModelProps> = ({ data, className, headless }) => {
+  const isInternal = !!data['x-internal'];
+
   return (
     <div className={cn('Model MarkdownViewer', className)}>
       {!headless && data.title !== void 0 && <h1 className={Classes.HEADING}>{data.title}</h1>}
 
+      {isInternal && (
+        <HStack spacing={2} mt={3} mb={12}>
+          {isInternal && <InternalBadge />}
+        </HStack>
+      )}
       <SchemaAndDescription schema={data} description={data.description} />
     </div>
   );


### PR DESCRIPTION
Addresses #1325

Adds internal badge for endpoints marked as `x-internal`
![Screen Shot 2021-05-25 at 3 53 56 PM](https://user-images.githubusercontent.com/47359669/119567069-7497ed80-bd71-11eb-837a-a9df76da8fe3.png)



Adds internal badge for models marked as `x-internal`
![Screen Shot 2021-05-25 at 3 51 50 PM](https://user-images.githubusercontent.com/47359669/119566818-326eac00-bd71-11eb-8692-f79a3cde4ebb.png)


I also updated the layout so that the icon and text are aligned...I don't think this has a negative ripple effect anywhere, but I am not super familiar with Elements, so please let me know if I should undo this.
<img width="682" alt="Screen Shot 2021-05-24 at 2 18 27 PM" src="https://user-images.githubusercontent.com/47359669/119398395-1b5e8a00-bc9d-11eb-9075-17bac6ce25eb.png">
<img width="675" alt="Screen Shot 2021-05-24 at 2 33 19 PM" src="https://user-images.githubusercontent.com/47359669/119398399-1c8fb700-bc9d-11eb-9de3-8e1a6e10d6e9.png">
