### PR TITLE
chore: create ES module build

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "yarn build.react",
     "postbuild": "yarn build.styles",
-    "build.react": "sl-scripts build",
+    "build.react": "sl-scripts bundle",
     "build.styles": "node ../../scripts/build-styles.js",
     "build.docs": "build-storybook -c .storybook -o dist-storybook",
     "commit": "git-cz",
@@ -78,7 +78,7 @@
     "util": "^0.12.4"
   },
   "devDependencies": {
-    "@stoplight/scripts": "8.2.3",
+    "@stoplight/scripts": "9.1.0",
     "@storybook/addon-docs": "^6.2.8",
     "@storybook/addon-essentials": "^6.2.8",
     "@storybook/react": "^6.2.8",

--- a/packages/elements-core/src/hooks/useComputeMarkdownHeadings.ts
+++ b/packages/elements-core/src/hooks/useComputeMarkdownHeadings.ts
@@ -1,20 +1,19 @@
 import { MDAST } from '@stoplight/markdown';
 import * as React from 'react';
 import { Parent } from 'unist';
+import { selectAll } from 'unist-util-select';
 
 import { IArticleHeading } from '../types';
-
-const selectAll = require('unist-util-select').selectAll;
 
 export function useComputeMarkdownHeadings(tree: MDAST.Root) {
   return React.useMemo(() => computeMarkdownHeadings(tree), [tree]);
 }
 
 export function computeMarkdownHeadings(tree: MDAST.Root): IArticleHeading[] {
-  return selectAll(':root > [type=heading]', tree)
+  return (selectAll(':root > [type=heading]', tree) as MDAST.Heading[])
     .map((heading: MDAST.Heading) => ({
       title: findTitle(heading),
-      id: heading.data && (heading.data.id as string | undefined),
+      id: (heading.data?.id as string | undefined) || '',
       depth: heading.depth - 1,
     }))
     .filter((item: IArticleHeading) => item.depth >= 1 && item.depth <= 2);

--- a/packages/elements-core/tsconfig.build.json
+++ b/packages/elements-core/tsconfig.build.json
@@ -9,7 +9,6 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "dist",
-    "moduleResolution": "node",
-    "module": "commonjs"
+    "moduleResolution": "node"
   }
 }

--- a/packages/elements-core/tsconfig.json
+++ b/packages/elements-core/tsconfig.json
@@ -3,9 +3,5 @@
 
   "include": ["src"],
 
-  "exclude": ["**/__fixtures__/**", "**/__stories__/**", "**/__tests__/**"],
-
-  "compilerOptions": {
-    "module": "commonjs"
-  }
+  "exclude": ["**/__fixtures__/**", "**/__stories__/**", "**/__tests__/**"]
 }

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "yarn version.set && concurrently \"yarn:build.react\" \"yarn:build.webcomponents\"",
     "postbuild": "yarn build.styles",
-    "build.react": "sl-scripts build",
+    "build.react": "sl-scripts bundle",
     "build.webcomponents": "webpack -c ./web-components.config.js",
     "build.docs": "build-storybook -c .storybook -o dist-storybook",
     "build.styles": "node ../../scripts/build-styles.js elements-dev-portal",
@@ -59,7 +59,7 @@
     "use-debounce": "^6.0.1"
   },
   "devDependencies": {
-    "@stoplight/scripts": "8.2.3",
+    "@stoplight/scripts": "9.1.0",
     "@storybook/addon-docs": "^6.2.8",
     "@storybook/addon-essentials": "^6.2.8",
     "@storybook/react": "^6.2.8",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -90,5 +90,8 @@
   },
   "release": {
     "extends": "@stoplight/scripts/release"
+  },
+  "exports": {
+    "./styles.min.css": "./styles.min.css"
   }
 }

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.0.6';
+export const appVersion = '1.0.8';

--- a/packages/elements-dev-portal/tsconfig.build.json
+++ b/packages/elements-dev-portal/tsconfig.build.json
@@ -10,7 +10,6 @@
     "baseUrl": "./",
     "outDir": "dist",
     "moduleResolution": "node",
