### PR TITLE
fix: gatsby build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   cypress-default:
     docker:
-      - image: cypress/base:12
+      - image: cypress/base:14.17.0
         environment:
           ## this enables colors in the output
           TERM: xterm

--- a/examples/react-gatsby/package.json
+++ b/examples/react-gatsby/package.json
@@ -11,6 +11,9 @@
   "bugs": {
     "url": "https://github.com/stoplightio/elements-starter-gatsby/issues"
   },
+  "engines": {
+    "node": ">=12.20"
+  },
   "scripts": {
     "start": "gatsby develop -p 4200",
     "serve": "gatsby serve -p 4200",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -52,7 +52,7 @@
     "@stoplight/json-schema-sampler": "0.2.0",
     "@stoplight/json-schema-viewer": "^4.0.3",
     "@stoplight/markdown": "^3.0.0",
-    "@stoplight/markdown-viewer": "^5.1.0",
+    "@stoplight/markdown-viewer": "^5.1.3",
     "@stoplight/mosaic": "^1",
     "@stoplight/mosaic-code-editor": "^1",
     "@stoplight/mosaic-code-viewer": "^1",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
     "@stoplight/elements-core": "~7.1.8",
-    "@stoplight/markdown-viewer": "^5.1.0",
+    "@stoplight/markdown-viewer": "^5.1.3",
     "@stoplight/mosaic": "^1",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4031,10 +4031,10 @@
   dependencies:
     wolfy87-eventemitter "~5.2.8"
 
-"@stoplight/markdown-viewer@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-5.1.0.tgz#2a21fc0032a63218a325923a0beca79e78c94c33"
-  integrity sha512-QcF/Ju54RZERH+ewGqW8dHYcuvL9YoaXNg8tvze5y4Z7L2bIpaNUdMUDsEDdFWC/h/MePumo3OQDpo4hV2VHFQ==
+"@stoplight/markdown-viewer@^5.1.3":
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-5.1.3.tgz#bfc29886a88391348507a2c9a72b3271d67cd463"
+  integrity sha512-t784OxZEJpRpUlh8t8Ohtm5NBF5n56ybtZhe252ehBQ9lPkS24p8LggMtf3bnZW37jsgaBpTdBkoR75145ujnQ==
   dependencies:
     "@stoplight/markdown" "^3.0.0"
     "@stoplight/react-error-boundary" "^1.1.0"
@@ -4047,6 +4047,7 @@
     mdast-util-to-hast "^11.1.1"
     remark-parse "^9.0.0"
     unified "^9.2.1"
+    unist-builder "^3.0.0"
     unist-util-visit "^3.1.0"
 
 "@stoplight/markdown@^3.0.0":


### PR DESCRIPTION
Fixes gatsby build by:
- bumping MDV
- using node >=14.13 for cypress workflow - gatsby has a dependency that requires usage of node in version >=12.20 which is missing in cypress docker images. 

Looks like @marcelltoth first approach in https://github.com/stoplightio/elements/pull/1653 was correct.