### PR TITLE
chore(release): elements-core v7.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,5 +98,6 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
-  }
+  },
+  "version": "0.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -98,6 +98,5 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
-  },
-  "version": "0.0.0"
+  }
 }

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.1.4",
+  "version": "7.2.0",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**"
@@ -51,7 +51,7 @@
     "@stoplight/json-schema-sampler": "0.2.0",
     "@stoplight/json-schema-viewer": "^4.0.3",
     "@stoplight/markdown": "^3.0.0",
-    "@stoplight/markdown-viewer": "^5.0.0",
+    "@stoplight/markdown-viewer": "^5.1.0",
     "@stoplight/mosaic": "^1",
     "@stoplight/mosaic-code-editor": "^1",
     "@stoplight/mosaic-code-viewer": "^1",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.2.0",
+  "version": "7.1.5",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**"

--- a/packages/elements-core/src/styles/_Docs.scss
+++ b/packages/elements-core/src/styles/_Docs.scss
@@ -14,3 +14,7 @@
 .Model {
   --fs-code: 12px;
 }
+
+.sl-markdown-viewer {
+  width: 0;
+}

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
     "@stoplight/elements-core": "~7.1.5",
-    "@stoplight/markdown-viewer": "^5.0.0",
+    "@stoplight/markdown-viewer": "^5.1.0",
     "@stoplight/mosaic": "^1",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^12.0.0",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
-    "@stoplight/elements-core": "~7.1.4",
+    "@stoplight/elements-core": "~7.1.5",
     "@stoplight/markdown-viewer": "^5.0.0",
     "@stoplight/mosaic": "^1",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.0.4';
+export const appVersion = '1.0.5';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.0.3",
+  "version": "7.0.2",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -48,7 +48,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.31",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "@stoplight/elements-core": "~7.1.2",
+    "@stoplight/elements-core": "~7.1.5",
     "@stoplight/http-spec": "^4.0.1",
     "@stoplight/json": "^3.10.0",
     "@stoplight/mosaic": "^1",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4091,24 +4091,6 @@
   dependencies:
     wolfy87-eventemitter "~5.2.8"
 
-"@stoplight/markdown-viewer@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-5.0.0.tgz#44fc6e1d8fcfd8b6804261665d2ed3d29beefc02"
-  integrity sha512-c+bkpZ1sPI/DqKRMI7ewKoeuAxfULdpoHUnJwM9q2KsER1bwxNkvpUIuVdH0bel2MAxA9Ac49TXezsCeYyBRKQ==
-  dependencies:
-    "@stoplight/markdown" "^3.0.0"
-    "@stoplight/react-error-boundary" "^1.1.0"
-    "@stoplight/types" "^12.3.0"
-    clsx "^1.1.1"
-    deepmerge "^4.2.2"
-    hast-to-hyperscript "^10.0.0"
-    hast-util-raw "^7.0.0"
-    hast-util-sanitize "^4.0.0"
-    mdast-util-to-hast "^11.1.1"
-    remark-parse "^9.0.0"
-    unified "^9.2.1"
-    unist-util-visit "^3.1.0"
-
 "@stoplight/markdown-viewer@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-5.1.0.tgz#2a21fc0032a63218a325923a0beca79e78c94c33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9200,7 +9200,7 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -12930,7 +12930,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -15276,11 +15276,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseisequal@^3.0.0:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
@@ -15298,29 +15293,17 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
 
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -15441,11 +15424,6 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4109,6 +4109,24 @@
     unified "^9.2.1"
     unist-util-visit "^3.1.0"
 
+"@stoplight/markdown-viewer@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-5.1.0.tgz#2a21fc0032a63218a325923a0beca79e78c94c33"
+  integrity sha512-QcF/Ju54RZERH+ewGqW8dHYcuvL9YoaXNg8tvze5y4Z7L2bIpaNUdMUDsEDdFWC/h/MePumo3OQDpo4hV2VHFQ==
+  dependencies:
+    "@stoplight/markdown" "^3.0.0"
+    "@stoplight/react-error-boundary" "^1.1.0"
+    "@stoplight/types" "^12.3.0"
+    clsx "^1.1.1"
+    deepmerge "^4.2.2"
+    hast-to-hyperscript "^10.0.0"
+    hast-util-raw "^7.0.0"
+    hast-util-sanitize "^4.0.0"
+    mdast-util-to-hast "^11.1.1"
+    remark-parse "^9.0.0"
+    unified "^9.2.1"
+    unist-util-visit "^3.1.0"
+
 "@stoplight/markdown@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@stoplight/markdown/-/markdown-3.0.0.tgz#2dd5dd1d8f13cfdb9c5cf9f070749b4fd47cbcd1"


### PR DESCRIPTION
Needed for: https://github.com/stoplightio/platform-internal/issues/7052

Also bumps `markdown-viewer` to `5.1.0`(this changes the `MarkdownViewer` components class, which affects the styling) - for details see: https://github.com/stoplightio/markdown-viewer/pull/100

Releases:
- `elements-core: 7.1.4 -> 7.1.5`
- `elements: 7.0.2 -> 7.0.3`
- `elements-dev-portal: 1.0.4 -> 1.0.5`