### PR TITLE
chore: less noisy dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /examples/angular
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
     schedule:
       interval: weekly
       day: monday
@@ -12,6 +15,9 @@ updates:
     versioning-strategy: increase
   - package-ecosystem: npm
     directory: /examples/react-cra
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
     schedule:
       interval: weekly
       day: monday
@@ -22,6 +28,9 @@ updates:
     versioning-strategy: increase
   - package-ecosystem: npm
     directory: /examples/react-gatsby
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
     schedule:
       interval: weekly
       day: monday

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -18,26 +18,26 @@
     "url": "https://github.com/stoplightio/elements-starter-angular/issues"
   },
   "dependencies": {
-    "@angular/animations": "12.1.0",
-    "@angular/common": "12.1.1",
-    "@angular/compiler": "12.0.4",
-    "@angular/core": "12.0.4",
-    "@angular/forms": "12.1.0",
-    "@angular/platform-browser": "12.1.0",
-    "@angular/platform-browser-dynamic": "12.1.1",
-    "@angular/router": "12.0.4",
+    "@angular/animations": "^12.1.0",
+    "@angular/common": "^12.1.1",
+    "@angular/compiler": "^12.0.4",
+    "@angular/core": "^12.0.4",
+    "@angular/forms": "^12.1.0",
+    "@angular/platform-browser": "^12.1.0",
+    "@angular/platform-browser-dynamic": "^12.1.1",
+    "@angular/router": "^12.0.4",
     "@stoplight/elements": "^7.0.0",
     "@stoplight/elements-dev-portal": "^1.0.0",
-    "rxjs": "7.1.0",
-    "tslib": "2.3.0",
-    "zone.js": "0.11.4"
+    "rxjs": "^7.1.0",
+    "tslib": "^2.3.0",
+    "zone.js": "^0.11.4"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "12.1.0",
-    "@angular/cli": "12.1.1",
-    "@angular/compiler-cli": "12.0.4",
-    "@angular/language-service": "12.0.5",
-    "angular-http-server": "1.10.0",
-    "typescript": "4.2.4"
+    "@angular-devkit/build-angular": "^12.1.0",
+    "@angular/cli": "^12.1.1",
+    "@angular/compiler-cli": "^12.0.4",
+    "@angular/language-service": "^12.0.5",
+    "angular-http-server": "^1.10.0",
+    "typescript": "^4.2.4"
   }
 }

--- a/examples/react-cra/package.json
+++ b/examples/react-cra/package.json
@@ -21,7 +21,7 @@
     "@types/react-router-dom": "^5.1.7",
     "node-sass": "^6.0.1",
     "react-dom": "^17.0.2",
-    "react-scripts": "4.0.3",
+    "react-scripts": "^4.0.3",
     "serve": "^12.0.0",
     "typescript": "^4.3.5"
   },


### PR DESCRIPTION
Fixes: https://github.com/stoplightio/elements/issues/1383

Dependabot got a recent [update](https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/) that allows to filter out bumps based on semver scope.
This PR makes it ignore all the patch and minor bumps leaving only major ones. The rest should be installed anyway in a latest version because of `^` usage.