### PR TITLE
feat: export DefaultSMDComponents

### DIFF
--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
@@ -1,6 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
-import { CustomComponentMapping, DefaultSMDComponents } from '@stoplight/markdown-viewer';
 import { Box, Flex } from '@stoplight/mosaic';
 import { HttpParamStyles, IHttpOperation, IHttpRequest, NodeType } from '@stoplight/types';
 import { isObject } from 'lodash';
@@ -14,6 +13,7 @@ import { JSONSchema } from '../../../types';
 import { isHttpOperation, isJSONSchema } from '../../../utils/guards';
 import { getOriginalObject } from '../../../utils/ref-resolving/resolvedObject';
 import { TryIt } from '../../TryIt';
+import { CustomComponentMapping, DefaultSMDComponents } from './Provider';
 
 type PartialHttpRequest = Pick<IHttpRequest, 'method' | 'url'> & Partial<IHttpRequest>;
 

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/Provider.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/Provider.tsx
@@ -1,10 +1,12 @@
-import { CustomComponentMapping as MDVCustomComponentMapping } from '@stoplight/markdown-viewer';
+import { CustomComponentMapping as MDVCustomComponentMapping, DefaultSMDComponents } from '@stoplight/markdown-viewer';
 import { defaults } from 'lodash';
 import * as React from 'react';
 
 import { CodeComponent } from './CodeComponent';
 
 export type CustomComponentMapping = MDVCustomComponentMapping;
+
+export { DefaultSMDComponents };
 
 const MarkdownComponentsContext = React.createContext<CustomComponentMapping | undefined>(undefined);
 MarkdownComponentsContext.displayName = 'MarkdownComponentsContext';

--- a/packages/elements-core/src/index.ts
+++ b/packages/elements-core/src/index.ts
@@ -5,6 +5,7 @@ export { SidebarLayout } from './components/Layout/SidebarLayout';
 export { Logo } from './components/Logo';
 export {
   CustomComponentMapping,
+  DefaultSMDComponents,
   MarkdownComponentsProvider,
 } from './components/MarkdownViewer/CustomComponents/Provider';
 export { TableOfContents } from './components/MosaicTableOfContents';


### PR DESCRIPTION
~status: currently yalcing it into a platform-internal branch to confirm it works as expected~

~fuck it, the dependency graph in platform-internal is just too dang complicated to get yalcing it to work with yarn resolutions AFAICT:~
![image](https://user-images.githubusercontent.com/587740/126682340-7dd602a3-a8ac-46bc-8c24-cf87cdd11550.png)

~oh oh wait, I might have figured it out. looks like it's called `generateClassicToC` now... testing it out now..~

I give up yalcing. Let's just merge and publish this if it seems like it won't hurt.