### PR TITLE
fix: bump jsv to beta.22 (fixes react-cra)

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -49,7 +49,7 @@
     "@stoplight/json": "^3.10.0",
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.0",
-    "@stoplight/json-schema-viewer": "4.0.0-beta.19",
+    "@stoplight/json-schema-viewer": "4.0.0-beta.22",
     "@stoplight/markdown": "^2.10.0",
     "@stoplight/markdown-viewer": "^4.3.3",
     "@stoplight/mosaic": "1.0.0-beta.58",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4057,15 +4057,14 @@
     "@types/json-schema" "^7.0.7"
     magic-error "^0.0.0"
 
-"@stoplight/json-schema-viewer@4.0.0-beta.19":
-  version "4.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.0.0-beta.19.tgz#ccc70a9786b96e4dd73ae8b5f33d2cf5832910f5"
-  integrity sha512-KF44xCcvo3DvHZuFt/itp8Zg8qiRuupxTQE198+5LmOOTIyLSxiyl2O/UwP/S0yMRWXm2lgbEb7sHU8Dm7GAfg==
+"@stoplight/json-schema-viewer@4.0.0-beta.22":
+  version "4.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.0.0-beta.22.tgz#e5dd437220f4cedead425be726fba07b4a8dd88e"
+  integrity sha512-qZugNj5vCz/aDN8CAmCysqCvesZWXM+JUBsdgEOHvxKL3rSg4TkIu5lSgMWj8ttMbsonLIqZ3FAbGeFa4YI9sQ==
   dependencies:
     "@fortawesome/free-solid-svg-icons" "^5.15.2"
     "@stoplight/json" "^3.10.0"
     "@stoplight/json-schema-tree" "^2.0.1"
-    "@stoplight/mosaic" "1.0.0-beta.46"
     "@stoplight/react-error-boundary" "^1.0.0"
     "@types/json-schema" "^7.0.7"
     classnames "^2.2.6"
@@ -4212,40 +4211,6 @@
     ts-keycode-enum "^1.0.6"
     tslib "^2.1.0"
     zustand "^3.5.1"
-
-"@stoplight/mosaic@1.0.0-beta.46":
-  version "1.0.0-beta.46"
-  resolved "https://registry.yarnpkg.com/@stoplight/mosaic/-/mosaic-1.0.0-beta.46.tgz#35fa3c9aebdb3c3535d1d8dd53cc52f1b2b1f5db"
-  integrity sha512-GlGLb2RzvzS7CQpq006c6eZhe7tIgRvDIt/nYqx+FXJEh0M045I2EObstdbyQt/sL7Zw5lae3uxiQ/1j8FqkRA==
-  dependencies:
-    "@fortawesome/fontawesome-svg-core" "^1.2.35"
-    "@fortawesome/free-solid-svg-icons" "^5.15.3"
-    "@fortawesome/react-fontawesome" "^0.1.14"
-    "@react-aria/button" "~3.3.1"
-    "@react-aria/dialog" "~3.1.2"
-    "@react-aria/focus" "~3.2.4"
-    "@react-aria/interactions" "~3.3.4"
-    "@react-aria/listbox" "~3.2.4"
-    "@react-aria/overlays" "~3.6.2"
-    "@react-aria/select" "~3.3.1"
-    "@react-aria/separator" "~3.1.1"
-    "@react-aria/ssr" "~3.0.1"
-    "@react-aria/tooltip" "~3.1.1"
-    "@react-aria/utils" "~3.7.0"
-    "@react-hook/size" "^2.1.1"
-    "@react-hook/window-size" "^3.0.7"
-    "@react-spectrum/utils" "~3.5.1"
-    "@react-stately/select" "~3.1.1"
-    "@react-stately/tooltip" "~3.0.3"
-    clsx "^1.1.1"
-    copy-to-clipboard "^3.3.1"
-    deepmerge "^4.2.2"
-    lodash.get "^4.4.2"
-    polished "^4.1.1"
-    reakit "npm:@stoplight/reakit@~1.3.5"
-    ts-keycode-enum "^1.0.6"
-    tslib "^2.1.0"
-    zustand "^3.3.3"
 
 "@stoplight/mosaic@1.0.0-beta.52":
   version "1.0.0-beta.52"


### PR DESCRIPTION
Related to: https://github.com/stoplightio/elements/pull/1426/files

Fixes react-cra build:

Before:

<img width="448" alt="Zrzut ekranu 2021-06-16 o 12 19 55" src="https://user-images.githubusercontent.com/7916523/122202677-8fa3dc00-ce9d-11eb-99b7-626687c22960.png">

After:

<img width="1030" alt="Zrzut ekranu 2021-06-16 o 12 20 35" src="https://user-images.githubusercontent.com/7916523/122202706-95012680-ce9d-11eb-833f-7ecb1a674d29.png">
