### PR TITLE
fix: model page layout

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, HStack } from '@stoplight/mosaic';
+import { Box, Heading, HStack } from '@stoplight/mosaic';
 import { withErrorBoundary } from '@stoplight/react-error-boundary';
 import { IHttpOperation } from '@stoplight/types';
 import cn from 'classnames';
@@ -11,6 +11,7 @@ import { getServiceUriFromOperation } from '../../../utils/oas/security';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { TryItWithRequestSamples } from '../../TryIt';
 import { DocsComponentProps } from '..';
+import { TwoColumnLayout } from '../TwoColumnLayout';
 import { DeprecatedBadge, InternalBadge, SecurityBadge } from './Badges';
 import { Request } from './Request';
 import { Responses } from './Responses';
@@ -35,16 +36,16 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
 
     const hasBadges = isDeprecated || securitySchemes.length > 0 || isInternal;
 
-    return (
-      <Box bg="transparent" className={cn('HttpOperation', className)} w="full">
+    const header = (!layoutOptions?.noHeading || hasBadges) && (
+      <>
         {!layoutOptions?.noHeading && (
-          <Heading size={1} fontWeight="semibold">
+          <Heading size={1} mb={4} fontWeight="semibold">
             {data.summary || data.iid || `${data.method} ${data.path}`}
           </Heading>
         )}
 
         {hasBadges && (
-          <HStack spacing={2} mt={3}>
+          <HStack spacing={2}>
             {isDeprecated && <DeprecatedBadge />}
             {sortBy(securitySchemes, 'type').map((scheme, i) => (
               <SecurityBadge key={i} scheme={scheme} httpServiceUri={allowRouting ? httpServiceUri : undefined} />
@@ -52,40 +53,47 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
             {isInternal && <InternalBadge isHttpService />}
           </HStack>
         )}
+      </>
+    );
 
-        <Flex mt={12}>
-          <Box flex={1}>
-            {data.description && (
-              <MarkdownViewer className="HttpOperation__Description sl-mb-10" markdown={data.description} />
-            )}
+    const description = (
+      <>
+        {data.description && (
+          <MarkdownViewer className="HttpOperation__Description sl-mb-10" markdown={data.description} />
+        )}
 
-            <Request onChange={setTextRequestBodyIndex} operation={data} />
+        <Request onChange={setTextRequestBodyIndex} operation={data} />
 
-            {data.responses && (
-              <Responses
-                responses={data.responses}
-                onMediaTypeChange={setResponseMediaType}
-                onStatusCodeChange={setResponseStatusCode}
-              />
-            )}
-          </Box>
+        {data.responses && (
+          <Responses
+            responses={data.responses}
+            onMediaTypeChange={setResponseMediaType}
+            onStatusCodeChange={setResponseStatusCode}
+          />
+        )}
+      </>
+    );
 
-          {!layoutOptions?.hideTryItPanel && (
-            <Box ml={16} pos="relative" w="2/5" style={{ maxWidth: 500 }}>
-              <Box className="HttpOperation__gutter">
-                <TryItWithRequestSamples
-                  httpOperation={data}
-                  responseMediaType={responseMediaType}
-                  responseStatusCode={responseStatusCode}
-                  requestBodyIndex={requestBodyIndex}
-                  hideTryIt={layoutOptions?.hideTryIt}
-                  mockUrl={mocking.hideMocking ? undefined : mocking.mockUrl}
-                />
-              </Box>
-            </Box>
-          )}
-        </Flex>
+    const tryItPanel = !layoutOptions?.hideTryItPanel && (
+      <Box className="HttpOperation__gutter">
+        <TryItWithRequestSamples
+          httpOperation={data}
+          responseMediaType={responseMediaType}
+          responseStatusCode={responseStatusCode}
+          requestBodyIndex={requestBodyIndex}
+          hideTryIt={layoutOptions?.hideTryIt}
+          mockUrl={mocking.hideMocking ? undefined : mocking.mockUrl}
+        />
       </Box>
+    );
+
+    return (
+      <TwoColumnLayout
+        className={cn('HttpOperation', className)}
+        header={header}
+        left={description}
+        right={tryItPanel}
+      />
     );
   },
 );

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
@@ -1,6 +1,7 @@
-import { Box, Flex, Heading, VStack } from '@stoplight/mosaic';
+import { Box, Heading, VStack } from '@stoplight/mosaic';
 import { withErrorBoundary } from '@stoplight/react-error-boundary';
 import { IHttpService } from '@stoplight/types';
+import cn from 'classnames';
 import * as React from 'react';
 
 import { MockingContext } from '../../../containers/MockingProvider';
@@ -63,7 +64,9 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(({ className, data, lo
     );
   }
 
-  return <TwoColumnLayout className={className} header={header} left={description} right={dataPanel} />;
+  return (
+    <TwoColumnLayout className={cn('HttpService', className)} header={header} left={description} right={dataPanel} />
+  );
 });
 HttpServiceComponent.displayName = 'HttpService.Component';
 

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
@@ -8,6 +8,7 @@ import { MarkdownViewer } from '../../MarkdownViewer';
 import { PoweredByLink } from '../../PoweredByLink';
 import { DocsComponentProps } from '..';
 import { VersionBadge } from '../HttpOperation/Badges';
+import { TwoColumnLayout } from '../TwoColumnLayout';
 import { SecuritySchemes } from './SecuritySchemes';
 import { ServerInfo } from './ServerInfo';
 
@@ -18,7 +19,25 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(({ className, data, lo
   const mocking = React.useContext(MockingContext);
   const query = new URLSearchParams(search);
 
-  const description = data.description && <MarkdownViewer className="sl-mb-10" markdown={data.description} />;
+  const shouldDisplayHeader = data.name && !layoutOptions?.noHeading;
+
+  const header = (shouldDisplayHeader || data.version) && (
+    <>
+      {shouldDisplayHeader && (
+        <Heading size={1} mb={4} fontWeight="semibold">
+          {data.name}
+        </Heading>
+      )}
+
+      {data.version && (
+        <Box mb={5}>
+          <VersionBadge value={data.version} />
+        </Box>
+      )}
+    </>
+  );
+
+  const description = data.description && <MarkdownViewer className="sl-mb-5" markdown={data.description} />;
 
   const dataPanel = (
     <VStack spacing={6}>
@@ -31,43 +50,20 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(({ className, data, lo
     </VStack>
   );
 
-  return (
-    <Box className={className} w="full">
-      {data.name && !layoutOptions?.noHeading && (
-        <Heading size={1} fontWeight="semibold">
-          {data.name}
-        </Heading>
-      )}
+  if (layoutOptions?.showPoweredByLink) {
+    return (
+      <Box mb={10}>
+        {header}
+        {description}
+        {pathname && (
+          <PoweredByLink source={data.name ?? 'no-title'} pathname={pathname} packageType="elements" layout="stacked" />
+        )}
+        {dataPanel}
+      </Box>
+    );
+  }
 
-      {data.version && (
-        <Box mt={3}>
-          <VersionBadge value={data.version} />
-        </Box>
-      )}
-
-      {layoutOptions?.showPoweredByLink ? (
-        <Box mb={10}>
-          {description}
-          {pathname && (
-            <PoweredByLink
-              source={data.name ?? 'no-title'}
-              pathname={pathname}
-              packageType="elements"
-              layout="stacked"
-            />
-          )}
-          {dataPanel}
-        </Box>
-      ) : (
-        <Flex mt={12}>
-          <Box flex={1}>{description}</Box>
-          <Box ml={16} pos="relative" w="2/5" style={{ maxWidth: 500 }}>
-            {dataPanel}
-          </Box>
-        </Flex>
-      )}
-    </Box>
-  );
+  return <TwoColumnLayout className={className} header={header} left={description} right={dataPanel} />;
 });
 HttpServiceComponent.displayName = 'HttpService.Component';
 

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -1,5 +1,5 @@
 import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
-import { Box, Flex, Heading, HStack, Panel, Text } from '@stoplight/mosaic';
+import { Heading, HStack, Panel, Text } from '@stoplight/mosaic';
 import { CodeViewer } from '@stoplight/mosaic-code-viewer';
 import { withErrorBoundary } from '@stoplight/react-error-boundary';
 import cn from 'classnames';
@@ -46,7 +46,7 @@ const ModelComponent: React.FC<ModelProps> = ({ data: unresolvedData, className,
   const description = (
     <>
       {data.description && <MarkdownViewer className="sl-mb-6" markdown={data.description} />}
-      <JsonSchemaViewer resolveRef={resolveRef} className={className} schema={getOriginalObject(data)} />
+      <JsonSchemaViewer resolveRef={resolveRef} schema={getOriginalObject(data)} />
     </>
   );
 
@@ -70,7 +70,9 @@ const ModelComponent: React.FC<ModelProps> = ({ data: unresolvedData, className,
     </Panel>
   );
 
-  return <TwoColumnLayout className="Model" header={header} left={description} right={modelExamples} />;
+  return (
+    <TwoColumnLayout className={cn('Model', className)} header={header} left={description} right={modelExamples} />
+  );
 };
 
 export const Model = withErrorBoundary<ModelProps>(ModelComponent, { recoverableProps: ['data'] });

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -12,6 +12,7 @@ import { getOriginalObject } from '../../../utils/ref-resolving/resolvedObject';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { DocsComponentProps } from '..';
 import { InternalBadge } from '../HttpOperation/Badges';
+import { TwoColumnLayout } from '../TwoColumnLayout';
 
 export type ModelProps = DocsComponentProps<JSONSchema7>;
 
@@ -24,50 +25,52 @@ const ModelComponent: React.FC<ModelProps> = ({ data: unresolvedData, className,
 
   const example = React.useMemo(() => generateExampleFromJsonSchema(data), [data]);
 
-  return (
-    <Box className={cn('Model', className)}>
-      {!layoutOptions?.noHeading && title !== undefined && (
+  const shouldDisplayHeader = !layoutOptions?.noHeading && title !== undefined;
+
+  const header = (shouldDisplayHeader || isInternal) && (
+    <>
+      {shouldDisplayHeader && (
         <Heading size={1} mb={4} fontWeight="semibold">
           {title}
         </Heading>
       )}
 
       {isInternal && (
-        <HStack spacing={2} mt={3} mb={12}>
+        <HStack spacing={2} mb={12}>
           <InternalBadge />
         </HStack>
       )}
-
-      {data.description && <MarkdownViewer markdown={data.description} />}
-
-      <Flex>
-        <Box flex={1}>
-          <JsonSchemaViewer resolveRef={resolveRef} className={className} schema={getOriginalObject(data)} />
-        </Box>
-        {!layoutOptions?.hideModelExamples && (
-          <Box ml={16} pos="relative" w="2/5" style={{ maxWidth: 500 }}>
-            <Panel rounded isCollapsible={false}>
-              <Panel.Titlebar>
-                <Text color="body" role="heading">
-                  Example
-                </Text>
-              </Panel.Titlebar>
-              <Panel.Content p={0}>
-                <CodeViewer
-                  aria-label={example}
-                  noCopyButton
-                  maxHeight="500px"
-                  language="json"
-                  value={example}
-                  showLineNumbers
-                />
-              </Panel.Content>
-            </Panel>
-          </Box>
-        )}
-      </Flex>
-    </Box>
+    </>
   );
+
+  const description = (
+    <>
+      {data.description && <MarkdownViewer className="sl-mb-6" markdown={data.description} />}
+      <JsonSchemaViewer resolveRef={resolveRef} className={className} schema={getOriginalObject(data)} />
+    </>
+  );
+
+  const modelExamples = !layoutOptions?.hideModelExamples && (
+    <Panel rounded isCollapsible={false}>
+      <Panel.Titlebar>
+        <Text color="body" role="heading">
+          Example
+        </Text>
+      </Panel.Titlebar>
+      <Panel.Content p={0}>
+        <CodeViewer
+          aria-label={example}
+          noCopyButton
+          maxHeight="500px"
+          language="json"
+          value={example}
+          showLineNumbers
+        />
+      </Panel.Content>
+    </Panel>
+  );
+
+  return <TwoColumnLayout className="Model" header={header} left={description} right={modelExamples} />;
 };
 
 export const Model = withErrorBoundary<ModelProps>(ModelComponent, { recoverableProps: ['data'] });

--- a/packages/elements-core/src/components/Docs/TwoColumnLayout.tsx
+++ b/packages/elements-core/src/components/Docs/TwoColumnLayout.tsx
@@ -1,0 +1,23 @@
+import { Box, Flex } from '@stoplight/mosaic';
+import React from 'react';
+
+export interface TwoColumnLayoutProps {
+  header: React.ReactNode;
+  right: React.ReactNode;
+  left: React.ReactNode;
+  className?: string;
+}
+
+export const TwoColumnLayout = ({ header, right, left, className }: TwoColumnLayoutProps) => (
+  <Box w="full" className={className}>
+    {header}
+    <Flex mt={header ? 12 : undefined}>
+      <Box flex={1}>{left}</Box>
+      {right && (
+        <Box ml={16} pos="relative" w="2/5" style={{ maxWidth: 500 }}>
+          {right}
+        </Box>
+      )}
+    </Flex>
+  </Box>
+);

--- a/packages/elements-core/src/styles/_Docs.scss
+++ b/packages/elements-core/src/styles/_Docs.scss
@@ -10,3 +10,7 @@
   pointer-events: none;
   user-select: none;
 }
+
+.Model {
+  --fs-code: 12px;
+}

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -39,15 +39,13 @@ export const NodeContent = ({ node, Link, hideTryIt, hideTryItPanel, hideMocking
       <NodeLinkContext.Provider value={[node, Link]}>
         <MarkdownComponentsProvider value={{ link: LinkComponent }}>
           <MockingProvider mockUrl={node.links.mock_url} hideMocking={hideMocking}>
-            <Box style={{ maxWidth: ['model'].includes(node.type) ? 1000 : undefined }}>
-              <Docs
-                nodeType={node.type as NodeType}
-                nodeData={node.data}
-                nodeTitle={node.title}
-                layoutOptions={{ hideTryIt: hideTryIt, hideTryItPanel: hideTryItPanel }}
-                useNodeForRefResolving
-              />
-            </Box>
+            <Docs
+              nodeType={node.type as NodeType}
+              nodeData={node.data}
+              nodeTitle={node.title}
+              layoutOptions={{ hideTryIt: hideTryIt, hideTryItPanel: hideTryItPanel }}
+              useNodeForRefResolving
+            />
           </MockingProvider>
         </MarkdownComponentsProvider>
       </NodeLinkContext.Provider>

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -6,7 +6,6 @@ import {
   PersistenceContextProvider,
 } from '@stoplight/elements-core';
 import { CustomComponentMapping } from '@stoplight/markdown-viewer';
-import { Box } from '@stoplight/mosaic';
 import { dirname, resolve } from '@stoplight/path';
 import { NodeType } from '@stoplight/types';
 import * as React from 'react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9208,7 +9208,7 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -12943,7 +12943,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -15273,11 +15273,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseisequal@^3.0.0:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
@@ -15295,29 +15290,17 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
 
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -15438,11 +15421,6 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"


### PR DESCRIPTION
Fixes #1522

Few things I've done here:

- `TwoColumnsLayout` component unifies layouts on model, operation and overview pages.
- In `noHeading` mode components don't have any padding at the top - I believe this makes it easier to reason about components in separation.
- Font in model examples was changed using the same method as in `HttpOperation` page.
- In dev-portal I removed min-width on a model page