### PR TITLE
fix: scroll on toc click

### DIFF
--- a/packages/elements-core/src/components/Layout/SidebarLayout.tsx
+++ b/packages/elements-core/src/components/Layout/SidebarLayout.tsx
@@ -6,49 +6,47 @@ type SidebarLayoutProps = {
   sidebar: React.ReactNode;
   maxContentWidth?: number;
   sidebarWidth?: number;
+  children?: React.ReactNode;
 };
 
 const MAX_CONTENT_WIDTH = 1800;
 const SIDEBAR_WIDTH = 300;
 
-export const SidebarLayout: React.FC<SidebarLayoutProps> = ({
-  sidebar,
-  children,
-  maxContentWidth = MAX_CONTENT_WIDTH,
-  sidebarWidth = SIDEBAR_WIDTH,
-}) => {
-  const scrollRef = React.useRef<HTMLDivElement | null>(null);
-  const { pathname } = useLocation();
+export const SidebarLayout = React.forwardRef<HTMLDivElement, SidebarLayoutProps>(
+  ({ sidebar, children, maxContentWidth = MAX_CONTENT_WIDTH, sidebarWidth = SIDEBAR_WIDTH }, ref) => {
+    const scrollRef = React.useRef<HTMLDivElement | null>(null);
+    const { pathname } = useLocation();
 
-  React.useEffect(() => {
-    // Scroll to top on page change
-    scrollRef.current?.scrollTo(0, 0);
-  }, [pathname]);
+    React.useEffect(() => {
+      // Scroll to top on page change
+      scrollRef.current?.scrollTo(0, 0);
+    }, [pathname]);
 
-  return (
-    <Flex className="sl-elements-api" pin h="full">
-      <Flex
-        direction="col"
-        bg="canvas-100"
-        borderR
-        pt={8}
-        pos="sticky"
-        pinY
-        overflowY="auto"
-        style={{
-          width: `calc((100% - ${maxContentWidth}px) / 2 + ${sidebarWidth}px)`,
-          paddingLeft: `calc((100% - ${maxContentWidth}px) / 2)`,
-          minWidth: `${sidebarWidth}px`,
-        }}
-      >
-        {sidebar}
-      </Flex>
+    return (
+      <Flex ref={ref} className="sl-elements-api" pin h="full">
+        <Flex
+          direction="col"
+          bg="canvas-100"
+          borderR
+          pt={8}
+          pos="sticky"
+          pinY
+          overflowY="auto"
+          style={{
+            width: `calc((100% - ${maxContentWidth}px) / 2 + ${sidebarWidth}px)`,
+            paddingLeft: `calc((100% - ${maxContentWidth}px) / 2)`,
+            minWidth: `${sidebarWidth}px`,
+          }}
+        >
+          {sidebar}
+        </Flex>
 
-      <Box ref={scrollRef} bg="canvas" px={24} flex={1} overflowY="auto" overflowX="hidden" w="full">
-        <Box style={{ maxWidth: `${maxContentWidth - sidebarWidth}px` }} py={16}>
-          {children}
+        <Box ref={scrollRef} bg="canvas" px={24} flex={1} overflowY="auto" overflowX="hidden" w="full">
+          <Box style={{ maxWidth: `${maxContentWidth - sidebarWidth}px` }} py={16}>
+            {children}
+          </Box>
         </Box>
-      </Box>
-    </Flex>
-  );
-};
+      </Flex>
+    );
+  },
+);

