### PR TITLE
feat: openapi export

### DIFF
--- a/packages/elements-core/src/components/Docs/Docs.tsx
+++ b/packages/elements-core/src/components/Docs/Docs.tsx
@@ -8,6 +8,7 @@ import { ParsedNode } from '../../types';
 import { Article } from './Article';
 import { HttpOperation } from './HttpOperation';
 import { HttpService } from './HttpService';
+import { ExportButtonProps } from './HttpService/ExportButton';
 import { Model } from './Model';
 
 interface BaseDocsProps {
@@ -35,6 +36,11 @@ interface BaseDocsProps {
    * Allows to use internal routing (requires wrapping with Router component)
    */
   allowRouting?: boolean;
+
+  /**
+   * Export button props
+   */
+  exportProps?: ExportButtonProps;
 
   /**
    * Allows to customize the layout of Docs
@@ -76,6 +82,12 @@ interface BaseDocsProps {
      * @default false
      */
     hideSecurityInfo?: boolean;
+
+    /**
+     * Allows to hide export button
+     * @default false
+     */
+    hideExport?: boolean;
   };
 }
 

--- a/packages/elements-core/src/components/Docs/HttpService/ExportButton.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/ExportButton.tsx
@@ -24,7 +24,7 @@ export const ExportButton: React.FC<ExportButtonProps> = ({ original, bundled })
         aria-label="Export"
         items={menuItems}
         renderTrigger={({ isOpen }) => (
-          <Button iconRight="chevron-down" appearance="primary" ml={2} active={isOpen} size="sm">
+          <Button iconRight="chevron-down" appearance="default" ml={2} active={isOpen} size="sm">
             Export
           </Button>
         )}

--- a/packages/elements-core/src/components/Docs/HttpService/ExportButton.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/ExportButton.tsx
@@ -1,0 +1,34 @@
+import { Box, Button, Menu, MenuActionItem, MenuItems } from '@stoplight/mosaic';
+import * as React from 'react';
+
+type ExportMenuProps = Pick<MenuActionItem, 'href' | 'onPress'>;
+
+export interface ExportButtonProps {
+  original: ExportMenuProps;
+  bundled: ExportMenuProps;
+}
+
+export const ExportButton: React.FC<ExportButtonProps> = ({ original, bundled }) => {
+  const menuItems = React.useMemo(() => {
+    const items: MenuItems = [
+      { id: 'original', title: 'Original', ...original },
+      { id: 'bundled', title: 'Bundled References', ...bundled },
+    ];
+
+    return items;
+  }, [original, bundled]);
+
+  return (
+    <Box>
+      <Menu
+        aria-label="Export"
+        items={menuItems}
+        renderTrigger={({ isOpen }) => (
+          <Button iconRight="chevron-down" appearance="primary" ml={2} active={isOpen} size="sm">
+            Export
+          </Button>
+        )}
+      />
+    </Box>
+  );
+};

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
@@ -281,7 +281,7 @@ describe('HttpService', () => {
       expect(exportButton).not.toBeInTheDocument();
     });
 
