### PR TITLE
fix: Query param description have larger fontsize than expected

### DIFF
--- a/packages/elements-core/src/styles/_HttpOperation.scss
+++ b/packages/elements-core/src/styles/_HttpOperation.scss
@@ -1,17 +1,17 @@
-.HttpOperation .JsonSchemaViewer .MarkdownViewer p {
+.HttpOperation .JsonSchemaViewer .sl-markdown-viewer p {
   font-size: 12px;
   line-height: 1.5em;
 }
 
 .HttpOperation__Parameters {
-  .MarkdownViewer p {
+  .sl-markdown-viewer p {
     font-size: 12px;
     line-height: 1.5em;
   }
 }
 
 .Model { .JsonSchemaViewer {
-  .MarkdownViewer p {
+  .sl-markdown-viewer p {
     font-size: 12px;
     line-height: 1.5em;
   }


### PR DESCRIPTION
Resolves: #1614

One of the recent MarkdownViewer releases changed the `.MarkdownViewer` class to `.sl-markdown-viewer`. We use this classes for styling, and this PR addresses the change

**Before**
![image](https://user-images.githubusercontent.com/58433203/126496506-b72d5413-e6ff-4a6c-8893-91ca277211aa.png)

**After**
<img width="948" alt="Screen Shot 2021-07-21 at 3 28 20 PM" src="https://user-images.githubusercontent.com/58433203/126496552-964b78b1-cbea-4502-b1c9-377ddd194004.png">
