### PR TITLE
fix: openapi and schema examples validations rendering

### DIFF
--- a/packages/elements-core/src/__fixtures__/operations/put-todos.ts
+++ b/packages/elements-core/src/__fixtures__/operations/put-todos.ts
@@ -317,7 +317,18 @@ export const httpOperation: IHttpOperation = {
         description: 'How many todos to limit?',
         name: 'limit',
         style: HttpParamStyles.Form,
-      },
+        example: 'hoho',
+        examples: [
+          {
+            key: 'a',
+            value: 'hehe',
+          },
+          {
+            key: 'b',
+            value: 'hihi',
+          },
+        ],
+      } as any,
       {
         schema: {
           type: 'string',

--- a/packages/elements-core/src/__fixtures__/operations/put-todos.ts
+++ b/packages/elements-core/src/__fixtures__/operations/put-todos.ts
@@ -317,18 +317,7 @@ export const httpOperation: IHttpOperation = {
         description: 'How many todos to limit?',
         name: 'limit',
         style: HttpParamStyles.Form,
-        example: 'hoho',
-        examples: [
-          {
-            key: 'a',
-            value: 'hehe',
-          },
-          {
-            key: 'b',
-            value: 'hihi',
-          },
-        ],
-      } as any,
+      },
       {
         schema: {
           type: 'string',

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.spec.tsx
@@ -298,6 +298,7 @@ describe('HttpOperation', () => {
               description: 'a parameter description',
               schema: {
                 type: 'string',
+                examples: ['another example'],
               },
               deprecated: true,
               explode: true,
@@ -322,6 +323,8 @@ describe('HttpOperation', () => {
       expect(pathParametersPanel).toBeEnabled();
 
       expect(await screen.findByText('parameter name')).toBeInTheDocument();
+      expect(await screen.findByText('"example value"')).toBeInTheDocument();
+      expect(await screen.findByText('"another example"')).toBeInTheDocument();
     });
 
     it('should still show path parameters panel when there are no parameters', () => {

--- a/packages/elements-core/src/components/Docs/HttpOperation/Parameters.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Parameters.tsx
@@ -62,17 +62,23 @@ export const Parameter: React.FunctionComponent<IParameterProps> = ({ parameter,
   // TODO (JJ): schema.deprecated is used in platform - to be removed once it's updated https://github.com/stoplightio/platform-internal/issues/2267
   const deprecated = get(parameter, 'deprecated') || get(parameter, 'schema.deprecated', false);
 
+  const parameterExamples =
+    parameter.examples?.map(example => {
+      if (isNodeExample(example)) {
+        return example.value;
+      }
+
+      return example.externalValue;
+    }) || [];
+
+  const schemaExamples = parameter.schema?.examples;
+  const schemaExamplesArray = Array.isArray(schemaExamples) ? schemaExamples : [];
+
   const validations = omitBy(
     {
       ...omit(parameter, ['name', 'required', 'deprecated', 'description', 'schema', 'style', 'examples']),
       ...omit(get(parameter, 'schema'), ['description', 'type', 'deprecated']),
-      examples: parameter.examples?.map(example => {
-        if (isNodeExample(example)) {
-          return example.value;
-        }
-
-        return example.externalValue;
-      }),
+      examples: [...parameterExamples, ...schemaExamplesArray],
     },
     // Remove empty arrays and objects
     value => (typeof value === 'object' && isEmpty(value)) || typeof value === 'undefined',

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -50,7 +50,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "@stoplight/elements-core": "~7.1.7",
-    "@stoplight/http-spec": "^4.0.1",
+    "@stoplight/http-spec": "^4.2.2",
     "@stoplight/json": "^3.10.0",
     "@stoplight/mosaic": "^1",
     "@stoplight/types": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3940,10 +3940,10 @@
   dependencies:
     eslint-config-prettier "^8.3.0"
 
-"@stoplight/http-spec@^4.0.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/http-spec/-/http-spec-4.2.1.tgz#f0816dec054ec1a373d725ee15543bcd0d20cb68"
-  integrity sha512-qS1JaAva6QpP3YfOyeeh/FXt+yvYF248GSSzHhIIv0xNl/WtuiilzAOaDxv1Hi/o/tRszfE8q2GPMi0h92g7cg==
+"@stoplight/http-spec@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/http-spec/-/http-spec-4.2.2.tgz#096286ee879e44fcc8237174e7f18ede37028677"
+  integrity sha512-m49Sn2iW7DeAqEaSFRixr7led6tLCkobKML16jWT0BBwInouZATPfzbSHymHGqyjqgaE0tJde+hgmiOFMAKLCQ==
   dependencies:
     "@stoplight/json" "^3.10.2"
     "@stoplight/types" "^12.3.0"


### PR DESCRIPTION
Closes https://github.com/stoplightio/platform-internal/issues/6720 and https://github.com/stoplightio/elements/issues/1032

Makes sure that `parameter.example`, `parameter.examples` and `parameter.schema.examples` are displayed correctly.

Doesn't display `parameter.schema.example`, since it doesn't exist on the typings nor is mentioned in JSON Schema docs - https://json-schema.org/understanding-json-schema/reference/generic.html

Unifying `parameter.example` and `parameter.examples` was done in `http-spec`, hence it is not visible in tests here. That's what `http-spec` update is for.