### PR TITLE
fix: badges

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
@@ -4,7 +4,7 @@ import { HttpSecurityScheme } from '@stoplight/types';
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { badgeDefaultColor } from '../../../constants';
+import { badgeDefaultBackgroundColor, badgeDefaultColor } from '../../../constants';
 import { getReadableSecurityName } from '../../../utils/oas/security';
 
 export const DeprecatedBadge: React.FC = () => (
@@ -40,7 +40,7 @@ export const SecurityBadge: React.FC<{ scheme: HttpSecurityScheme; httpServiceUr
       icon={faLock}
       data-testid="badge-security"
       className="sl-truncate"
-      style={{ backgroundColor: badgeDefaultColor }}
+      style={{ backgroundColor: badgeDefaultBackgroundColor, color: badgeDefaultColor }}
     >
       {getReadableSecurityName(scheme, true)}
     </Badge>
@@ -53,4 +53,23 @@ export const SecurityBadge: React.FC<{ scheme: HttpSecurityScheme; httpServiceUr
   ) : (
     badge
   );
+};
+
+export const VersionBadge: React.FC<{ value: string; backgroundColor?: string }> = ({ value, backgroundColor }) => (
+  <Badge
+    appearance="solid"
+    style={{
+      backgroundColor: backgroundColor || badgeDefaultBackgroundColor,
+      border: 'none',
+      color: badgeDefaultColor,
+    }}
+  >
+    {enhanceVersionString(value)}
+  </Badge>
+);
+
+const enhanceVersionString = (version: string): string => {
+  if (version[0] === 'v') return version;
+
+  return `v${version}`;
 };

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
@@ -1,21 +1,15 @@
-import { Badge, Box, Flex, Heading, VStack } from '@stoplight/mosaic';
+import { Box, Flex, Heading, VStack } from '@stoplight/mosaic';
 import { withErrorBoundary } from '@stoplight/react-error-boundary';
 import { IHttpService } from '@stoplight/types';
 import * as React from 'react';
 
-import { badgeDefaultColor } from '../../../constants';
 import { MockingContext } from '../../../containers/MockingProvider';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { PoweredByLink } from '../../PoweredByLink';
 import { DocsComponentProps } from '..';
+import { VersionBadge } from '../HttpOperation/Badges';
 import { SecuritySchemes } from './SecuritySchemes';
 import { ServerInfo } from './ServerInfo';
-
-const enhanceVersionString = (version: string): string => {
-  if (version[0] === 'v') return version;
-
-  return `v${version}`;
-};
 
 export type HttpServiceProps = DocsComponentProps<Partial<IHttpService>>;
 
@@ -47,7 +41,7 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(({ className, data, lo
 
       {data.version && (
         <Box mt={3}>
-          <Badge style={{ backgroundColor: badgeDefaultColor }}>{enhanceVersionString(data.version)}</Badge>
+          <VersionBadge value={data.version} />
         </Box>
       )}
 

--- a/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
+++ b/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
@@ -1,6 +1,7 @@
-import { Badge, Box, Flex, Icon } from '@stoplight/mosaic';
+import { Box, Flex, Icon } from '@stoplight/mosaic';
 import * as React from 'react';
 
+import { VersionBadge } from '../Docs/HttpOperation/Badges';
 import { NODE_META_COLOR, NODE_TYPE_ICON_COLOR, NODE_TYPE_META_ICON, NODE_TYPE_TITLE_ICON } from './constants';
 import {
   CustomLinkComponent,
@@ -252,15 +253,7 @@ const Node = React.memo<{
 const Version: React.FC<{ value: string }> = ({ value }) => {
   return (
     <Box mr={2}>
-      <Badge
-        appearance="solid"
-        style={{
-          backgroundColor: '#909DAB',
-          border: 'none',
-        }}
-      >
-        v{value}
-      </Badge>
+      <VersionBadge value={value} backgroundColor="#909DAB" />
     </Box>
   );
 };

--- a/packages/elements-core/src/constants.ts
+++ b/packages/elements-core/src/constants.ts
@@ -139,4 +139,5 @@ export const HttpCodeDescriptions = {
   599: 'Network connect timeout error',
 };
 
-export const badgeDefaultColor = '#293742';
+export const badgeDefaultBackgroundColor = '#293742';
+export const badgeDefaultColor = '#FFFFFF';


### PR DESCRIPTION
Fixes: https://github.com/stoplightio/elements/issues/1526

Brings back previous badges styles.

<img width="996" alt="Screenshot 2021-07-06 at 20 23 38" src="https://user-images.githubusercontent.com/14196079/124649132-653fb000-de98-11eb-91fd-3bef661d5198.png">
<img width="998" alt="Screenshot 2021-07-06 at 20 23 19" src="https://user-images.githubusercontent.com/14196079/124649137-67097380-de98-11eb-8575-3c6efb6d34f7.png">
<img width="959" alt="Screenshot 2021-07-06 at 20 26 40" src="https://user-images.githubusercontent.com/14196079/124649227-81435180-de98-11eb-8818-350b9046aa26.png">
