### PR TITLE
fix: read/write only params in generated content

### DIFF
--- a/packages/elements-core/src/__fixtures__/operations/operation-with-examples.ts
+++ b/packages/elements-core/src/__fixtures__/operations/operation-with-examples.ts
@@ -68,6 +68,25 @@ export const httpOperation: IHttpOperation = {
       ],
     },
     {
+      code: '204',
+      contents: [
+        {
+          mediaType: 'application/json',
+          schema: {
+            properties: {
+              writeOnlyParameter: {
+                type: 'string',
+                writeOnly: true,
+              },
+              someOtherParameter: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      ],
+    },
+    {
       code: '404',
       contents: [
         {

--- a/packages/elements-core/src/components/ResponseExamples/ResponseExamples.spec.tsx
+++ b/packages/elements-core/src/components/ResponseExamples/ResponseExamples.spec.tsx
@@ -65,4 +65,13 @@ describe('Response Examples', () => {
 
     expect(select).not.toBeInTheDocument();
   });
+
+  it('does not show write only parameters in the response example', () => {
+    const { container } = render(
+      <ResponseExamples httpOperation={httpOperation} responseMediaType="application/json" responseStatusCode="204" />,
+    );
+
+    expect(container).not.toHaveTextContent('writeOnlyParamter');
+    expect(container).toHaveTextContent('someOtherParameter');
+  });
 });

--- a/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
+++ b/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
@@ -21,7 +21,8 @@ export const ResponseExamples = ({ httpOperation, responseMediaType, responseSta
     userDefinedExamples = responseContents?.examples;
   }
 
-  const responseExample = useGenerateExampleFromMediaTypeContent(responseContents, chosenExampleIndex);
+  const options = React.useMemo(() => ({ skipWriteOnly: true }), []);
+  const responseExample = useGenerateExampleFromMediaTypeContent(responseContents, chosenExampleIndex, options);
 
   if (!userDefinedExamples && responseMediaType !== 'application/json') return null;
 

--- a/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
+++ b/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
@@ -21,8 +21,9 @@ export const ResponseExamples = ({ httpOperation, responseMediaType, responseSta
     userDefinedExamples = responseContents?.examples;
   }
 
-  const options = React.useMemo(() => ({ skipWriteOnly: true }), []);
-  const responseExample = useGenerateExampleFromMediaTypeContent(responseContents, chosenExampleIndex, options);
+  const responseExample = useGenerateExampleFromMediaTypeContent(responseContents, chosenExampleIndex, {
+    skipWriteOnly: true,
+  });
 
   if (!userDefinedExamples && responseMediaType !== 'application/json') return null;
 

--- a/packages/elements-core/src/components/TryIt/useTextRequestBodyState.ts
+++ b/packages/elements-core/src/components/TryIt/useTextRequestBodyState.ts
@@ -12,7 +12,8 @@ import { useGenerateExampleFromMediaTypeContent } from '../../utils/exampleGener
 export const useTextRequestBodyState = (
   mediaTypeContent: IMediaTypeContent | undefined,
 ): [string, React.Dispatch<React.SetStateAction<string>>] => {
-  const initialRequestBody = useGenerateExampleFromMediaTypeContent(mediaTypeContent);
+  const options = React.useMemo(() => ({ skipReadOnly: true }), []);
+  const initialRequestBody = useGenerateExampleFromMediaTypeContent(mediaTypeContent, undefined, options);
 
   const [textRequestBody, setTextRequestBody] = React.useState<string>(initialRequestBody);
 

--- a/packages/elements-core/src/components/TryIt/useTextRequestBodyState.ts
+++ b/packages/elements-core/src/components/TryIt/useTextRequestBodyState.ts
@@ -12,8 +12,9 @@ import { useGenerateExampleFromMediaTypeContent } from '../../utils/exampleGener
 export const useTextRequestBodyState = (
   mediaTypeContent: IMediaTypeContent | undefined,
 ): [string, React.Dispatch<React.SetStateAction<string>>] => {
-  const options = React.useMemo(() => ({ skipReadOnly: true }), []);
-  const initialRequestBody = useGenerateExampleFromMediaTypeContent(mediaTypeContent, undefined, options);
+  const initialRequestBody = useGenerateExampleFromMediaTypeContent(mediaTypeContent, undefined, {
+    skipReadOnly: true,
+  });
 
   const [textRequestBody, setTextRequestBody] = React.useState<string>(initialRequestBody);
 

--- a/packages/elements-core/src/utils/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration.ts
@@ -11,12 +11,17 @@ export type GenerateExampleFromMediaTypeContentOptions = Sampler.Options;
 export const useGenerateExampleFromMediaTypeContent = (
   mediaTypeContent: IMediaTypeContent | undefined,
   chosenExampleIndex?: number,
-  options?: GenerateExampleFromMediaTypeContentOptions,
+  { skipReadOnly, skipWriteOnly, skipNonRequired }: GenerateExampleFromMediaTypeContentOptions = {},
 ) => {
   const document = useDocument();
   return React.useMemo(
-    () => generateExampleFromMediaTypeContent(mediaTypeContent, document, chosenExampleIndex, options),
-    [mediaTypeContent, document, chosenExampleIndex, options],
+    () =>
+      generateExampleFromMediaTypeContent(mediaTypeContent, document, chosenExampleIndex, {
+        skipNonRequired,
+        skipWriteOnly,
+        skipReadOnly,
+      }),
+    [mediaTypeContent, document, chosenExampleIndex, skipNonRequired, skipReadOnly, skipWriteOnly],
   );
 };
 

--- a/packages/elements-core/src/utils/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration.ts
@@ -6,14 +6,17 @@ import React from 'react';
 
 import { useDocument } from '../context/InlineRefResolver';
 
+export type GenerateExampleFromMediaTypeContentOptions = Sampler.Options;
+
 export const useGenerateExampleFromMediaTypeContent = (
   mediaTypeContent: IMediaTypeContent | undefined,
   chosenExampleIndex?: number,
+  options?: GenerateExampleFromMediaTypeContentOptions,
 ) => {
   const document = useDocument();
   return React.useMemo(
-    () => generateExampleFromMediaTypeContent(mediaTypeContent, document, chosenExampleIndex),
-    [mediaTypeContent, document, chosenExampleIndex],
+    () => generateExampleFromMediaTypeContent(mediaTypeContent, document, chosenExampleIndex, options),
+    [mediaTypeContent, document, chosenExampleIndex, options],
   );
 };
 
@@ -21,6 +24,7 @@ export const generateExampleFromMediaTypeContent = (
   mediaTypeContent: IMediaTypeContent | undefined,
   document: any,
   chosenExampleIndex = 0,
+  options?: GenerateExampleFromMediaTypeContentOptions,
 ) => {
   const textRequestBodySchema = mediaTypeContent?.schema;
   const textRequestBodyExamples = mediaTypeContent?.examples;
@@ -29,7 +33,7 @@ export const generateExampleFromMediaTypeContent = (
     if (textRequestBodyExamples?.length) {
       return safeStringify(textRequestBodyExamples?.[chosenExampleIndex]['value'], undefined, 2) ?? '';
     } else if (textRequestBodySchema) {
-      const generated = Sampler.sample(textRequestBodySchema, { skipReadOnly: true }, document);
+      const generated = Sampler.sample(textRequestBodySchema, options, document);
       return generated !== null ? safeStringify(generated, undefined, 2) ?? '' : '';
     }
   } catch (e) {


### PR DESCRIPTION
Fixes #1369 

Before:

![120624486-54fc7580-c493-11eb-9445-776c2c6f0e62](https://user-images.githubusercontent.com/7916523/122401468-eaf8cb80-cf7c-11eb-89c9-112c8e22cca3.png)


After:

<img width="509" alt="Zrzut ekranu 2021-06-17 o 15 01 09" src="https://user-images.githubusercontent.com/7916523/122401494-f1874300-cf7c-11eb-8eff-e1eefe046d0c.png">
