### PR TITLE
chore: no(de) 10

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -19,7 +19,7 @@
     "**/*"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "yarn build.react",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -20,7 +20,7 @@
     "**/*"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "concurrently \"yarn:build.react\" \"yarn:build.webcomponents\"",

--- a/packages/elements-utils/package.json
+++ b/packages/elements-utils/package.json
@@ -14,7 +14,7 @@
     "**/*"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "sl-scripts build",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -20,7 +20,7 @@
     "**/*"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "concurrently \"yarn:build.react\" \"yarn:build.webcomponents\"",


### PR DESCRIPTION
We obviously don't support Node 10, just try
```sh
nvm use 10
yarn install --force
```

Also we shouldn't, it's pretty much EOL and SL doesn't use it either. So let's not advertise support for it because bumping this is technically a breaking change later.