### PR TITLE
chore: quiet dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,6 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /examples/angular
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
     schedule:
       interval: weekly
       day: monday
@@ -12,12 +9,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: scope
-    versioning-strategy: increase
+    versioning-strategy: increase-if-necessary
   - package-ecosystem: npm
     directory: /examples/react-cra
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
     schedule:
       interval: weekly
       day: monday
@@ -25,12 +19,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: scope
-    versioning-strategy: increase
+    versioning-strategy: increase-if-necessary
   - package-ecosystem: npm
     directory: /examples/react-gatsby
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
     schedule:
       interval: weekly
       day: monday
@@ -38,6 +29,6 @@ updates:
     commit-message:
       prefix: "chore"
       include: scope
-    versioning-strategy: increase
+    versioning-strategy: increase-if-necessary
 
 


### PR DESCRIPTION
Followup to #1549 

This should hopefully solve the issue. 

IDK why the ignore approach wasn't working TBH, this is just a different - hopefully more supported - way of doing the same thing. What the `increase-if-necessary` strategy does is that it only changes `package.json` if the new package version falls out of the current range constraint. That should mean that wherever we have carets, we'll only get notified of major updates.