### PR TITLE
feat: models export button

### DIFF
--- a/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
@@ -1,4 +1,6 @@
+import { Provider as MosaicProvider } from '@stoplight/mosaic';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { JSONSchema7 } from 'json-schema';
 import * as React from 'react';
 
@@ -20,5 +22,52 @@ describe('Model', () => {
 
     expect(screen.getByRole('heading', { name: /example/i })).toBeInTheDocument();
     expect(container).toHaveTextContent('"propA": "valueA"');
+  });
+
+  describe('export button', () => {
+    it('should render correctly', () => {
+      const wrapper = render(
+        <MosaicProvider>
+          <Model
+            data={exampleSchema}
+            exportProps={{ original: { onPress: jest.fn() }, bundled: { onPress: jest.fn() } }}
+          />
+          ,
+        </MosaicProvider>,
+      );
+
+      const exportButton = wrapper.getByRole('button', { name: 'Export' });
+      expect(exportButton).toBeInTheDocument();
+
+      userEvent.click(exportButton);
+      expect(wrapper.getByRole('menuitem', { name: 'Original' })).toBeInTheDocument();
+      expect(wrapper.getByRole('menuitem', { name: 'Bundled References' })).toBeInTheDocument();
+    });
+
+    it('should not render if hideExport is true', () => {
+      const wrapper = render(
+        <MosaicProvider>
+          <Model
+            data={exampleSchema}
+            exportProps={{ original: { onPress: jest.fn() }, bundled: { onPress: jest.fn() } }}
+            layoutOptions={{ hideExport: true }}
+          />
+        </MosaicProvider>,
+      );
+
+      const exportButton = wrapper.queryByRole('button', { name: 'Export' });
+      expect(exportButton).not.toBeInTheDocument();
+    });
+
+    it('should not render if no exportProps are present', () => {
+      const wrapper = render(
+        <MosaicProvider>
+          <Model data={exampleSchema} />
+        </MosaicProvider>,
+      );
+
+      const exportButton = wrapper.queryByRole('button', { name: 'Export' });
+      expect(exportButton).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -32,7 +32,7 @@ const ModelComponent: React.FC<ModelProps> = ({
 
   const example = React.useMemo(() => generateExampleFromJsonSchema(data), [data]);
 
-  const shouldDisplayHeader = !layoutOptions?.noHeading && title !== undefined;
+  const shouldDisplayHeader = !layoutOptions?.noHeading && (title !== undefined || exportProps);
 
   const header = (shouldDisplayHeader || isInternal) && (
     <>

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -32,7 +32,8 @@ const ModelComponent: React.FC<ModelProps> = ({
 
   const example = React.useMemo(() => generateExampleFromJsonSchema(data), [data]);
 
-  const shouldDisplayHeader = !layoutOptions?.noHeading && (title !== undefined || exportProps);
+  const shouldDisplayHeader =
+    !layoutOptions?.noHeading && (title !== undefined || (exportProps && !layoutOptions?.hideExport));
 
   const header = (shouldDisplayHeader || isInternal) && (
     <>

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -1,5 +1,5 @@
 import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
-import { Heading, HStack, Panel, Text } from '@stoplight/mosaic';
+import { Flex, Heading, HStack, Panel, Text } from '@stoplight/mosaic';
 import { CodeViewer } from '@stoplight/mosaic-code-viewer';
 import { withErrorBoundary } from '@stoplight/react-error-boundary';
 import cn from 'classnames';
@@ -12,11 +12,18 @@ import { getOriginalObject } from '../../../utils/ref-resolving/resolvedObject';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { DocsComponentProps } from '..';
 import { InternalBadge } from '../HttpOperation/Badges';
+import { ExportButton } from '../HttpService/ExportButton';
 import { TwoColumnLayout } from '../TwoColumnLayout';
 
 export type ModelProps = DocsComponentProps<JSONSchema7>;
 
-const ModelComponent: React.FC<ModelProps> = ({ data: unresolvedData, className, nodeTitle, layoutOptions }) => {
+const ModelComponent: React.FC<ModelProps> = ({
+  data: unresolvedData,
+  className,
+  nodeTitle,
+  layoutOptions,
+  exportProps,
+}) => {
   const resolveRef = useInlineRefResolver();
   const data = useResolvedObject(unresolvedData) as JSONSchema7;
 
@@ -30,9 +37,12 @@ const ModelComponent: React.FC<ModelProps> = ({ data: unresolvedData, className,
   const header = (shouldDisplayHeader || isInternal) && (
     <>
       {shouldDisplayHeader && (
-        <Heading size={1} mb={4} fontWeight="semibold">
-          {title}
-        </Heading>
+        <Flex justifyContent="between" alignItems="center">
+          <Heading size={1} mb={4} fontWeight="semibold">
+            {title}
+          </Heading>
+          {exportProps && !layoutOptions?.hideExport && <ExportButton {...exportProps} />}
+        </Flex>
       )}
 
       {isInternal && (

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -55,7 +55,7 @@ export const NodeContent = ({ node, Link, hideTryIt, hideTryItPanel, hideMocking
               }}
               useNodeForRefResolving
               exportProps={
-                node.type === NodeType.HttpService
+                [NodeType.HttpService, NodeType.Model].includes(node.type as NodeType)
                   ? {
                       original: {
                         href: node.links.export_url,

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.0.8';
+export const appVersion = '1.0.9';

--- a/packages/elements/src/components/API/APIWithSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithSidebarLayout.tsx
@@ -7,6 +7,7 @@ import {
   TableOfContents,
 } from '@stoplight/elements-core';
 import { Flex, Heading } from '@stoplight/mosaic';
+import { NodeType } from '@stoplight/types';
 import * as React from 'react';
 import { Link, Redirect, useLocation } from 'react-router-dom';
 
@@ -86,7 +87,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
           uri={pathname}
           node={node}
           nodeTitle={node.name}
-          layoutOptions={{ hideTryIt: hideTryIt, hideExport }}
+          layoutOptions={{ hideTryIt: hideTryIt, hideExport: hideExport || node.type !== NodeType.HttpService }}
           location={location}
           allowRouting
           exportProps={exportProps}


### PR DESCRIPTION
Fixes: https://github.com/stoplightio/elements/issues/1658

Adds export button for standalone models in DevPortal.
It doesn't make sense to export models in API component since they are embedded into API document itself.