### PR TITLE
fix: change font size in jsv for models

### DIFF
--- a/packages/elements-core/src/styles/styles.scss
+++ b/packages/elements-core/src/styles/styles.scss
@@ -4,3 +4,8 @@
 .sl-elements {
   @import './elements';
 }
+
+.Model .JsonSchemaViewer .MarkdownViewer p {
+  font-size: 12px;
+  line-height: 1.5em;
+}


### PR DESCRIPTION
Currently, font size in JSV (description within a row) in models differs from JSV displayed for Http operation. This fixes that.

**Before**
![Screenshot 2021-06-02 at 16 18 21](https://user-images.githubusercontent.com/58433203/120501205-b94f0480-c3c1-11eb-9b5b-ea67be3ba24f.png)

**After**
![Screenshot 2021-06-02 at 16 38 34](https://user-images.githubusercontent.com/58433203/120501232-beac4f00-c3c1-11eb-9902-b04c3f83dfa8.png)