-    it('should not render if hno exportProps are present', () => {
+    it('should not render if no exportProps are present', () => {
       const wrapper = render(
         <Router>
           <MosaicProvider>

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
@@ -1,5 +1,6 @@
 import 'jest-enzyme';
 
+import { Provider as MosaicProvider } from '@stoplight/mosaic';
 import {
   IOauth2AuthorizationCodeFlow,
   IOauth2ClientCredentialsFlow,
@@ -239,6 +240,58 @@ describe('HttpService', () => {
         Scopes:
         - \`scope:password\` - password scope description"
       `);
+    });
+  });
+
+  describe('export button', () => {
+    it('should render correctly', () => {
+      const wrapper = render(
+        <Router>
+          <MosaicProvider>
+            <HttpService
+              data={httpService}
+              exportProps={{ original: { onPress: jest.fn() }, bundled: { onPress: jest.fn() } }}
+            />
+          </MosaicProvider>
+        </Router>,
+      );
+
+      const exportButton = wrapper.getByRole('button', { name: 'Export' });
+      expect(exportButton).toBeInTheDocument();
+
+      userEvent.click(exportButton);
+      expect(wrapper.getByRole('menuitem', { name: 'Original' })).toBeInTheDocument();
+      expect(wrapper.getByRole('menuitem', { name: 'Bundled References' })).toBeInTheDocument();
+    });
+
+    it('should not render if hideExport is true', () => {
+      const wrapper = render(
+        <Router>
+          <MosaicProvider>
+            <HttpService
+              data={httpService}
+              exportProps={{ original: { onPress: jest.fn() }, bundled: { onPress: jest.fn() } }}
+              layoutOptions={{ hideExport: true }}
+            />
+          </MosaicProvider>
+        </Router>,
+      );
+
+      const exportButton = wrapper.queryByRole('button', { name: 'Export' });
+      expect(exportButton).not.toBeInTheDocument();
+    });
+
+    it('should not render if hno exportProps are present', () => {
+      const wrapper = render(
+        <Router>
+          <MosaicProvider>
+            <HttpService data={httpService} />
+          </MosaicProvider>
+        </Router>,
+      );
+
+      const exportButton = wrapper.queryByRole('button', { name: 'Export' });
+      expect(exportButton).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, VStack } from '@stoplight/mosaic';
+import { Box, Flex, Heading, VStack } from '@stoplight/mosaic';
 import { withErrorBoundary } from '@stoplight/react-error-boundary';
 import { IHttpService } from '@stoplight/types';
 import cn from 'classnames';
@@ -10,64 +10,75 @@ import { PoweredByLink } from '../../PoweredByLink';
 import { DocsComponentProps } from '..';
 import { VersionBadge } from '../HttpOperation/Badges';
 import { TwoColumnLayout } from '../TwoColumnLayout';
+import { ExportButton } from './ExportButton';
 import { SecuritySchemes } from './SecuritySchemes';
 import { ServerInfo } from './ServerInfo';
 
 export type HttpServiceProps = DocsComponentProps<Partial<IHttpService>>;
 
-const HttpServiceComponent = React.memo<HttpServiceProps>(({ className, data, location = {}, layoutOptions }) => {
-  const { search, pathname } = location;
-  const mocking = React.useContext(MockingContext);
-  const query = new URLSearchParams(search);
+const HttpServiceComponent = React.memo<HttpServiceProps>(
+  ({ className, data, location = {}, layoutOptions, exportProps }) => {
+    const { search, pathname } = location;
+    const mocking = React.useContext(MockingContext);
+    const query = new URLSearchParams(search);
 
-  const shouldDisplayHeader = data.name && !layoutOptions?.noHeading;
+    const shouldDisplayHeader = data.name && !layoutOptions?.noHeading;
 
-  const header = (shouldDisplayHeader || data.version) && (
-    <>
-      {shouldDisplayHeader && (
-        <Heading size={1} mb={4} fontWeight="semibold">
-          {data.name}
-        </Heading>
-      )}
-
-      {data.version && (
-        <Box mb={5}>
-          <VersionBadge value={data.version} />
-        </Box>
-      )}
-    </>
-  );
-
-  const description = data.description && <MarkdownViewer className="sl-mb-5" markdown={data.description} />;
-
-  const dataPanel = (
-    <VStack spacing={6}>
-      <ServerInfo servers={data.servers ?? []} mockUrl={mocking.mockUrl} />
-      <Box>
-        {data.securitySchemes?.length && (
-          <SecuritySchemes schemes={data.securitySchemes} defaultScheme={query.get('security') || undefined} />
+    const header = (shouldDisplayHeader || data.version) && (
+      <>
+        {shouldDisplayHeader && (
+          <Flex justifyContent="between" alignItems="center">
+            <Heading size={1} mb={4} fontWeight="semibold">
+              {data.name}
+            </Heading>
+            {exportProps && !layoutOptions?.hideExport && <ExportButton {...exportProps} />}
+          </Flex>
         )}
-      </Box>
-    </VStack>
-  );
 
-  if (layoutOptions?.showPoweredByLink) {
-    return (
-      <Box mb={10}>
-        {header}
-        {description}
-        {pathname && (
-          <PoweredByLink source={data.name ?? 'no-title'} pathname={pathname} packageType="elements" layout="stacked" />
+        {data.version && (
+          <Box mb={5}>
+            <VersionBadge value={data.version} />
+          </Box>
         )}
-        {dataPanel}
-      </Box>
+      </>
     );
-  }
 
-  return (
-    <TwoColumnLayout className={cn('HttpService', className)} header={header} left={description} right={dataPanel} />
-  );
-});
+    const description = data.description && <MarkdownViewer className="sl-mb-5" markdown={data.description} />;
+
+    const dataPanel = (
+      <VStack spacing={6}>
+        <ServerInfo servers={data.servers ?? []} mockUrl={mocking.mockUrl} />
+        <Box>
+          {data.securitySchemes?.length && (
+            <SecuritySchemes schemes={data.securitySchemes} defaultScheme={query.get('security') || undefined} />
+          )}
+        </Box>
+      </VStack>
+    );
+
+    if (layoutOptions?.showPoweredByLink) {
+      return (
+        <Box mb={10}>
+          {header}
+          {description}
+          {pathname && (
+            <PoweredByLink
+              source={data.name ?? 'no-title'}
+              pathname={pathname}
+              packageType="elements"
+              layout="stacked"
+            />
+          )}
+          {dataPanel}
+        </Box>
+      );
+    }
+
+    return (
+      <TwoColumnLayout className={cn('HttpService', className)} header={header} left={description} right={dataPanel} />
+    );
+  },
+);
 HttpServiceComponent.displayName = 'HttpService.Component';
 
 export const HttpService = withErrorBoundary<HttpServiceProps>(HttpServiceComponent, { recoverableProps: ['data'] });

--- a/packages/elements-core/src/index.ts
+++ b/packages/elements-core/src/index.ts
@@ -1,5 +1,6 @@
 export { Docs, ParsedDocs } from './components/Docs';
 export { DeprecatedBadge } from './components/Docs/HttpOperation/Badges';
+export { ExportButton, ExportButtonProps } from './components/Docs/HttpService/ExportButton';
 export { SidebarLayout } from './components/Layout/SidebarLayout';
 export { Logo } from './components/Logo';
 export {

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -1,6 +1,7 @@
 import {
   CustomLinkComponent,
   Docs,
+  ExportButtonProps,
   MarkdownComponentsProvider,
   MockingProvider,
   PersistenceContextProvider,
@@ -30,9 +31,15 @@ export type NodeContentProps = {
    * Allows to hide mocking button
    */
   hideMocking?: boolean;
+
+  /**
+   * Allows to hide export button
+   * @default false
+   */
+  hideExport?: boolean;
 };
 
-export const NodeContent = ({ node, Link, hideTryIt, hideTryItPanel, hideMocking }: NodeContentProps) => {
+export const NodeContent = ({ node, Link, hideTryIt, hideTryItPanel, hideMocking, hideExport }: NodeContentProps) => {
   return (
     <PersistenceContextProvider>
       <NodeLinkContext.Provider value={[node, Link]}>
@@ -42,8 +49,20 @@ export const NodeContent = ({ node, Link, hideTryIt, hideTryItPanel, hideMocking
               nodeType={node.type as NodeType}
               nodeData={node.data}
               nodeTitle={node.title}
-              layoutOptions={{ hideTryIt: hideTryIt, hideTryItPanel: hideTryItPanel }}
+              layoutOptions={{
+                hideTryIt: hideTryIt,
+                hideTryItPanel: hideTryItPanel,
+                hideExport: hideExport || node.links.export_url === undefined,
+              }}
               useNodeForRefResolving
+              exportProps={{
+                original: {
+                  href: node.links.export_url,
+                },
+                bundled: {
+                  href: `${node.links.export_url}?deref=optimizedBundle`,
+                },
+              }}
             />
           </MockingProvider>
         </MarkdownComponentsProvider>

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -54,14 +54,18 @@ export const NodeContent = ({ node, Link, hideTryIt, hideTryItPanel, hideMocking
                 hideExport: hideExport || node.links.export_url === undefined,
               }}
               useNodeForRefResolving
-              exportProps={{
-                original: {
-                  href: node.links.export_url,
-                },
-                bundled: {
-                  href: `${node.links.export_url}?deref=optimizedBundle`,
-                },
-              }}
+              exportProps={
+                node.type === NodeType.HttpService
+                  ? {
+                      original: {
+                        href: node.links.export_url,
+                      },
+                      bundled: {
+                        href: getBundledUrl(node.links.export_url),
+                      },
+                    }
+                  : undefined
+              }
             />
           </MockingProvider>
         </MarkdownComponentsProvider>
@@ -107,3 +111,12 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
 
   return <a href={href}>{children}</a>;
 };
+
+function getBundledUrl(url: string | undefined) {
+  if (url === undefined) return undefined;
+  const bundledUrl = new URL(url);
+  const searchParams = new URLSearchParams(bundledUrl.search);
+  searchParams.append('deref', 'optimizedBundle');
+  bundledUrl.search = searchParams.toString();
+  return bundledUrl.toString();
+}

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -1,7 +1,6 @@
 import {
   CustomLinkComponent,
   Docs,
-  ExportButtonProps,
   MarkdownComponentsProvider,
   MockingProvider,
   PersistenceContextProvider,

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -47,6 +47,12 @@ export interface StoplightProjectProps extends RoutingProps {
   hideMocking?: boolean;
 
   /**
+   * Allows to hide export button
+   * @default false
+   */
+  hideExport?: boolean;
+
+  /**
    * If set to true, all table of contents panels will be collapsed.
    * @default false
    */
@@ -57,6 +63,7 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
   projectId,
   hideTryIt,
   hideMocking,
+  hideExport,
   collapseTableOfContents = false,
 }) => {
   const { branchSlug = '', nodeSlug = '' } = useParams<{ branchSlug?: string; nodeSlug: string }>();
@@ -95,7 +102,9 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
   } else if (!node) {
     elem = <NotFound />;
   } else {
-    elem = <NodeContent node={node} Link={Link} hideTryIt={hideTryIt} hideMocking={hideMocking} />;
+    elem = (
+      <NodeContent node={node} Link={Link} hideTryIt={hideTryIt} hideMocking={hideMocking} hideExport={hideExport} />
+    );
   }
 
   const handleTocClick = () => {

--- a/packages/elements-dev-portal/src/web-components/components.ts
+++ b/packages/elements-dev-portal/src/web-components/components.ts
@@ -6,6 +6,7 @@ export const StoplightProjectElement = createElementClass(StoplightProject, {
   projectId: { type: 'string', defaultValue: '' },
   hideTryIt: { type: 'boolean' },
   hideMocking: { type: 'boolean' },
+  hideExport: { type: 'boolean' },
   basePath: { type: 'string' },
   router: { type: 'string' },
   platformUrl: { type: 'string' },

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -55,6 +55,7 @@
     "@stoplight/mosaic": "^1",
     "@stoplight/types": "^12.0.0",
     "classnames": "^2.2.6",
+    "file-saver": "^2.0.5",
     "lodash": "^4.17.19",
     "react-query": "^3.15.2",
     "react-router-dom": "^5.2.0"
@@ -68,6 +69,7 @@
     "@testing-library/user-event": "^12.2.0",
     "@types/enzyme": "3.x.x",
     "@types/enzyme-adapter-react-16": "1.x.x",
+    "@types/file-saver": "^2.0.3",
     "@types/json-schema": "^7.0.0",
     "@types/lodash": "^4.14.149",
     "@types/react": "16.9.56",

--- a/packages/elements/src/__fixtures__/api-descriptions/todosApiBundled.ts
+++ b/packages/elements/src/__fixtures__/api-descriptions/todosApiBundled.ts
@@ -1,0 +1,430 @@
+export const todosApiBundled = `
+openapi: 3.0.0
+info:
+  title: To-dos
+  version: 1.0.0
+  description: "![](https://i.ibb.co/v3Yt03v/todo-api-background.png)\n\n## \U0001F4AB Overview\n\nTo Do API provides a simple way for people to manage their tasks and plan their day. This API can be used to create mobile and web applications.This API is documented using **OpenAPI 3.0**. The implementation lives in this [GitHub repo](https://github.com/stoplightio/studio-demo/blob/master/reference/todos/todo.v1.yaml).\n\n### \U0001F9F0 Cross-Origin Resource Sharing\nThis API features Cross-Origin Resource Sharing (CORS) implemented in compliance with  [W3C spec](https://www.w3.org/TR/cors/). CORS support is necessary to make calls from the request maker within the API docs.\n\n### \U0001F3C1 Trying out your own API Specification\nElements can be used to generate API docs for any OpenAPI document. Replace this OpenAPI with a URL to your own OpenAPI document to get started. "
+  contact:
+    name: Stoplight Support
+    email: support@stoplight.io
+    url: 'https://www.stoplight.io'
+  license:
+    name: MIT
+    url: 'https://spdx.org/licenses/MIT'
+  termsOfService: 'https://stoplight.io/terms/'
+servers:
+  - url: 'https://todos.stoplight.io'
+    description: Production
+  - description: Sandbox
+    url: 'https://todos-sandbox.stoplight.io'
+paths:
+  /todos:
+    get:
+      summary: List Todos
+      responses:
+        '200':
+          description: Returns a list of Todos
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Todos'
+              examples:
+                List of Todos:
+                  $ref: '#/components/examples/multiple-todos'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      operationId: get-todos
+      description: >-
+        Returns a list of todos
+
+
+        *Markdown is supported in descriptions. Add information here for users
+        to get accustomed to endpoints*
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/contentType'
+      security: []
+    post:
+      summary: Create Todo
+      operationId: post-todos
+      responses:
+        '201':
+          description: New Todo Created
+          content:
+            multipart/form-data:
+              schema:
+                $ref: '#/components/schemas/Todos'
+              examples:
+                Example Todo:
+                  $ref: '#/components/examples/todo'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      description: >-
+        This creates a Todo object
+
+
+        *Markdown is supported in descriptions. Add information here for users
+        to get accustomed to endpoints*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Todos'
+        description: Name of the Todo
+      parameters:
+        - $ref: '#/components/parameters/contentType'
+      security:
+        - API Key: []
+  '/todos/{id}':
+    get:
+      summary: Get Todo
+      responses:
+        '200':
+          description: Returns the Todo for the ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Todos'
+              examples:
+                Example Todo:
+                  $ref: '#/components/examples/todo'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      operationId: get-todos-id
+      description: >-
+        Get a single todo using an ID
+
+
+        *Markdown is supported in descriptions. Add information here for users
+        to get accustomed to endpoints*
+      parameters: []
+      security: []
+    put:
+      summary: Replace Todo
+      operationId: put-todos-id
+      responses:
+        '200':
+          description: Todo Updated
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Todos'
+        description: ''
+      description: >-
+        Update a single todo using an ID
+
+
+        *Markdown is supported in descriptions. Add information here for users
+        to get accustomed to endpoints*
+      parameters:
+        - $ref: '#/components/parameters/contentType'
+      security:
+        - API Key: []
+    delete:
+      summary: Delete Todo
+      operationId: delete-todos-id
+      responses:
+        '200':
+          description: Todo Deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Todos'
+              examples:
+                Example Todo:
+                  $ref: '#/components/examples/todo'
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      description: >-
+        Delete a todo using an ID
+
+
+        *Markdown is supported in descriptions. Add information here for users
+        to get accustomed to endpoints*
+      security:
+        - API Key: []
+    patch:
+      summary: Update Todo
+      operationId: patch-todos-id
+      responses:
+        '200':
+          description: Todo Updated
+        '403':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      deprecated: true
+      description: >-
+        Don't use this endpoint. Notice it's deprecated.
+
+
+        *Markdown is supported in descriptions. Add information here for users
+        to get accustomed to endpoints*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Todos'
+      security:
+        - API Key: []
+    parameters:
+      - $ref: '#/components/parameters/ID'
+  /users:
+    get:
+      summary: Get User
+      tags:
+        - Users
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      operationId: get-users
+      description: >-
+        Get a user by ID
+
+
+        *Markdown is supported in descriptions. Add information here for users
+        to get accustomed to endpoints*
+      parameters:
+        - $ref: '#/components/parameters/contentType'
+      security: []
+    parameters: []
+    delete:
+      summary: Delete User
+      operationId: delete-users-userID
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+      description: Delete a user by ID
+      tags:
+        - Users
+      security:
+        - API Key: []
+    post:
+      summary: Create User
+      operationId: post-users-userID
+      responses:
+        '201':
+          description: User Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+              examples:
+                Example User:
+                  $ref: '#/components/examples/user'
+      description: Create a User
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+            examples: {}
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/components/parameters/contentType'
+      security:
+        - API Key: []
+components:
+  schemas:
+    Todos:
+      description: I'm a model's description.
+      type: object
+      x-examples: {}
+      title: Todo
+      properties:
+        id:
+          type: number
+          minimum: 0
+          maximum: 9999
+          description: ID of the task
+          readOnly: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+          description: Name of the task
+        completed:
+          type: boolean
+          default: false
+          description: Boolean indicating if the task has been completed or not
+        completed_at:
+          type: string
+          format: date-time
+          description: Time when the task was completed
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          description: Time when the task was created
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          description: Time when the task was updated
+          readOnly: true
+      required:
+        - id
+        - name
+        - completed_at
+        - created_at
+        - updated_at
+    User:
+      description: ''
+      type: object
+      title: User
+      properties:
+        userId:
+          type: number
+          description: ID of the user
+          readOnly: true
+        firstName:
+          type: string
+          minLength: 1
+          description: ''
+        lastName:
+          type: string
+          minLength: 1
+          description: ''
+        phoneNumber:
+          type: string
+          minLength: 1
+          description: Official Phone Number
+        emailAddress:
+          type: string
+          minLength: 1
+          description: Work Email Address
+      required:
+        - userId
+        - firstName
+        - lastName
+        - phoneNumber
+        - emailAddress
+  securitySchemes:
+    API Key:
+      name: apikey
+      type: apiKey
+      in: query
+      description: Just use \`123\`. It's super secure ;)
+  parameters:
+    limit:
+      name: limit
+      in: query
+      required: false
+      schema:
+        type: number
+      description: >-
+        Return a limited set of results *I'm a shared parameter. I can be reused
+        in multiple endpoints!*
+    contentType:
+      name: Content-Type
+      in: header
+      required: true
+      schema:
+        type: string
+        default: application/json
+      description: application/json
+    ID:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: ID of the Todo
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            title: Error
+            type: object
+            description: A standard error object.
+            x-tags:
+              - Common
+            properties:
+              status:
+                type: string
+                description: A code.
+              error:
+                type: string
+            required:
+              - status
+              - error
+    Unauthorized:
+      description: Action not allowed
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+            required:
+              - message
+  examples:
+    todo:
+      value:
+        id: 0
+        name: string
+        completed: true
+        completed_at: '2019-08-24T14:15:22Z'
+        created_at: '2019-08-24T14:15:22Z'
+        updated_at: '2019-08-24T14:15:22Z'
+    multiple-todos:
+      value:
+        - id: 0
+          name: my todo
+          completed: true
+          completed_at: '2019-08-24T14:15:22Z'
+          created_at: '2019-08-24T14:15:22Z'
+          updated_at: '2019-08-24T14:15:22Z'
+        - id: 1
+          name: another todo
+          completed: false
+          completed_at: '2019-08-24T14:15:22Z'
+          created_at: '2019-08-24T14:15:22Z'
+          updated_at: '2019-08-24T14:15:22Z'
+        - id: 2
+          name: yet another todo
+          completed: false
+          completed_at: '2019-08-24T14:15:22Z'
+          created_at: '2019-08-24T14:15:22Z'
+          updated_at: '2019-08-24T14:15:22Z'
+    user:
+      value:
+        userId: 2
+        firstName: racks
+        lastName: jacson
+        phoneNumber: '123456'
+        emailAddress: racks.jacson@learningcontainer.com
+tags:
+  - name: Todos
+`;

--- a/packages/elements/src/components/API/APIWithSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithSidebarLayout.tsx
@@ -19,6 +19,7 @@ type SidebarLayoutProps = {
   hideTryIt?: boolean;
   hideSchemas?: boolean;
   hideInternal?: boolean;
+  hideExport?: boolean;
   exportProps?: ExportButtonProps;
 };
 
@@ -28,6 +29,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
   hideTryIt,
   hideSchemas,
   hideInternal,
+  hideExport,
   exportProps,
 }) => {
   const container = React.useRef<HTMLDivElement>(null);
@@ -84,7 +86,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
           uri={pathname}
           node={node}
           nodeTitle={node.name}
-          layoutOptions={{ hideTryIt: hideTryIt }}
+          layoutOptions={{ hideTryIt: hideTryIt, hideExport }}
           location={location}
           allowRouting
           exportProps={exportProps}

--- a/packages/elements/src/components/API/APIWithSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithSidebarLayout.tsx
@@ -1,4 +1,11 @@
-import { Logo, ParsedDocs, PoweredByLink, SidebarLayout, TableOfContents } from '@stoplight/elements-core';
+import {
+  ExportButtonProps,
+  Logo,
+  ParsedDocs,
+  PoweredByLink,
+  SidebarLayout,
+  TableOfContents,
+} from '@stoplight/elements-core';
 import { Flex, Heading } from '@stoplight/mosaic';
 import * as React from 'react';
 import { Link, Redirect, useLocation } from 'react-router-dom';
@@ -12,6 +19,7 @@ type SidebarLayoutProps = {
   hideTryIt?: boolean;
   hideSchemas?: boolean;
   hideInternal?: boolean;
+  exportProps?: ExportButtonProps;
 };
 
 export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
@@ -20,6 +28,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
   hideTryIt,
   hideSchemas,
   hideInternal,
+  exportProps,
 }) => {
   const container = React.useRef<HTMLDivElement>(null);
   const tree = React.useMemo(
@@ -78,6 +87,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
           layoutOptions={{ hideTryIt: hideTryIt }}
           location={location}
           allowRouting
+          exportProps={exportProps}
         />
       )}
     </SidebarLayout>

--- a/packages/elements/src/components/API/APIWithStackedLayout.tsx
+++ b/packages/elements/src/components/API/APIWithStackedLayout.tsx
@@ -18,6 +18,7 @@ import { computeTagGroups, TagGroup } from './utils';
 type StackedLayoutProps = {
   serviceNode: ServiceNode;
   hideTryIt?: boolean;
+  hideExport?: boolean;
   exportProps?: ExportButtonProps;
 };
 
@@ -28,7 +29,12 @@ const itemMatchesHash = (hash: string, item: OperationNode) => {
 const TryItContext = React.createContext<{ hideTryIt?: boolean }>({ hideTryIt: false });
 TryItContext.displayName = 'TryItContext';
 
-export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({ serviceNode, hideTryIt, exportProps }) => {
+export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({
+  serviceNode,
+  hideTryIt,
+  hideExport,
+  exportProps,
+}) => {
   const location = useLocation();
   const { groups } = computeTagGroups(serviceNode);
 
@@ -42,7 +48,7 @@ export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({ serviceNode
             nodeTitle={serviceNode.name}
             nodeType={NodeType.HttpService}
             location={location}
-            layoutOptions={{ showPoweredByLink: true }}
+            layoutOptions={{ showPoweredByLink: true, hideExport }}
             exportProps={exportProps}
           />
         </Box>

--- a/packages/elements/src/components/API/APIWithStackedLayout.tsx
+++ b/packages/elements/src/components/API/APIWithStackedLayout.tsx
@@ -1,4 +1,11 @@
-import { DeprecatedBadge, Docs, HttpMethodColors, ParsedDocs, TryItWithRequestSamples } from '@stoplight/elements-core';
+import {
+  DeprecatedBadge,
+  Docs,
+  ExportButtonProps,
+  HttpMethodColors,
+  ParsedDocs,
+  TryItWithRequestSamples,
+} from '@stoplight/elements-core';
 import { Box, Flex, Icon, Tab, TabList, TabPanel, TabPanels, Tabs } from '@stoplight/mosaic';
 import { NodeType } from '@stoplight/types';
 import cn from 'classnames';
@@ -11,6 +18,7 @@ import { computeTagGroups, TagGroup } from './utils';
 type StackedLayoutProps = {
   serviceNode: ServiceNode;
   hideTryIt?: boolean;
+  exportProps?: ExportButtonProps;
 };
 
 const itemMatchesHash = (hash: string, item: OperationNode) => {
@@ -20,7 +28,7 @@ const itemMatchesHash = (hash: string, item: OperationNode) => {
 const TryItContext = React.createContext<{ hideTryIt?: boolean }>({ hideTryIt: false });
 TryItContext.displayName = 'TryItContext';
 
-export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({ serviceNode, hideTryIt }) => {
+export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({ serviceNode, hideTryIt, exportProps }) => {
   const location = useLocation();
   const { groups } = computeTagGroups(serviceNode);
 
@@ -35,6 +43,7 @@ export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({ serviceNode
             nodeType={NodeType.HttpService}
             location={location}
             layoutOptions={{ showPoweredByLink: true }}
+            exportProps={exportProps}
           />
         </Box>
 

--- a/packages/elements/src/containers/API.tsx
+++ b/packages/elements/src/containers/API.tsx
@@ -68,6 +68,12 @@ export interface CommonAPIProps extends RoutingProps {
    * @default false
    */
   hideInternal?: boolean;
+
+  /**
+   * Hides export button from being displayed in overview page
+   * @default false
+   */
+  hideExport?: boolean;
 }
 
 const propsAreWithDocument = (props: APIProps): props is APIPropsWithDocument => {
@@ -75,7 +81,7 @@ const propsAreWithDocument = (props: APIProps): props is APIPropsWithDocument =>
 };
 
 export const APIImpl: React.FC<APIProps> = props => {
-  const { layout, apiDescriptionUrl = '', logo, hideTryIt, hideSchemas, hideInternal } = props;
+  const { layout, apiDescriptionUrl = '', logo, hideTryIt, hideSchemas, hideInternal, hideExport } = props;
   const apiDescriptionDocument = propsAreWithDocument(props) ? props.apiDescriptionDocument : undefined;
 
   const { data: fetchedDocument, error } = useQuery(
@@ -164,7 +170,12 @@ export const APIImpl: React.FC<APIProps> = props => {
   return (
     <InlineRefResolverProvider document={parsedDocument}>
       {layout === 'stacked' ? (
-        <APIWithStackedLayout serviceNode={serviceNode} hideTryIt={hideTryIt} exportProps={exportProps} />
+        <APIWithStackedLayout
+          serviceNode={serviceNode}
+          hideTryIt={hideTryIt}
+          hideExport={hideExport}
+          exportProps={exportProps}
+        />
       ) : (
         <APIWithSidebarLayout
           logo={logo}
@@ -172,6 +183,7 @@ export const APIImpl: React.FC<APIProps> = props => {
           hideTryIt={hideTryIt}
           hideSchemas={hideSchemas}
           hideInternal={hideInternal}
+          hideExport={hideExport}
           exportProps={exportProps}
         />
       )}

--- a/packages/elements/src/containers/API.tsx
+++ b/packages/elements/src/containers/API.tsx
@@ -11,13 +11,15 @@ import {
   withStyles,
 } from '@stoplight/elements-core';
 import { Box, Flex, Icon } from '@stoplight/mosaic';
+import { safeStringify } from '@stoplight/yaml';
+import { saveAs } from 'file-saver';
 import { pipe } from 'lodash/fp';
 import * as React from 'react';
 import { useQuery } from 'react-query';
 
 import { APIWithSidebarLayout } from '../components/API/APIWithSidebarLayout';
 import { APIWithStackedLayout } from '../components/API/APIWithStackedLayout';
-import { transformOasToServiceNode } from '../utils/oas';
+import { isJson, transformOasToServiceNode } from '../utils/oas';
 
 export type APIProps = APIPropsWithDocument | APIPropsWithUrl;
 
@@ -90,9 +92,43 @@ export const APIImpl: React.FC<APIProps> = props => {
     },
   );
 
-  const parsedDocument = useParsedValue(apiDescriptionDocument || fetchedDocument);
+  const document = apiDescriptionDocument || fetchedDocument;
+  const isJsonDocument = typeof document === 'object' || (!!document && isJson(document));
+  const parsedDocument = useParsedValue(document);
   const bundledDocument = useBundleRefsIntoDocument(parsedDocument, { baseUrl: apiDescriptionUrl });
   const serviceNode = React.useMemo(() => transformOasToServiceNode(bundledDocument), [bundledDocument]);
+
+  const exportDocument = React.useCallback(
+    (document: string) => {
+      const type = isJsonDocument ? 'json' : 'yaml';
+      const blob = new Blob([document], {
+        type: `application/${type}`,
+      });
+      saveAs(blob, `document.${type}`);
+    },
+    [isJsonDocument],
+  );
+
+  const exportOriginalDocument = React.useCallback(() => {
+    const originalDocument = typeof document === 'object' ? JSON.stringify(document, null, 2) : document || '';
+    exportDocument(originalDocument);
+  }, [document, exportDocument]);
+
+  const exportBundledDocument = React.useCallback(() => {
+    const stringifiedDocument = isJsonDocument
+      ? JSON.stringify(bundledDocument, null, 2)
+      : safeStringify(bundledDocument);
+    exportDocument(stringifiedDocument);
+  }, [bundledDocument, isJsonDocument, exportDocument]);
+
+  const exportProps = {
+    original: {
+      onPress: exportOriginalDocument,
+    },
+    bundled: {
+      onPress: exportBundledDocument,
+    },
+  };
 
   if (error) {
     return (
@@ -128,7 +164,7 @@ export const APIImpl: React.FC<APIProps> = props => {
   return (
     <InlineRefResolverProvider document={parsedDocument}>
       {layout === 'stacked' ? (
-        <APIWithStackedLayout serviceNode={serviceNode} hideTryIt={hideTryIt} />
+        <APIWithStackedLayout serviceNode={serviceNode} hideTryIt={hideTryIt} exportProps={exportProps} />
       ) : (
         <APIWithSidebarLayout
           logo={logo}
@@ -136,6 +172,7 @@ export const APIImpl: React.FC<APIProps> = props => {
           hideTryIt={hideTryIt}
           hideSchemas={hideSchemas}
           hideInternal={hideInternal}
+          exportProps={exportProps}
         />
       )}
     </InlineRefResolverProvider>

--- a/packages/elements/src/hooks/useExportDocumentProps.spec.tsx
+++ b/packages/elements/src/hooks/useExportDocumentProps.spec.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom';
+
+import { safeStringify } from '@stoplight/yaml';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { saveAs } from 'file-saver';
+
+import { InstagramAPI as bundledJson } from '../__fixtures__/api-descriptions/Instagram';
+import { simpleApiWithoutDescription as json } from '../__fixtures__/api-descriptions/simpleApiWithoutDescription';
+import { todosApiBundled as bundledYaml } from '../__fixtures__/api-descriptions/todosApiBundled';
+import { zoomApiYaml as yaml } from '../__fixtures__/api-descriptions/zoomApiYaml';
+import { useExportDocumentProps } from './useExportDocumentProps';
+
+jest.mock('file-saver');
+
+describe('useExportDocumentProps', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it('exports json document', () => {
+    const data = renderHook(() =>
+      useExportDocumentProps({
+        originalDocument: json,
+        bundledDocument: bundledJson,
+      }),
+    );
+
+    act(() => {
+      data.result.current.original.onPress();
+      data.result.current.bundled.onPress();
+    });
+
+    const expectedOriginalDocument = new Blob([JSON.stringify(json, null, 2)], {
+      type: 'application/json',
+    });
+
+    const expectedBundledDocument = new Blob([JSON.stringify(bundledJson, null, 2)], {
+      type: 'application/json',
+    });
+    expect(saveAs).toBeCalledTimes(2);
+    expect(saveAs).toHaveBeenCalledWith(expectedOriginalDocument, 'document.json');
+    expect(saveAs).toHaveBeenCalledWith(expectedBundledDocument, 'document.json');
+  });
+
+  it('exports yaml document', () => {
+    const data = renderHook(() =>
+      useExportDocumentProps({
+        originalDocument: safeStringify(yaml),
+        bundledDocument: bundledYaml,
+      }),
+    );
+
+    act(() => {
+      data.result.current.original.onPress();
+      data.result.current.bundled.onPress();
+    });
+
+    const expectedOriginalDocument = new Blob([safeStringify(yaml)], {
+      type: 'application/yaml',
+    });
+
+    const expectedBundledDocument = new Blob([safeStringify(bundledYaml)], {
+      type: 'application/yaml',
+    });
+    expect(saveAs).toBeCalledTimes(2);
+    expect(saveAs).toHaveBeenCalledWith(expectedOriginalDocument, 'document.yaml');
+    expect(saveAs).toHaveBeenCalledWith(expectedBundledDocument, 'document.yaml');
+  });
+});

--- a/packages/elements/src/hooks/useExportDocumentProps.tsx
+++ b/packages/elements/src/hooks/useExportDocumentProps.tsx
@@ -1,0 +1,48 @@
+import { safeStringify } from '@stoplight/yaml';
+import { saveAs } from 'file-saver';
+import * as React from 'react';
+
+import { isJson } from '../utils/oas';
+
+export function useExportDocumentProps({
+  originalDocument,
+  bundledDocument,
+}: {
+  originalDocument: string | object;
+  bundledDocument: unknown;
+}) {
+  const isJsonDocument = typeof originalDocument === 'object' || (!!originalDocument && isJson(originalDocument));
+
+  const exportDocument = React.useCallback(
+    (document: string) => {
+      const type = isJsonDocument ? 'json' : 'yaml';
+      const blob = new Blob([document], {
+        type: `application/${type}`,
+      });
+      saveAs(blob, `document.${type}`);
+    },
+    [isJsonDocument],
+  );
+
+  const exportOriginalDocument = React.useCallback(() => {
+    const stringifiedDocument =
+      typeof originalDocument === 'object' ? JSON.stringify(originalDocument, null, 2) : originalDocument || '';
+    exportDocument(stringifiedDocument);
+  }, [originalDocument, exportDocument]);
+
+  const exportBundledDocument = React.useCallback(() => {
+    const stringifiedDocument = isJsonDocument
+      ? JSON.stringify(bundledDocument, null, 2)
+      : safeStringify(bundledDocument);
+    exportDocument(stringifiedDocument);
+  }, [bundledDocument, isJsonDocument, exportDocument]);
+
+  return {
+    original: {
+      onPress: exportOriginalDocument,
+    },
+    bundled: {
+      onPress: exportBundledDocument,
+    },
+  };
+}

--- a/packages/elements/src/utils/oas/index.ts
+++ b/packages/elements/src/utils/oas/index.ts
@@ -146,3 +146,12 @@ function findMapMatch(key: string | number, map: ISourceNodeMap[]): ISourceNodeM
     }
   }
 }
+
+export function isJson(value: string) {
+  try {
+    JSON.parse(value);
+  } catch (e) {
+    return false;
+  }
+  return true;
+}

--- a/packages/elements/src/web-components/components.ts
+++ b/packages/elements/src/web-components/components.ts
@@ -11,5 +11,6 @@ export const ApiElement = createElementClass(API, {
   hideTryIt: { type: 'boolean' },
   hideSchemas: { type: 'boolean' },
   hideInternal: { type: 'boolean' },
+  hideExport: { type: 'boolean' },
   logo: { type: 'string' },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5272,6 +5272,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/file-saver@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/file-saver/-/file-saver-2.0.3.tgz#b734c4f5a04d20615eaed3dc106e2ab321082009"
+  integrity sha512-MBIou8pd/41jkff7s97B47bc9+p0BszqqDJsO51yDm49uUxeKzrfuNl5fSLC6BpLEWKA8zlwyqALVmXrFwoBHQ==
+
 "@types/glob-base@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@types/glob-base/-/glob-base-0.3.0.tgz#a581d688347e10e50dd7c17d6f2880a10354319d"
@@ -10761,6 +10766,11 @@ file-loader@^6.2.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+file-saver@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.5.tgz#d61cfe2ce059f414d899e9dd6d4107ee25670c38"
+  integrity sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==
 
 file-system-cache@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Fixes: https://github.com/stoplightio/elements/issues/707
Requires https://github.com/stoplightio/platform-internal/pull/7315 to make export button visible in StoplightProject (it's on v2 but not yet in prod)

Adds export/download feature to API and StopolightProject components.



<img width="560" alt="Screenshot 2021-07-28 at 16 04 42" src="https://user-images.githubusercontent.com/14196079/127336232-60f47c0c-bdb7-417b-b415-5931c1b815a6.png">
<img width="601" alt="Screenshot 2021-07-28 at 16 04 51" src="https://user-images.githubusercontent.com/14196079/127336253-f50dc695-29c4-4170-9bb4-5def406f438d.png">
