### PR TITLE
fix: example project id

### DIFF
--- a/examples/angular/src/app/stoplight-project/stoplight-project.component.ts
+++ b/examples/angular/src/app/stoplight-project/stoplight-project.component.ts
@@ -7,7 +7,7 @@ import { environment } from '../../environments/environment';
   templateUrl: './stoplight-project.component.html',
 })
 export class StoplightProjectComponent {
-  projectId = 'cHJqOjExOTY';
+  projectId = 'cHJqOjYwNjYx';
   platformUrl = 'https://stoplight.io';
   basePath = environment.basePath ? `${environment.basePath}/stoplight-project` : 'stoplight-project';
 }

--- a/examples/react-cra/src/components/StoplightProject.tsx
+++ b/examples/react-cra/src/components/StoplightProject.tsx
@@ -4,5 +4,5 @@ import { StoplightProject } from '@stoplight/elements-dev-portal';
 import React from 'react';
 
 export const StoplightProjectDocs: React.FC = () => {
-  return <StoplightProject basePath="stoplight-project" platformUrl="https://stoplight.io" projectId="cHJqOjExOTY" />;
+  return <StoplightProject basePath="stoplight-project" platformUrl="https://stoplight.io" projectId="cHJqOjQzMjk1" />;
 };

--- a/examples/react-cra/src/components/StoplightProject.tsx
+++ b/examples/react-cra/src/components/StoplightProject.tsx
@@ -4,5 +4,5 @@ import { StoplightProject } from '@stoplight/elements-dev-portal';
 import React from 'react';
 
 export const StoplightProjectDocs: React.FC = () => {
-  return <StoplightProject basePath="stoplight-project" platformUrl="https://stoplight.io" projectId="cHJqOjQzMjk1" />;
+  return <StoplightProject basePath="stoplight-project" platformUrl="https://stoplight.io" projectId="cHJqOjYwNjYx" />;
 };

--- a/examples/react-gatsby/src/pages/stoplight-project-demo.tsx
+++ b/examples/react-gatsby/src/pages/stoplight-project-demo.tsx
@@ -11,7 +11,7 @@ const StoplightProjectPage = () => {
 
       <StoplightProject
         platformUrl="https://stoplight.io"
-        projectId="cHJqOjExOTY"
+        projectId="cHJqOjYwNjYx"
         basePath="stoplight-project"
         router={typeof window === 'undefined' ? 'memory' : 'history'}
       />

--- a/examples/static-html/stoplight-project/index.html
+++ b/examples/static-html/stoplight-project/index.html
@@ -20,6 +20,6 @@
   </head>
 
   <body>
-    <elements-stoplight-project projectId="cHJqOjExOTY" router="history" basePath="/stoplight-project"></elements-stoplight-project>
+    <elements-stoplight-project projectId="cHJqOjYwNjYx" router="history" basePath="/stoplight-project"></elements-stoplight-project>
   </body>
 </html>

--- a/packages/elements-dev-portal/src/components/BranchSelector/BranchSelector.stories.tsx
+++ b/packages/elements-dev-portal/src/components/BranchSelector/BranchSelector.stories.tsx
@@ -29,7 +29,7 @@ export default {
     platformUrl: { table: { category: 'Input' } },
   },
   args: {
-    projectId: 'cHJqOjExOTY',
+    projectId: 'cHJqOjYwNjYx',
     platformUrl: 'https://stoplight.io',
   },
 };

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.stories.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.stories.tsx
@@ -47,7 +47,7 @@ export default {
   },
   args: {
     nodeSlug: 'b3A6Mzg5NDM2-create-todo',
-    projectId: 'cHJqOjExOTY',
+    projectId: 'cHJqOjYwNjYx',
     branchSlug: '',
     platformUrl: 'https://stoplight.io',
   },

--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -51,8 +51,8 @@ export default {
     platformUrl: { table: { category: 'Input' } },
   },
   args: {
-    projectIds: ['cHJqOjExOTY'],
-    workspaceId: 'd2s6MQ',
+    projectIds: ['cHJqOjYwNjYx'],
+    workspaceId: 'd2s6NDE1NTU',
     platformUrl: 'https://stoplight.io',
   },
 };

--- a/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -41,7 +41,7 @@ export default {
     platformUrl: { table: { category: 'Input' } },
   },
   args: {
-    projectId: 'cHJqOjExOTY',
+    projectId: 'cHJqOjYwNjYx',
     branchSlug: '',
     platformUrl: 'https://stoplight.io',
   },

--- a/packages/elements-dev-portal/src/containers/StoplightProject.spec.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.spec.tsx
@@ -45,7 +45,7 @@ describe('Stoplight Project', () => {
   });
 
   it('loads correctly', async () => {
-    render(<StoplightProject router="memory" projectId="cHJqOjExOTY" platformUrl="https://stoplight.io" />);
+    render(<StoplightProject router="memory" projectId="cHJqOjYwNjYx" platformUrl="https://stoplight.io" />);
 
     expect(
       await screen.findByText(

--- a/packages/elements-dev-portal/src/containers/StoplightProject.stories.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.stories.tsx
@@ -23,6 +23,6 @@ export default {
 export const Playground: Story<StoplightProjectProps> = args => <StoplightProject {...args} />;
 Playground.storyName = 'Studio Demo';
 Playground.args = {
-  projectId: 'cHJqOjExOTY',
+  projectId: 'cHJqOjYwNjYx',
   platformUrl: 'https://stoplight.io',
 };

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -27,7 +27,7 @@ import { useGetTableOfContents } from '../hooks/useGetTableOfContents';
 export interface StoplightProjectProps extends RoutingProps {
   /**
    * The ID of the Stoplight Project.
-   * @example "cHJqOjExOTY"
+   * @example "d2s6NDE1NTU"
    */
   projectId: string;
   /**

--- a/packages/elements-dev-portal/src/web-components/__stories__/StoplightProject.stories.tsx
+++ b/packages/elements-dev-portal/src/web-components/__stories__/StoplightProject.stories.tsx
@@ -25,6 +25,6 @@ export default {
 export const defaultProject = Template.bind({});
 defaultProject.storyName = "Stoplight's Demo workspace";
 defaultProject.args = {
-  projectId: 'cHJqOjExOTY',
+  projectId: 'cHJqOjYwNjYx',
   platformUrl: 'https://stoplight.io',
 };


### PR DESCRIPTION
Updates dev-portal `projectId` for storybook and examples as the current one no longer exists. 
New one comes from `https://elements-examples.stoplight.io` workspace.