--- a/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
+++ b/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
@@ -26,8 +26,14 @@ const ActiveIdContext = React.createContext<string | undefined>(undefined);
 const LinkContext = React.createContext<CustomLinkComponent | undefined>(undefined);
 
 export const TableOfContents = React.memo<TableOfContentsProps>(({ tree, activeId, Link, maxDepthOpenByDefault }) => {
+  const container = React.useRef<HTMLDivElement>(null);
+  const child = React.useRef<HTMLDivElement>(null);
+
   React.useEffect(() => {
-    if (activeId && typeof window !== 'undefined') {
+    const tocHasScrollbar =
+      container.current && child.current && container.current.offsetHeight < child.current.offsetHeight;
+
+    if (activeId && typeof window !== 'undefined' && tocHasScrollbar) {
       const elem = window.document.getElementById(getHtmlIdFromItemId(activeId));
       if (elem && 'scrollIntoView' in elem) {
         elem.scrollIntoView({ block: 'center' });
@@ -38,8 +44,8 @@ export const TableOfContents = React.memo<TableOfContentsProps>(({ tree, activeI
   }, []);
 
   return (
-    <Box w="full" bg="canvas-100">
-      <Box my={3}>
+    <Box ref={container} w="full" bg="canvas-100" overflowY="auto">
+      <Box ref={child} my={3}>
         <LinkContext.Provider value={Link}>
           <ActiveIdContext.Provider value={activeId}>
             {tree.map((item, key) => {

--- a/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
+++ b/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
@@ -25,42 +25,52 @@ import {
 const ActiveIdContext = React.createContext<string | undefined>(undefined);
 const LinkContext = React.createContext<CustomLinkComponent | undefined>(undefined);
 
-export const TableOfContents = React.memo<TableOfContentsProps>(({ tree, activeId, Link, maxDepthOpenByDefault }) => {
-  const container = React.useRef<HTMLDivElement>(null);
-  const child = React.useRef<HTMLDivElement>(null);
+export const TableOfContents = React.memo<TableOfContentsProps>(
+  ({ tree, activeId, Link, maxDepthOpenByDefault, onLinkClick }) => {
+    const container = React.useRef<HTMLDivElement>(null);
+    const child = React.useRef<HTMLDivElement>(null);
 
-  React.useEffect(() => {
-    const tocHasScrollbar =
-      container.current && child.current && container.current.offsetHeight < child.current.offsetHeight;
+    React.useEffect(() => {
+      const tocHasScrollbar =
+        container.current && child.current && container.current.offsetHeight < child.current.offsetHeight;
 
-    if (activeId && typeof window !== 'undefined' && tocHasScrollbar) {
-      const elem = window.document.getElementById(getHtmlIdFromItemId(activeId));
-      if (elem && 'scrollIntoView' in elem) {
-        elem.scrollIntoView({ block: 'center' });
+      if (activeId && typeof window !== 'undefined' && tocHasScrollbar) {
+        const elem = window.document.getElementById(getHtmlIdFromItemId(activeId));
+        if (elem && 'scrollIntoView' in elem) {
+          elem.scrollIntoView({ block: 'center' });
+        }
       }
-    }
-    // Only want to run this effect on initial render
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+      // Only want to run this effect on initial render
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
-  return (
-    <Box ref={container} w="full" bg="canvas-100" overflowY="auto">
-      <Box ref={child} my={3}>
-        <LinkContext.Provider value={Link}>
-          <ActiveIdContext.Provider value={activeId}>
-            {tree.map((item, key) => {
-              if (isDivider(item)) {
-                return <Divider key={key} item={item} />;
-              }
+    return (
+      <Box ref={container} w="full" bg="canvas-100" overflowY="auto">
+        <Box ref={child} my={3}>
+          <LinkContext.Provider value={Link}>
+            <ActiveIdContext.Provider value={activeId}>
+              {tree.map((item, key) => {
+                if (isDivider(item)) {
+                  return <Divider key={key} item={item} />;
+                }
 
-              return <GroupItem key={key} item={item} depth={0} maxDepthOpenByDefault={maxDepthOpenByDefault} />;
-            })}
-          </ActiveIdContext.Provider>
-        </LinkContext.Provider>
+                return (
+                  <GroupItem
+                    key={key}
+                    item={item}
+                    depth={0}
+                    maxDepthOpenByDefault={maxDepthOpenByDefault}
+                    onLinkClick={onLinkClick}
+                  />
+                );
+              })}
+            </ActiveIdContext.Provider>
+          </LinkContext.Provider>
+        </Box>
       </Box>
-    </Box>
-  );
-});
+    );
+  },
+);
 
 const Divider = React.memo<{
   item: TableOfContentsDivider;
@@ -85,7 +95,8 @@ const GroupItem = React.memo<{
   depth: number;
   item: TableOfContentsGroupItem;
   maxDepthOpenByDefault?: number;
-}>(({ item, depth, maxDepthOpenByDefault }) => {
+  onLinkClick?(): void;
+}>(({ item, depth, maxDepthOpenByDefault, onLinkClick }) => {
   if (isExternalLink(item)) {
     return (
       <Box as="a" href={item.url} target="_blank" rel="noopener noreferrer" display="block">
@@ -93,12 +104,13 @@ const GroupItem = React.memo<{
       </Box>
     );
   } else if (isGroup(item) || isNodeGroup(item)) {
-    return <Group depth={depth} item={item} maxDepthOpenByDefault={maxDepthOpenByDefault} />;
+    return <Group depth={depth} item={item} maxDepthOpenByDefault={maxDepthOpenByDefault} onLinkClick={onLinkClick} />;
   } else if (isNode(item)) {
     return (
       <Node
         depth={depth}
         item={item}
+        onLinkClick={onLinkClick}
         meta={
           item.meta ? (
             <Box color={NODE_META_COLOR[item.meta]} textTransform="uppercase" fontWeight="medium">
@@ -124,14 +136,15 @@ const Group = React.memo<{
   depth: number;
   item: TableOfContentsGroup | TableOfContentsNodeGroup;
   maxDepthOpenByDefault?: number;
-}>(({ depth, item, maxDepthOpenByDefault }) => {
+  onLinkClick?(): void;
+}>(({ depth, item, maxDepthOpenByDefault, onLinkClick = () => {} }) => {
   const activeId = React.useContext(ActiveIdContext);
   const [isOpen, setIsOpen] = React.useState(() => {
     // Only need to check during initial render
     return isGroupOpenByDefault(depth, item, activeId, maxDepthOpenByDefault);
   });
 
-  const onClick = (e: React.MouseEvent, forceOpen?: boolean) => {
+  const handleClick = (e: React.MouseEvent, forceOpen?: boolean) => {
     setIsOpen(forceOpen ? true : !isOpen);
   };
 
@@ -147,7 +160,7 @@ const Group = React.memo<{
           // Don't propagate event when clicking icon
           e.stopPropagation();
           e.preventDefault();
-          onClick(e);
+          handleClick(e);
         }}
       />
     </Flex>
@@ -155,9 +168,9 @@ const Group = React.memo<{
 
   let elem;
   if (isNodeGroup(item)) {
-    elem = <Node depth={depth} item={item} meta={meta} onClick={onClick} />;
+    elem = <Node depth={depth} item={item} meta={meta} onClick={handleClick} onLinkClick={onLinkClick} />;
   } else {
-    elem = <Item title={item.title} meta={meta} onClick={onClick} depth={depth} />;
+    elem = <Item title={item.title} meta={meta} onClick={handleClick} depth={depth} />;
   }
 
   return (
@@ -166,7 +179,7 @@ const Group = React.memo<{
 
       {isOpen &&
         item.items.map((groupItem, key) => {
-          return <GroupItem key={key} item={groupItem} depth={depth + 1} />;
+          return <GroupItem key={key} item={groupItem} depth={depth + 1} onLinkClick={onLinkClick} />;
         })}
     </>
   );
@@ -213,7 +226,8 @@ const Node = React.memo<{
   depth: number;
   meta?: React.ReactNode;
   onClick?: (e: React.MouseEvent, forceOpen?: boolean) => void;
-}>(({ item, depth, meta, onClick }) => {
+  onLinkClick?(): void;
+}>(({ item, depth, meta, onClick, onLinkClick = () => {} }) => {
   const activeId = React.useContext(ActiveIdContext);
   const isActive = activeId === item.id;
   const shouldNavigate = !!item.slug;
@@ -224,6 +238,8 @@ const Node = React.memo<{
       // Don't trigger link click when we're active
       e.stopPropagation();
       e.preventDefault();
+    } else {
+      onLinkClick();
     }
 
     // Force open when clicking inactive group

--- a/packages/elements-core/src/components/MosaicTableOfContents/types.ts
+++ b/packages/elements-core/src/components/MosaicTableOfContents/types.ts
@@ -3,6 +3,7 @@ export type TableOfContentsProps = {
   activeId: string;
   Link: CustomLinkComponent;
   maxDepthOpenByDefault?: number;
+  onLinkClick?(): void;
 };
 
 export type CustomLinkComponent = React.ComponentType<{

--- a/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
@@ -13,6 +13,7 @@ export type TableOfContentsProps = BoxProps<'div'> & {
   tableOfContents: ProjectTableOfContents;
   Link: CustomLinkComponent;
   collapseTableOfContents?: boolean;
+  onLinkClick?(): void;
 };
 
 export const TableOfContents = ({
@@ -20,6 +21,7 @@ export const TableOfContents = ({
   activeId,
   Link,
   collapseTableOfContents = false,
+  onLinkClick,
   ...boxProps
 }: TableOfContentsProps) => {
   return (
@@ -30,6 +32,7 @@ export const TableOfContents = ({
           activeId={activeId}
           Link={Link}
           maxDepthOpenByDefault={collapseTableOfContents ? 0 : 1}
+          onLinkClick={onLinkClick}
         />
       </Flex>
 

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -74,6 +74,7 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
     projectId,
     branchSlug,
   });
+  const container = React.useRef<HTMLDivElement>(null);
 
   if (!nodeSlug && isTocFetched && tableOfContents?.items) {
     const firstNode = findFirstNode(tableOfContents.items);
@@ -97,8 +98,15 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
     elem = <NodeContent node={node} Link={Link} hideTryIt={hideTryIt} hideMocking={hideMocking} />;
   }
 
+  const handleTocClick = () => {
+    if (container.current) {
+      container.current.scrollIntoView();
+    }
+  };
+
   return (
     <SidebarLayout
+      ref={container}
       sidebar={
         <>
           {branches && branches.length > 1 ? (
@@ -116,6 +124,7 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
               tableOfContents={tableOfContents}
               Link={Link}
               collapseTableOfContents={collapseTableOfContents}
+              onLinkClick={handleTocClick}
             />
           ) : null}
         </>

--- a/packages/elements/src/components/API/APIWithSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithSidebarLayout.tsx
@@ -21,6 +21,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
   hideSchemas,
   hideInternal,
 }) => {
+  const container = React.useRef<HTMLDivElement>(null);
   const tree = React.useMemo(
     () => computeAPITree(serviceNode, { hideSchemas, hideInternal }),
     [serviceNode, hideSchemas, hideInternal],
@@ -44,6 +45,12 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
     return <Redirect to="/" />;
   }
 
+  const handleTocClick = () => {
+    if (container.current) {
+      container.current.scrollIntoView();
+    }
+  };
+
   const sidebar = (
     <>
       <Flex ml={4} mb={5} alignItems="center">
@@ -55,14 +62,14 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
         <Heading size={4}>{serviceNode.name}</Heading>
       </Flex>
       <Flex flexGrow flexShrink overflowY="auto" direction="col">
-        <TableOfContents tree={tree} activeId={pathname} Link={Link} />
+        <TableOfContents tree={tree} activeId={pathname} Link={Link} onLinkClick={handleTocClick} />
       </Flex>
       <PoweredByLink source={serviceNode.name} pathname={pathname} packageType="elements" />
     </>
   );
 
   return (
-    <SidebarLayout sidebar={sidebar}>
+    <SidebarLayout ref={container} sidebar={sidebar}>
       {node && (
         <ParsedDocs
           key={pathname}


### PR DESCRIPTION
Fixes #1442 

You can test the behaviour in storybooks for `API` and `StoplightProject`, since those don't have limited height.

https://user-images.githubusercontent.com/7916523/125603360-6028431a-377c-4fa2-8015-ffd4eb4c8845.mov

Also fixes an additional problem - when loading a page ToC tries to scroll to the active element in the table of contents.

This is great when ToC has its own scroll, but bad when it doesn't - then the whole webpage is being scrolled to seemingly random places.

