### PR TITLE
chore: refactor examples layouts & fix stoplight toc layout

### DIFF
--- a/docs/getting-started/usage/layout.md
+++ b/docs/getting-started/usage/layout.md
@@ -2,11 +2,9 @@
 
 The following section applies both to `API` and `StoplightProject` components. We will focus on `API` as an example.
 
-When you render `API` component on your page without any additional styling, it behaves like a regular `div` element. In particular this means that it will grow in height indefinitely, depending on how much content it has inside. 
+When you render `API` component on your page without any additional styling, it behaves like a regular `div` element. In particular this means that it will grow in height indefinitely, depending on how much content it has inside. We did this because we wanted the component to behave as predictably as possible.
 
-We did this because we wanted the component to behave as predictably as possible, emulating typical HTML `div` behavior.
-
-There exists however a second layout option, which we recommend. `API` has two scrolls built-in inside - one on Table of Contents and one on actual content page. This makes scrolling through massive API docs much more pleasant.
+There exists however a second layout option, which we recommend. `API` has two scrollable areas built-in inside - one on Table of Contents and one on the actual content. This makes scrolling through massive API docs much more pleasant.
 
 In order to achieve that effect, you just have to limit the height of `API` component. 
 
@@ -18,7 +16,7 @@ For example if you have an empty page displaying *only* the `API` component, you
 </body>
 ```
 
-If you have some additional components above and/or below `API`, you can use a flexbox layout This is in fact the layout that we use in majority of our examples:
+If you have some additional components above and/or below `API`, you can use a flexbox layout. This is in fact the layout that we use in majority of our examples:
 
 ```html
 <body>
