### PR TITLE
feat(http-service): hide Base URL box when empty

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
@@ -28,7 +28,7 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(({ className, data, he
 
   const dataPanel = (
     <VStack spacing={6}>
-      {(data.servers ?? mocking.mockUrl) && <ServerInfo servers={data.servers} mockUrl={mocking.mockUrl} />}
+      <ServerInfo servers={data.servers ?? []} mockUrl={mocking.mockUrl} />
       <Box>
         {data.securitySchemes?.length && (
           <SecuritySchemes schemes={data.securitySchemes} defaultScheme={query.get('security') || undefined} />

--- a/packages/elements-core/src/components/Docs/HttpService/ServerInfo.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/ServerInfo.tsx
@@ -7,15 +7,20 @@ import { isProperUrl } from '../../../utils/guards';
 import { getServerUrlWithDefaultValues } from '../../../utils/http-spec/IServer';
 
 interface ServerInfoProps {
-  servers?: IServer[];
+  servers: IServer[];
   mockUrl?: string;
 }
 
 export const ServerInfo: React.FC<ServerInfoProps> = ({ servers, mockUrl }) => {
   const mocking = React.useContext(MockingContext);
   const showMocking = !mocking.hideMocking && mockUrl && isProperUrl(mockUrl);
-  const productionServer = servers?.[0];
+  const productionServer = servers[0];
   const productionUrl = productionServer && getServerUrlWithDefaultValues(productionServer);
+  const showProductionUrl = productionUrl && isProperUrl(productionUrl);
+
+  if (!showMocking && !showProductionUrl) {
+    return null;
+  }
 
   return (
     <InvertTheme>
@@ -23,7 +28,7 @@ export const ServerInfo: React.FC<ServerInfoProps> = ({ servers, mockUrl }) => {
         <Panel.Titlebar whitespace="nowrap">API Base URL</Panel.Titlebar>
         <div className="overflow-x-auto">
           <Panel.Content w="max" className="flex flex-col">
-            {productionUrl && isProperUrl(productionUrl) && (
+            {showProductionUrl && (
               <div className="whitespace-nowrap">
                 {showMocking && (
                   <Text pr={2} fontWeight="bold">


### PR DESCRIPTION
Resolves #1111 

More general than the issue: we would like to hide the box any time it would be empty, as an empty box looks broken.


To break it you can just use `https:///something` (note the triple forward slash).