### PR TITLE
fix: toc link colors in platform

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**"

--- a/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
+++ b/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
@@ -225,7 +225,13 @@ const Node = React.memo<{
   };
 
   return (
-    <Box as={LinkComponent} to={item.slug} display="block" textDecoration="no-underline">
+    <Box
+      as={LinkComponent}
+      to={item.slug}
+      display="block"
+      textDecoration="no-underline"
+      className="ElementsTableOfContentsItem"
+    >
       <Item
         id={getHtmlIdFromItemId(item.id)}
         isActive={isActive}

--- a/packages/elements-core/src/styles/_TableOfContents.scss
+++ b/packages/elements-core/src/styles/_TableOfContents.scss
@@ -1,0 +1,4 @@
+.ElementsTableOfContentsItem:hover {
+    text-decoration: none;
+    color: inherit;
+  }

--- a/packages/elements-core/src/styles/_main.scss
+++ b/packages/elements-core/src/styles/_main.scss
@@ -1,3 +1,4 @@
 @import 'HttpOperation.scss';
 @import 'TryIt.scss';
 @import 'Docs.scss';
+@import 'TableOfContents.scss';

--- a/packages/elements-core/src/styles/elements.scss
+++ b/packages/elements-core/src/styles/elements.scss
@@ -7,10 +7,6 @@ html {
   font-size: 13px;
 }
 
-a:hover {
-  text-decoration: none;
-}
-
 .svg-inline--fa {
   display: inline-block;
 }


### PR DESCRIPTION
Relates to https://github.com/stoplightio/platform-internal/issues/6900

This change should have no effect on how ToC looks in elements and dev-portal. Only related to platform.