@@ -41,7 +39,7 @@ If you have some additional components above and/or below `API`, you can use a f
 </style>
 ```
 
-Note that those are only our recommendations. You can use any other HTML/CSS method to limit the height of `API` component.
+Note that those are only our recommendations. You can use any other HTML/CSS approaches to limit the height of `API` component.
 
-Also, you don't *have to* limit the height. It's just our recommendation, but the `API` component without any additional styling will still work 100% correctly and look aesthetic. You just won't get the "two scrolls" functionality.
+Also, you don't *have to* limit the height. Tthe `API` component without any additional styling will still work 100% correctly and look aesthetic. You just won't get the "two scrollbars" functionality.
 

--- a/docs/getting-started/usage/layout.md
+++ b/docs/getting-started/usage/layout.md
@@ -1,0 +1,47 @@
+# Layout
+
+The following section applies both to `API` and `StoplightProject` components. We will focus on `API` as an example.
+
+When you render `API` component on your page without any additional styling, it behaves like a regular `div` element. In particular this means that it will grow in height indefinitely, depending on how much content it has inside. 
+
+We did this because we wanted the component to behave as predictably as possible, emulating typical HTML `div` behavior.
+
+There exists however a second layout option, which we recommend. `API` has two scrolls built-in inside - one on Table of Contents and one on actual content page. This makes scrolling through massive API docs much more pleasant.
+
+In order to achieve that effect, you just have to limit the height of `API` component. 
+
+For example if you have an empty page displaying *only* the `API` component, you can limit the height of `body` container:
+
+```html
+<body style="height: 100vh;">
+    <stoplight-api />
+</body>
+```
+
+If you have some additional components above and/or below `API`, you can use a flexbox layout This is in fact the layout that we use in majority of our examples:
+
+```html
+<body>
+    <header>Some header</header>
+    <div class="api-container">
+        <stoplight-api />
+    </div>
+    <footer>Some footer</footer>
+</body>
+<style>
+    body {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+    }
+    .api-container {
+        flex: 1 0 0;
+        overflow: hidden;
+    }
+</style>
+```
+
+Note that those are only our recommendations. You can use any other HTML/CSS method to limit the height of `API` component.
+
+Also, you don't *have to* limit the height. It's just our recommendation, but the `API` component without any additional styling will still work 100% correctly and look aesthetic. You just won't get the "two scrolls" functionality.
+

--- a/examples/angular/src/app/api/api.component.html
+++ b/examples/angular/src/app/api/api.component.html
@@ -1,6 +1,4 @@
-<div class="docs">
-  <elements-api
-    [apiDescriptionUrl]="apiDescriptionUrl"
-    [basePath]="basePath"
-  ></elements-api>
-</div>
+<elements-api
+  [apiDescriptionUrl]="apiDescriptionUrl"
+  [basePath]="basePath"
+></elements-api>

--- a/examples/angular/src/app/app.component.css
+++ b/examples/angular/src/app/app.component.css
@@ -25,8 +25,15 @@ p {
   flex: 1;
 }
 
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
 .docs {
-  height: calc(100vh - 60px);
+  flex: 1 0 0;
+  overflow: hidden;
 }
 
 .toolbar {

--- a/examples/angular/src/app/app.component.html
+++ b/examples/angular/src/app/app.component.html
@@ -1,16 +1,20 @@
 <!-- Toolbar -->
-<div class="toolbar" role="banner">
-  <img
-    width="40"
-    alt="Angular Logo"
-    src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTAgMjUwIj4KICAgIDxwYXRoIGZpbGw9IiNERDAwMzEiIGQ9Ik0xMjUgMzBMMzEuOSA2My4ybDE0LjIgMTIzLjFMMTI1IDIzMGw3OC45LTQzLjcgMTQuMi0xMjMuMXoiIC8+CiAgICA8cGF0aCBmaWxsPSIjQzMwMDJGIiBkPSJNMTI1IDMwdjIyLjItLjFWMjMwbDc4LjktNDMuNyAxNC4yLTEyMy4xTDEyNSAzMHoiIC8+CiAgICA8cGF0aCAgZmlsbD0iI0ZGRkZGRiIgZD0iTTEyNSA1Mi4xTDY2LjggMTgyLjZoMjEuN2wxMS43LTI5LjJoNDkuNGwxMS43IDI5LjJIMTgzTDEyNSA1Mi4xem0xNyA4My4zaC0zNGwxNy00MC45IDE3IDQwLjl6IiAvPgogIDwvc3ZnPg=="
-  />
+<div class="container">
+  <div class="toolbar" role="banner">
+    <img
+      width="40"
+      alt="Angular Logo"
+      src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTAgMjUwIj4KICAgIDxwYXRoIGZpbGw9IiNERDAwMzEiIGQ9Ik0xMjUgMzBMMzEuOSA2My4ybDE0LjIgMTIzLjFMMTI1IDIzMGw3OC45LTQzLjcgMTQuMi0xMjMuMXoiIC8+CiAgICA8cGF0aCBmaWxsPSIjQzMwMDJGIiBkPSJNMTI1IDMwdjIyLjItLjFWMjMwbDc4LjktNDMuNyAxNC4yLTEyMy4xTDEyNSAzMHoiIC8+CiAgICA8cGF0aCAgZmlsbD0iI0ZGRkZGRiIgZD0iTTEyNSA1Mi4xTDY2LjggMTgyLjZoMjEuN2wxMS43LTI5LjJoNDkuNGwxMS43IDI5LjJIMTgzTDEyNSA1Mi4xem0xNyA4My4zaC0zNGwxNy00MC45IDE3IDQwLjl6IiAvPgogIDwvc3ZnPg=="
+    />
 
-  <a routerLink="/" routerLinkActive="active">Welcome</a>
-  <a routerLink="/stoplight-project" routerLinkActive="active">Stoplight Project</a>
-  <a routerLink="/zoom-api" routerLinkActive="active">Zoom API</a>
+    <a routerLink="/" routerLinkActive="active">Welcome</a>
+    <a routerLink="/stoplight-project" routerLinkActive="active">Stoplight Project</a>
+    <a routerLink="/zoom-api" routerLinkActive="active">Zoom API</a>
 
-  <div class="spacer"></div>
+    <div class="spacer"></div>
+  </div>
+
+  <div class="docs">
+    <router-outlet></router-outlet>
+  </div>
 </div>
-
-<router-outlet></router-outlet>

--- a/examples/angular/src/app/stoplight-project/stoplight-project.component.html
+++ b/examples/angular/src/app/stoplight-project/stoplight-project.component.html
@@ -1,7 +1,5 @@
-<div class="docs">
-  <elements-stoplight-project
-    [platformUrl]="platformUrl"
-    [projectId]="projectId"
-    [basePath]="basePath"
-  ></elements-stoplight-project>
-</div>
+<elements-stoplight-project
+  [platformUrl]="platformUrl"
+  [projectId]="projectId"
+  [basePath]="basePath"
+></elements-stoplight-project>

--- a/examples/bootstrap/index.html
+++ b/examples/bootstrap/index.html
@@ -17,6 +17,19 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <!-- Twitter Bootstrap: Sticky Footer Example -->
     <link rel="stylesheet" href="https://getbootstrap.com/docs/4.5/examples/sticky-footer-navbar/sticky-footer-navbar.css">
+
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+      }
+
+      main {
+        flex: 1 0 0;
+        overflow: hidden;
+      }
+    </style>
   </head>
 
   <body>
@@ -61,19 +74,5 @@
         <span class="text-muted">Awesome footer goes here.</span>
       </div>
     </footer>
-
-    <style>
-      body {
-        display: flex;
-        flex-direction: column;
-        height: 100vh;
-      }
-
-      main {
-        flex: 1 0 0;
-        overflow: hidden;
-      }
-    </style>
-
   </body>
 </html>

--- a/examples/bootstrap/index.html
+++ b/examples/bootstrap/index.html
@@ -23,7 +23,7 @@
 
     <header>
       <!-- Fixed navbar -->
-      <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+      <nav class="navbar navbar-expand-md navbar-dark bg-dark">
         <a class="navbar-brand" href="#">Fixed navbar</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -61,6 +61,19 @@
         <span class="text-muted">Awesome footer goes here.</span>
       </div>
     </footer>
+
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+      }
+
+      main {
+        flex: 1 0 0;
+        overflow: hidden;
+      }
+    </style>
 
   </body>
 </html>

--- a/examples/bootstrap/project.html
+++ b/examples/bootstrap/project.html
@@ -17,6 +17,19 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <!-- Twitter Bootstrap: Sticky Footer Example -->
     <link rel="stylesheet" href="https://getbootstrap.com/docs/4.5/examples/sticky-footer-navbar/sticky-footer-navbar.css">
+
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+      }
+
+      main {
+        flex: 1 0 0;
+        overflow: hidden;
+      }
+    </style>
   </head>
 
   <body>
@@ -61,19 +74,6 @@
         <span class="text-muted">Awesome footer goes here.</span>
       </div>
     </footer>
-
-    <style>
-      body {
-        display: flex;
-        flex-direction: column;
-        height: 100vh;
-      }
-
-      main {
-        flex: 1 0 0;
-        overflow: hidden;
-      }
-    </style>
 
   </body>
 </html>

--- a/examples/bootstrap/project.html
+++ b/examples/bootstrap/project.html
@@ -23,7 +23,7 @@
 
     <header>
       <!-- Fixed navbar -->
-      <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
+      <nav class="navbar navbar-expand-md navbar-dark bg-dark">
         <a class="navbar-brand" href="#">Fixed navbar</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -51,7 +51,7 @@
     <!-- Begin page content -->
     <main role="main"">
       <elements-stoplight-project 
-        projectId="cHJqOjYyNTgw"
+        projectId="cHJqOjYwNjYx"
         router="hash"
       ></elements-stoplight-project>
     </main>
@@ -61,6 +61,19 @@
         <span class="text-muted">Awesome footer goes here.</span>
       </div>
     </footer>
+
+    <style>
+      body {
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+      }
+
+      main {
+        flex: 1 0 0;
+        overflow: hidden;
+      }
+    </style>
 
   </body>
 </html>

--- a/examples/react-cra/src/App.tsx
+++ b/examples/react-cra/src/App.tsx
@@ -10,11 +10,11 @@ class App extends Component {
   render() {
     return (
       <BrowserRouter>
-        <div>
+        <div className="app-container">
           <header>
             <Navigation />
           </header>
-          <main>
+          <main className="main-content">
             <Switch>
               <Route exact path="/">
                 <Redirect to="/stoplight-project" />

--- a/examples/react-cra/src/index.css
+++ b/examples/react-cra/src/index.css
@@ -39,7 +39,7 @@ code {
   height: 100vh;
 }
 
-.main-content {
+main {
   flex: 1 0 0;
   overflow: hidden;
 }

--- a/examples/react-cra/src/index.css
+++ b/examples/react-cra/src/index.css
@@ -32,3 +32,14 @@ code {
   background-color: #ddd;
   color: black;
 }
+
+.app-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.main-content {
+  flex: 1 0 0;
+  overflow: hidden;
+}

--- a/examples/react-gatsby/src/components/layout.css
+++ b/examples/react-gatsby/src/components/layout.css
@@ -6,3 +6,14 @@ html {
     "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   margin: 0;
 }
+
+.Layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.MainContent {
+  flex: 1 0 0;
+  overflow: hidden;
+}

--- a/examples/react-gatsby/src/components/layout.tsx
+++ b/examples/react-gatsby/src/components/layout.tsx
@@ -11,7 +11,7 @@ const Layout = ({ children }) => {
     <div className="Layout">
       <Header />
 
-      <main>{children}</main>
+      <main className="MainContent">{children}</main>
     </div>
   );
 };

--- a/examples/static-html/index.html
+++ b/examples/static-html/index.html
@@ -7,7 +7,7 @@
         <nav>
             <ul>
                 <li>
-                    <a href="/api">API</a>
+                    <a href="/zoom-api">API</a>
                 </li>
                 <li>
                     <a href="/stoplight-project">Stoplight Project</a>

--- a/examples/static-html/stoplight-project/index.html
+++ b/examples/static-html/stoplight-project/index.html
@@ -15,6 +15,7 @@
       body {
         font-family: ui-sans-serif, sans-serif;
         font-size: 12px;
+        height: 100vh;
       }
     </style>
   </head>

--- a/examples/static-html/zoom-api/index.html
+++ b/examples/static-html/zoom-api/index.html
@@ -15,6 +15,7 @@
         body {
             font-family: ui-sans-serif, sans-serif;
             font-size: 12px;
+            height: 100vh;
         }
     </style>
 </head>

--- a/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
@@ -3,7 +3,7 @@ import {
   PoweredByLink,
   TableOfContents as ElementsTableOfContents,
 } from '@stoplight/elements-core';
-import { Box, BoxProps } from '@stoplight/mosaic';
+import { BoxProps, Flex } from '@stoplight/mosaic';
 import * as React from 'react';
 
 import { ProjectTableOfContents } from '../../types';
@@ -23,13 +23,15 @@ export const TableOfContents = ({
   ...boxProps
 }: TableOfContentsProps) => {
   return (
-    <Box bg="canvas-100" {...boxProps}>
-      <ElementsTableOfContents
-        tree={tableOfContents.items}
-        activeId={activeId}
-        Link={Link}
-        maxDepthOpenByDefault={collapseTableOfContents ? 0 : 1}
-      />
+    <Flex bg="canvas-100" {...boxProps} flexDirection="col" maxH="full">
+      <Flex flexGrow flexShrink overflowY="auto">
+        <ElementsTableOfContents
+          tree={tableOfContents.items}
+          activeId={activeId}
+          Link={Link}
+          maxDepthOpenByDefault={collapseTableOfContents ? 0 : 1}
+        />
+      </Flex>
 
       {tableOfContents.hide_powered_by ? null : (
         <PoweredByLink
@@ -38,6 +40,6 @@ export const TableOfContents = ({
           packageType="elements-dev-portal"
         />
       )}
-    </Box>
+    </Flex>
   );
 };


### PR DESCRIPTION
Resolves #1443 

This issue involves small fix in StoplightProject ToC layout, making it behave the same as API component.

If you run examples as copy (`copy:react-cra` etc.) and compare it to currently published examples, you will see that change.