### PR TITLE
fix: toc node check

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.0.0-beta.10",
+  "version": "7.0.0-beta.11",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**"

--- a/packages/elements-core/src/components/MosaicTableOfContents/utils.ts
+++ b/packages/elements-core/src/components/MosaicTableOfContents/utils.ts
@@ -70,25 +70,10 @@ export function isGroup(item: TableOfContentsItem): item is TableOfContentsGroup
   return Object.keys(item).length === 2 && 'title' in item && 'items' in item;
 }
 export function isNodeGroup(item: TableOfContentsItem): item is TableOfContentsNodeGroup {
-  return (
-    Object.keys(item).length === 6 &&
-    'title' in item &&
-    'items' in item &&
-    'slug' in item &&
-    'id' in item &&
-    'meta' in item &&
-    'type' in item
-  );
+  return 'title' in item && 'items' in item && 'slug' in item && 'id' in item && 'meta' in item && 'type' in item;
 }
 export function isNode(item: TableOfContentsItem): item is TableOfContentsNode {
-  return (
-    Object.keys(item).length === 5 &&
-    'title' in item &&
-    'slug' in item &&
-    'id' in item &&
-    'meta' in item &&
-    'type' in item
-  );
+  return 'title' in item && 'slug' in item && 'id' in item && 'meta' in item && 'type' in item;
 }
 export function isExternalLink(item: TableOfContentsItem): item is TableOfContentsExternalLink {
   return Object.keys(item).length === 2 && 'title' in item && 'url' in item;


### PR DESCRIPTION
Branched out from https://github.com/stoplightio/elements/pull/1483
Removing length check as added optional `version` property in elements service toc result makes it fail the check