### PR TITLE
chore: upgrade node in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   cypress-default:
     docker:
-      - image: cypress/base:14.17.0
+      - image: cimg/node:12.22.3
         environment:
           ## this enables colors in the output
           TERM: xterm
@@ -56,6 +56,9 @@ jobs:
       example-name:
         type: string
     steps:
+      - run:
+          name: Install Cypress dependencies
+          command: sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - attach_workspace:
           at: /mnt/ramdisk/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   cypress-default:
     docker:
-      - image: cypress/base:12
+      - image: cypress/base:14.17.0
         environment:
           ## this enables colors in the output
           TERM: xterm
@@ -11,7 +11,7 @@ executors:
 jobs:
   lint-and-check:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12.22.3
     steps:
       - checkout
       - run: yarn --frozen-lockfile
@@ -24,7 +24,7 @@ jobs:
   build:
     working_directory: /mnt/ramdisk/project
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12.22.3
     resource_class: large
     environment:
       CYPRESS_CACHE_FOLDER: /mnt/ramdisk/.cache/Cypress
@@ -40,7 +40,7 @@ jobs:
             - .cache/Cypress
   build-docs:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12.22.3
     steps:
       - checkout
       - run: yarn --frozen-lockfile
@@ -86,7 +86,7 @@ jobs:
           destination: screenshots
   lockfile-maintenance:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12.22.3
     steps:
       - checkout
       - run:
@@ -100,7 +100,7 @@ jobs:
             BODY='{"head":''"'${BRANCH_NAME}'"'',"base":"main","title":"Weekly lockfile maintenance"}' && curl -X POST -H "Accept:application/vnd.github.v3+json" -u $GIT_AUTHOR_NAME:$GH_TOKEN https://api.github.com/repos/stoplightio/elements/pulls -d "$BODY"
   release:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12.22.3
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   cypress-default:
     docker:
-      - image: cimg/node:12.22.3
+      - image: cypress/base:12
         environment:
           ## this enables colors in the output
           TERM: xterm
@@ -57,8 +57,10 @@ jobs:
         type: string
     steps:
       - run:
-          name: Install Cypress dependencies
-          command: sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+          name: Install Node 12.22+
+          command: |
+            curl -fsSL https://deb.nodesource.com/setup_12.x | bash -
+            apt-get install -y nodejs
       - attach_workspace:
           at: /mnt/ramdisk/
       - run:


### PR DESCRIPTION
Fixes the install problem with the gatsby example hopefully.

Unfortunately Cypress no longer seems to maintain its 12.x images, so I had to move up to 14.x (no 12.20+ image which the dependency requires).