### PR TITLE
fix: security badge link

### DIFF
--- a/packages/elements-core/src/components/Docs/Docs.tsx
+++ b/packages/elements-core/src/components/Docs/Docs.tsx
@@ -45,6 +45,11 @@ interface BaseDocsProps {
    * The original title of the node. It serves as a fallback title in case on is not available inside the model.
    */
   nodeTitle?: string;
+
+  /**
+   * Allows to use internal routing (requires wrapping with Router component)
+   */
+  allowRouting?: boolean;
 }
 
 export interface DocsProps extends BaseDocsProps {

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.spec.tsx
@@ -133,9 +133,7 @@ describe('HttpOperation', () => {
 
     it('should not contain link to Overview for operation with uri by default', () => {
       const { unmount } = render(
-        <Router>
-          <HttpOperation data={{ ...httpOperation }} uri="/reference/todos/openapi.v1.json/paths/~1todos/post" />
-        </Router>,
+        <HttpOperation data={{ ...httpOperation }} uri="/reference/todos/openapi.v1.json/paths/~1todos/post" />,
       );
       const apikeyBadge = getSecurityBadge(/API Key/i);
       expect(apikeyBadge?.closest('a')).not.toBeInTheDocument();

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.spec.tsx
@@ -115,14 +115,30 @@ describe('HttpOperation', () => {
       unmount();
     });
 
-    it('should contain link to Overview for operation with uri', () => {
+    it('should contain link to Overview for operation with uri when `allowRouting` is present', () => {
+      const { unmount } = render(
+        <Router>
+          <HttpOperation
+            data={{ ...httpOperation }}
+            uri="/reference/todos/openapi.v1.json/paths/~1todos/post"
+            allowRouting
+          />
+        </Router>,
+      );
+      const apikeyBadge = getSecurityBadge(/API Key/i);
+      expect(apikeyBadge?.closest('a')).toHaveAttribute('href', '/reference/todos/openapi.v1.json?security=api_key');
+
+      unmount();
+    });
+
+    it('should not contain link to Overview for operation with uri by default', () => {
       const { unmount } = render(
         <Router>
           <HttpOperation data={{ ...httpOperation }} uri="/reference/todos/openapi.v1.json/paths/~1todos/post" />
         </Router>,
       );
       const apikeyBadge = getSecurityBadge(/API Key/i);
-      expect(apikeyBadge?.closest('a')).toHaveAttribute('href', '/reference/todos/openapi.v1.json?security=api_key');
+      expect(apikeyBadge?.closest('a')).not.toBeInTheDocument();
 
       unmount();
     });

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -17,7 +17,7 @@ import { Responses } from './Responses';
 export type HttpOperationProps = DocsComponentProps<IHttpOperation>;
 
 const HttpOperationComponent = React.memo<HttpOperationProps>(
-  ({ className, data, headless, uri, hideTryIt, hideTryItPanel }) => {
+  ({ className, data, headless, uri, hideTryIt, hideTryItPanel, allowRouting = false }) => {
     const mocking = React.useContext(MockingContext);
     const isDeprecated = !!data.deprecated;
     const isInternal = !!data.internal;
@@ -43,7 +43,7 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
             <HStack spacing={2} mt={3}>
               {isDeprecated && <DeprecatedBadge />}
               {sortBy(securitySchemes, 'type').map((scheme, i) => (
-                <SecurityBadge key={i} scheme={scheme} httpServiceUri={httpServiceUri} />
+                <SecurityBadge key={i} scheme={scheme} httpServiceUri={allowRouting ? httpServiceUri : undefined} />
               ))}
               {isInternal && <InternalBadge isHttpService />}
             </HStack>

--- a/packages/elements/src/components/API/APIWithSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithSidebarLayout.tsx
@@ -56,6 +56,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({ serviceNode
           nodeTitle={node.name}
           hideTryIt={hideTryIt}
           location={location}
+          allowRouting
         />
       )}
     </SidebarLayout>


### PR DESCRIPTION
Fixes: https://github.com/stoplightio/elements/issues/1333

Adds optional `allowRouting` prop to Docs that we can use with API component and which defaults to `false` for external usage.