-    "module": "commonjs",
     "paths": {
       "@stoplight/elements-core": ["../elements-core/dist"],
       "@stoplight/elements-core/*": ["../elements-core/dist/*"]

--- a/packages/elements-dev-portal/tsconfig.json
+++ b/packages/elements-dev-portal/tsconfig.json
@@ -3,9 +3,5 @@
 
   "include": ["src"],
 
-  "exclude": ["**/__fixtures__/**", "**/__stories__/**", "**/__tests__/**"],
-
-  "compilerOptions": {
-    "module": "commonjs"
-  }
+  "exclude": ["**/__fixtures__/**", "**/__stories__/**", "**/__tests__/**"]
 }

--- a/packages/elements-utils/package.json
+++ b/packages/elements-utils/package.json
@@ -17,7 +17,7 @@
     "node": ">=12"
   },
   "scripts": {
-    "build": "sl-scripts build",
+    "build": "sl-scripts bundle",
     "test": "jest",
     "test.prod": "yarn test --coverage --maxWorkers=2",
     "type-check": "tsc --noEmit"
@@ -26,7 +26,7 @@
     "lodash": "^4.17.19"
   },
   "devDependencies": {
-    "@stoplight/scripts": "8.2.3",
+    "@stoplight/scripts": "9.1.0",
     "@stoplight/types": "^12.0.0"
   }
 }

--- a/packages/elements-utils/tsconfig.build.json
+++ b/packages/elements-utils/tsconfig.build.json
@@ -8,7 +8,6 @@
   ],
   "compilerOptions": {
     "outDir": "dist",
-    "moduleResolution": "node",
-    "module": "commonjs"
+    "moduleResolution": "node"
   }
 }

--- a/packages/elements-utils/tsconfig.json
+++ b/packages/elements-utils/tsconfig.json
@@ -3,9 +3,5 @@
 
   "include": ["src"],
 
-  "exclude": ["**/__fixtures__/**", "**/__stories__/**", "**/__tests__/**"],
-
-  "compilerOptions": {
-    "module": "commonjs",
-  }
+  "exclude": ["**/__fixtures__/**", "**/__stories__/**", "**/__tests__/**"]
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "concurrently \"yarn:build.react\" \"yarn:build.webcomponents\"",
     "postbuild": "yarn build.styles",
-    "build.react": "sl-scripts build",
+    "build.react": "sl-scripts bundle",
     "build.styles": "node ../../scripts/build-styles.js elements",
     "build.webcomponents": "webpack -c ./web-components.config.js",
     "build.docs": "build-storybook -c .storybook -o dist-storybook",
@@ -59,7 +59,7 @@
     "react-router-dom": "^5.2.0"
   },
   "devDependencies": {
-    "@stoplight/scripts": "8.2.3",
+    "@stoplight/scripts": "9.1.0",
     "@storybook/addon-docs": "^6.2.8",
     "@storybook/addon-essentials": "^6.2.8",
     "@storybook/react": "^6.2.8",
@@ -96,5 +96,8 @@
   },
   "release": {
     "extends": "@stoplight/scripts/release"
+  },
+  "exports": {
+    "./styles.min.css": "./styles.min.css"
   }
 }

--- a/packages/elements/tsconfig.build.json
+++ b/packages/elements/tsconfig.build.json
@@ -10,7 +10,6 @@
     "baseUrl": "./",
     "outDir": "dist",
     "moduleResolution": "node",
