### PR TITLE
fix: resolving relative urls in dev portal

### DIFF
--- a/packages/elements-dev-portal/src/components/NodeContent/index.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/index.tsx
@@ -69,8 +69,8 @@ const LinkComponent: React.FC<{ node: { url: string } }> = ({ children, node: { 
     // Resolve relative file URI with
     const resolvedUri = resolve(dirname(node.uri), url);
     const [resolvedUriWithoutAnchor, hash] = resolvedUri.split('#');
-    const decodedUrl = window.decodeURI(url);
-    const decodedResolvedUriWithoutAnchor = window.decodeURI(resolvedUriWithoutAnchor);
+    const decodedUrl = decodeURIComponent(url);
+    const decodedResolvedUriWithoutAnchor = decodeURIComponent(resolvedUriWithoutAnchor);
     const edge = node.outbound_edges.find(
       edge => edge.uri === decodedUrl || edge.uri === decodedResolvedUriWithoutAnchor,
     );

--- a/packages/elements-dev-portal/src/components/NodeContent/index.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/index.tsx
@@ -69,7 +69,11 @@ const LinkComponent: React.FC<{ node: { url: string } }> = ({ children, node: { 
     // Resolve relative file URI with
     const resolvedUri = resolve(dirname(node.uri), url);
     const [resolvedUriWithoutAnchor, hash] = resolvedUri.split('#');
-    const edge = node.outbound_edges.find(edge => edge.uri === url || edge.uri === resolvedUriWithoutAnchor);
+    const decodedUrl = window.decodeURI(url);
+    const decodedResolvedUriWithoutAnchor = window.decodeURI(resolvedUriWithoutAnchor);
+    const edge = node.outbound_edges.find(
+      edge => edge.uri === decodedUrl || edge.uri === decodedResolvedUriWithoutAnchor,
+    );
 
     if (edge) {
       return (


### PR DESCRIPTION
Fixes another issue reported by @philsturgeon for Qualtrics.

To test, open project with id `cHJqOjk3NDQ` in storybook. Before fix many urls in markdown documentation are not working (for example visit Overview > API General Instructions > Quickstart).

After fix links work.

The solution is necessary because backend provides encoded links in markdown, but decoded links in `outbound_edges` part of the response.