### PR TITLE
chore: ci jest test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
       - run: yarn type-check
       - run: yarn lint
       - run: yarn test.prod
+      - store_test_results:
+          name: Upload test results
+          path: test-results
   build:
     working_directory: /mnt/ramdisk/project
     docker:
@@ -87,7 +90,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: | 
+          command: |
             git checkout main
             export BRANCH_NAME=feat/lockfile-maintenance-ci-job-$(date +"%m-%d-%Y") && git checkout -b $BRANCH_NAME
             yarn upgrade
@@ -147,7 +150,7 @@ workflows:
             - e2e-angular
           filters:
             branches:
-              only: 
+              only:
                 - main
   perform-lockfile-maintenance:
     triggers:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 packages/*/coverage
 cypress/results
 cypress/fixtures
+test-results
 
 # production
 build

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "jest": "^26.6.3",
     "jest-environment-jsdom": "^26.3.1",
+    "jest-junit": "12.2.0",
     "lerna": "^3.22.1",
     "prettier": "^2.0.5",
     "start-server-and-test": "^1.11.6",

--- a/packages/elements-core/jest.config.js
+++ b/packages/elements-core/jest.config.js
@@ -1,1 +1,10 @@
-module.exports = require('../../jest.config');
+module.exports = {
+  ...require('../../jest.config'),
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      { suiteName: 'elements-core', outputFile: '<rootDir>/../../test-results/elements-core/results.xml' },
+    ],
+  ],
+};

--- a/packages/elements-dev-portal/jest.config.js
+++ b/packages/elements-dev-portal/jest.config.js
@@ -1,1 +1,10 @@
-module.exports = require('../../jest.config');
+module.exports = {
+  ...require('../../jest.config'),
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      { suiteName: 'elements-dev-portal', outputFile: '<rootDir>/../../test-results/elements-dev-portal/results.xml' },
+    ],
+  ],
+};

--- a/packages/elements/jest.config.js
+++ b/packages/elements/jest.config.js
@@ -1,1 +1,7 @@
-module.exports = require('../../jest.config');
+module.exports = {
+  ...require('../../jest.config'),
+  reporters: [
+    'default',
+    ['jest-junit', { suiteName: 'elements', outputFile: '<rootDir>/../../test-results/elements/results.xml' }],
+  ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -14128,6 +14128,16 @@ jest-jasmine2@^26.6.3:
     pretty-format "^26.6.2"
     throat "^5.0.0"
 
+jest-junit@12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-12.2.0.tgz#cff7f9516e84f8e30f6bdea04cd84db6b095a376"
+  integrity sha512-ecGzF3KEQwLbMP5xMO7wqmgmyZlY/5yWDvgE/vFa+/uIT0KsU5nluf0D2fjIlOKB+tb6DiuSSpZuGpsmwbf7Fw==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^5.2.0"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-leak-detector@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz#7717cf118b92238f2eba65054c8a0c9c653a91af"
@@ -22863,7 +22873,7 @@ uuid@3.4.0, uuid@^3.0.1, uuid@^3.3.2, uuid@^3.3.3, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -23546,6 +23556,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Fixes: https://github.com/stoplightio/elements/issues/1301

Produces jest test result files and uploads them to CircleCI.
Cypress ones are already there.

<img width="704" alt="Screenshot 2021-07-16 at 23 11 48" src="https://user-images.githubusercontent.com/14196079/126008983-a411b70d-3125-42ab-b600-d9e793f66e00.png">
