### PR TITLE
fix: add missing exports

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.1.8",
+  "version": "7.1.9",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**"

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/Provider.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/Provider.tsx
@@ -1,8 +1,10 @@
-import { CustomComponentMapping } from '@stoplight/markdown-viewer';
+import { CustomComponentMapping as MDVCustomComponentMapping } from '@stoplight/markdown-viewer';
 import { defaults } from 'lodash';
 import * as React from 'react';
 
 import { CodeComponent } from './CodeComponent';
+
+export type CustomComponentMapping = MDVCustomComponentMapping;
 
 const MarkdownComponentsContext = React.createContext<CustomComponentMapping | undefined>(undefined);
 MarkdownComponentsContext.displayName = 'MarkdownComponentsContext';

--- a/packages/elements-core/src/index.ts
+++ b/packages/elements-core/src/index.ts
@@ -5,7 +5,12 @@ export { SidebarLayout } from './components/Layout/SidebarLayout';
 export { Logo } from './components/Logo';
 export { MarkdownComponentsProvider } from './components/MarkdownViewer/CustomComponents/Provider';
 export { TableOfContents } from './components/MosaicTableOfContents';
-export { CustomLinkComponent, TableOfContentsItem } from './components/MosaicTableOfContents/types';
+export {
+  CustomLinkComponent,
+  TableOfContentsItem,
+  TableOfContentsNode,
+  TableOfContentsNodeGroup,
+} from './components/MosaicTableOfContents/types';
 export { findFirstNode } from './components/MosaicTableOfContents/utils';
 export { NonIdealState } from './components/NonIdealState';
 export { PoweredByLink } from './components/PoweredByLink';
@@ -22,7 +27,7 @@ export { useParsedData } from './hooks/useParsedData';
 export { useParsedValue } from './hooks/useParsedValue';
 export { useRouter } from './hooks/useRouter';
 export { Styled, withStyles } from './styled';
-export { Divider, Group, ITableOfContentsTree, Item, RoutingProps, TableOfContentItem } from './types';
+export { Divider, Group, ITableOfContentsTree, Item, ParsedNode, RoutingProps, TableOfContentItem } from './types';
 export { isHttpOperation, isHttpService } from './utils/guards';
 export { ReferenceResolver } from './utils/ref-resolving/ReferenceResolver';
 export { createResolvedObject } from './utils/ref-resolving/resolvedObject';

--- a/packages/elements-core/src/index.ts
+++ b/packages/elements-core/src/index.ts
@@ -3,7 +3,10 @@ export { Docs, ParsedDocs } from './components/Docs';
 export { DeprecatedBadge } from './components/Docs/HttpOperation/Badges';
 export { SidebarLayout } from './components/Layout/SidebarLayout';
 export { Logo } from './components/Logo';
-export { MarkdownComponentsProvider } from './components/MarkdownViewer/CustomComponents/Provider';
+export {
+  CustomComponentMapping,
+  MarkdownComponentsProvider,
+} from './components/MarkdownViewer/CustomComponents/Provider';
 export { TableOfContents } from './components/MosaicTableOfContents';
 export {
   CustomLinkComponent,


### PR DESCRIPTION
Needed for https://github.com/stoplightio/platform-internal/issues/7072

Adds elements-core missing exports that are used in platform