### PR TITLE
fix(try-it): contrast issue of CORS link

### DIFF
--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -1,7 +1,7 @@
 import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { safeParse, safeStringify } from '@stoplight/json';
-import { Box, Button, Flex, Panel, Text, useThemeIsDark } from '@stoplight/mosaic';
+import { Box, Button, Flex, Link, Panel, Text, useThemeIsDark } from '@stoplight/mosaic';
 import { CodeViewer } from '@stoplight/mosaic-code-viewer';
 import { IHttpOperation } from '@stoplight/types';
 import { Request as HarRequest } from 'har-format';
@@ -226,14 +226,14 @@ const NetworkErrorMessage = () => (
 
     <p>
       3. If you've checked all of the above and still experiencing issues, check if the API supports{' '}
-      <a
+      <Link
         target="_blank"
         rel="noopener noreferrer"
-        className="font-semibold text-darken-7 dark:text-gray-6"
         href="https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS"
+        fontWeight="semibold"
       >
         CORS
-      </a>
+      </Link>
       .
     </p>
   </>


### PR DESCRIPTION
Resolves #1131 

Nothing too fancy. Unfortunately mosaic's `Link` doesn't have any default stying, so to still show that it may be clickable I applied the same semibold weight we used to have on there.

![image](https://user-images.githubusercontent.com/543372/121025451-7916ca00-c7a5-11eb-92bb-864430568fb8.png)
