### PR TITLE
fix: expand node when child is active

### DIFF
--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -120,7 +120,7 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
           ) : null}
           {tableOfContents ? (
             <TableOfContents
-              activeId={node?.id || ''}
+              activeId={node?.id || nodeSlug?.split('-')[0] || ''}
               tableOfContents={tableOfContents}
               Link={Link}
               collapseTableOfContents={collapseTableOfContents}


### PR DESCRIPTION
Fixes: https://github.com/stoplightio/elements/issues/1524

ToC groups are initialized during the first render when data might not yet be fetched, which causes `activeId` to be undefined and a group collapsed. Using node id from node slug (which we know already) fixes the issue.