### PR TITLE
fix(toc): find first node

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.1.3",
+  "version": "7.1.4",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**"

--- a/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.spec.tsx
+++ b/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.spec.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 
 import { withMosaicProvider } from '../../hoc/withMosaicProvider';
 import { TableOfContents as TOC } from './TableOfContents';
+import { TableOfContentsItem } from './types';
+import { findFirstNode } from './utils';
 
 const TableOfContents = withMosaicProvider(TOC);
 
@@ -217,6 +219,81 @@ describe('TableOfContents', () => {
       expect(screen.queryByText(/v1.0.2/)).not.toBeInTheDocument();
 
       unmount();
+    });
+  });
+});
+
+describe('utils', () => {
+  describe('findFirstNode', () => {
+    it('should find the first node', () => {
+      const items: TableOfContentsItem[] = [
+        {
+          title: 'group',
+          items: [
+            {
+              id: 'abc',
+              title: 'Doc',
+              type: 'article',
+              slug: 'abc-doc',
+              meta: '',
+            },
+            {
+              id: 'targetId',
+              title: 'Target',
+              slug: 'target',
+              type: 'article',
+              meta: '',
+            },
+          ],
+        },
+      ];
+
+      const firstNode = findFirstNode(items);
+
+      expect(firstNode).toEqual({
+        id: 'abc',
+        title: 'Doc',
+        type: 'article',
+        slug: 'abc-doc',
+        meta: '',
+      });
+    });
+
+    it('should ignore group node if slug is empty', () => {
+      const items: TableOfContentsItem[] = [
+        {
+          id: 'abc',
+          title: 'Todo API',
+          type: 'http_service',
+          meta: '',
+          slug: '',
+          items: [
+            {
+              id: 'def',
+              title: 'Get Todo',
+              slug: 'def-get-todo',
+              type: 'http_operation',
+              meta: 'get',
+            },
+            {
+              id: 'ghi',
+              title: 'Add Todo',
+              slug: 'ghi-add-todo',
+              type: 'http_operation',
+              meta: 'post',
+            },
+          ],
+        },
+      ];
+
+      const firstNode = findFirstNode(items);
+      expect(firstNode).toEqual({
+        id: 'def',
+        title: 'Get Todo',
+        slug: 'def-get-todo',
+        type: 'http_operation',
+        meta: 'get',
+      });
     });
   });
 });

--- a/packages/elements-core/src/components/MosaicTableOfContents/utils.ts
+++ b/packages/elements-core/src/components/MosaicTableOfContents/utils.ts
@@ -42,15 +42,12 @@ function hasActiveItem(items: TableOfContentsGroupItem[], activeId: string): boo
 // Recursively finds the first node
 export function findFirstNode(items: TableOfContentsItem[]): TableOfContentsNode | TableOfContentsNodeGroup | void {
   for (const item of items) {
-    if (isNode(item)) {
+    // ignore nodes with empty slug
+    if ((isNode(item) || isNodeGroup(item)) && item.slug) {
       return item;
     }
 
-    if (isNodeGroup(item)) {
-      return item;
-    }
-
-    if (isGroup(item)) {
+    if (isGroup(item) || isNodeGroup(item)) {
       const firstNode = findFirstNode(item.items);
       if (firstNode) {
         return firstNode;

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
-    "@stoplight/elements-core": "~7.1.3",
+    "@stoplight/elements-core": "~7.1.4",
     "@stoplight/markdown-viewer": "^5.0.0",
     "@stoplight/mosaic": "^1",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.0.3';
+export const appVersion = '1.0.4';


### PR DESCRIPTION
Addresses: stoplightio/platform-internal#6995 and follows https://github.com/stoplightio/elements/pull/1567

Ignores group nodes with an empty slug when searching for the first node. This way we can skip http services with no description (empty slug) and redirect to the next existing node. 

For testing in dev portal storybook you may use pr-env from linked platform PR:
platform URL: https://x-7031.stoplight-dev.com

https://user-images.githubusercontent.com/14196079/124975015-d1075180-e02d-11eb-844b-418f369a3a91.mov