-    "module": "commonjs",
     "paths": {
       "@stoplight/elements-core": ["../elements-core/dist"],
       "@stoplight/elements-core/*": ["../elements-core/dist/*"],

--- a/packages/elements/tsconfig.json
+++ b/packages/elements/tsconfig.json
@@ -3,9 +3,5 @@
 
   "include": ["src"],
 
-  "exclude": ["**/__fixtures__/**", "**/__stories__/**", "**/__tests__/**"],
-
-  "compilerOptions": {
-    "module": "commonjs"
-  }
+  "exclude": ["**/__fixtures__/**", "**/__stories__/**", "**/__tests__/**"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3787,21 +3787,41 @@
     "@react-types/overlays" "^3.4.0"
     "@react-types/shared" "^3.4.0"
 
-"@rollup/plugin-typescript@^3.0.0":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-3.1.1.tgz#a39175a552ed82a3e424862e6bb403bf9da451ee"
-  integrity sha512-VPY1MbzIJT+obpav9Kns4MlipVJ1FuefwzO4s1uCVXAzVWya+bhhNauOmmqR/hy1zj7tePfh3t9iBN+HbIzyRA==
+"@rollup/plugin-commonjs@^19.0.0":
+  version "19.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-19.0.1.tgz#94a2c103d675523d3ab1c60bfbec567b3eb70410"
+  integrity sha512-bRrPTIAsWw2LmEspEMvV9f+7N7CEQgZCj2Zi1F0e0P3+/tbjQaSNNVVRSRWVhuDagp8yjK5kbIut8KTPsseRhg==
   dependencies:
-    "@rollup/pluginutils" "^3.0.1"
-    resolve "^1.14.1"
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
 
-"@rollup/pluginutils@^3.0.1":
+"@rollup/plugin-json@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
   dependencies:
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
+"@rollup/pluginutils@^4.1.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.1.1.tgz#1d4da86dd4eded15656a57d933fda2b9a08d47ec"
+  integrity sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==
+  dependencies:
+    estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
 "@samverschueren/stream-to-observable@^0.3.0":
@@ -4325,17 +4345,18 @@
   dependencies:
     "@stoplight/types" "^11.9.0"
 
-"@stoplight/scripts@8.2.3":
-  version "8.2.3"
-  resolved "https://registry.yarnpkg.com/@stoplight/scripts/-/scripts-8.2.3.tgz#641191ff47b74109ca275bdfe77468f2a06d3a37"
-  integrity sha512-v0hh+e7PqdNuMLc9fv4rBKvtaLYU2Lva/Mmd7HZ9joSrczEfVcowM4BNDGrkbfIeA74mbWIFebi0+dJ9asYzrg==
+"@stoplight/scripts@9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/scripts/-/scripts-9.1.0.tgz#6b2c059fe150bcd34a055d870c4746057b48dad2"
+  integrity sha512-IKVHv8JJUb/oPveuv7DEiDDfii+3GOzQIoWPMwQz18NaVyLPp9v+jHSkAAa8euDiwtXeiJw2MdPQRXIsVbJJOg==
   dependencies:
     "@commitlint/cli" "8.3.5"
     "@commitlint/config-conventional" "8.3.4"
     "@oclif/command" "1.5.19"
     "@oclif/config" "1.14.0"
     "@oclif/plugin-help" "2.2.3"
-    "@rollup/plugin-typescript" "^3.0.0"
+    "@rollup/plugin-commonjs" "^19.0.0"
+    "@rollup/plugin-json" "^4.1.0"
     "@semantic-release/commit-analyzer" "8.0.1"
     "@semantic-release/git" "9.0.0"
     "@semantic-release/github" "7.0.3"
@@ -4350,11 +4371,12 @@
     inquirer "7.0.4"
     lint-staged "10.0.7"
     rimraf "3.0.2"
-    rollup "^1.31.1"
-    rollup-plugin-terser "^5.2.0"
+    rollup "^2.47.0"
+    rollup-plugin-terser "^7.0.2"
+    rollup-plugin-typescript2 "^0.30.0"
     semantic-release "17.0.3"
     shelljs "0.8.x"
-    tslib "1.10.0"
+    tslib "^2.2.0"
 
 "@stoplight/types@^11.9.0":
   version "11.10.0"
@@ -6047,7 +6069,7 @@ acorn@^6.0.1, acorn@^6.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0, acorn@^7.4.1:
+acorn@^7.1.1, acorn@^7.4.0, acorn@^7.4.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
@@ -10481,15 +10503,15 @@ estree-to-babel@^3.1.0:
     "@babel/types" "^7.2.0"
     c8 "^7.6.0"
 
-estree-walker@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
-  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
-
 estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -13631,6 +13653,13 @@ is-redirect@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
+
 is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.2, is-regex@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.3.tgz#d029f9aff6448b93ebbe3f33dac71511fdcbef9f"
@@ -14395,7 +14424,7 @@ jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
-jest-worker@^26.5.0, jest-worker@^26.6.2:
+jest-worker@^26.2.1, jest-worker@^26.5.0, jest-worker@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
   integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
@@ -15657,6 +15686,13 @@ magic-error@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/magic-error/-/magic-error-0.0.1.tgz#95ebe658ca4a86f1aebda390cab6ea50d41bfa2a"
   integrity sha512-1+N1ET8cbC5bfLQZcRojClzgK2gbUt9keTMr9OJeuXnQKWsfwRRRICuMA3HKaCIXFEgKzxivuMGCNKD7cdU5pg==
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 make-dir@^1.0.0, make-dir@^1.2.0:
   version "1.3.0"
@@ -20049,7 +20085,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.1, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.9.0:
+resolve@1.20.0, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -20161,32 +20197,33 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-terser@^5.2.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz#8c650062c22a8426c64268548957463bf981b413"
-  integrity sha512-1pkwkervMJQGFYvM9nscrUoncPwiKR/K+bHdjv6PFgRo3cgPHoRT83y2Aa3GvINj4539S15t/tpFPb775TDs6w==
+rollup-plugin-terser@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
+  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
   dependencies:
-    "@babel/code-frame" "^7.5.5"
-    jest-worker "^24.9.0"
-    rollup-pluginutils "^2.8.2"
+    "@babel/code-frame" "^7.10.4"
+    jest-worker "^26.2.1"
     serialize-javascript "^4.0.0"
-    terser "^4.6.2"
+    terser "^5.0.0"
 
-rollup-pluginutils@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
-  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
+rollup-plugin-typescript2@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz#1cc99ac2309bf4b9d0a3ebdbc2002aecd56083d3"
+  integrity sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==
   dependencies:
-    estree-walker "^0.6.1"
+    "@rollup/pluginutils" "^4.1.0"
+    find-cache-dir "^3.3.1"
+    fs-extra "8.1.0"
+    resolve "1.20.0"
+    tslib "2.1.0"
 
-rollup@^1.31.1:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
+rollup@^2.47.0:
+  version "2.53.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.53.2.tgz#3279f9bfba1fe446585560802e418c5fbcaefa51"
+  integrity sha512-1CtEYuS5CRCzFZ7SNW5528SlDlk4VDXIRGwbm/2POQxA/G4+7/crIqJwkmnj8Q/74hGx4oVlNvh4E1CJQ5hZ6w==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 rst-selector-parser@^2.2.3:
   version "2.2.3"
@@ -20933,6 +20970,11 @@ source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 space-separated-tokens@^1.0.0:
   version "1.1.5"
@@ -21808,7 +21850,7 @@ terser-webpack-plugin@^4.2.3:
     terser "^5.3.4"
     webpack-sources "^1.4.3"
 
-terser@^4.1.2, terser@^4.6.2, terser@^4.6.3:
+terser@^4.1.2, terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
   integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
@@ -21817,7 +21859,7 @@ terser@^4.1.2, terser@^4.6.2, terser@^4.6.3:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.3.4:
+terser@^5.0.0, terser@^5.3.4:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.7.1.tgz#2dc7a61009b66bb638305cb2a824763b116bf784"
   integrity sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==
@@ -22193,10 +22235,10 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+tslib@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"


### PR DESCRIPTION
Fixes: https://github.com/stoplightio/elements/issues/1392

Builds ES module along with CJS using sl-scripts bundling. 
Adds `styles.min.css` to exports to include it in the encapsulated bundle.

Tested with examples and platform (requires replacing deep imports for elements-core).