### PR TITLE
fix: jsv padding

### DIFF
--- a/packages/elements-core/src/styles.css
+++ b/packages/elements-core/src/styles.css
@@ -85,6 +85,10 @@
   line-height: 1.5em;
 }
 
+.sl-elements .sl-markdown-viewer .JsonSchemaViewer {
+  padding-right: 10px;
+}
+
 .sl-elements .HttpOperation__gutter {
   --fs-code: 12px;
 }

--- a/packages/elements-core/src/styles.css
+++ b/packages/elements-core/src/styles.css
@@ -69,18 +69,7 @@
 
 /* HttpOperation */
 
-.sl-elements .HttpOperation .JsonSchemaViewer .MarkdownViewer p {
-  font-size: 12px;
-  line-height: 1.5em;
-}
-
-.sl-elements .HttpOperation__Parameters .MarkdownViewer p {
-
-  font-size: 12px;
-  line-height: 1.5em;
-}
-
-.sl-elements .Model .JsonSchemaViewer .MarkdownViewer p {
+.sl-elements .HttpOperation .JsonSchemaViewer .sl-markdown-viewer p, .sl-elements .HttpOperation__Parameters .sl-markdown-viewer p, .sl-elements .Model .JsonSchemaViewer .sl-markdown-viewer p {
   font-size: 12px;
   line-height: 1.5em;
 }

--- a/packages/elements-core/src/styles.css
+++ b/packages/elements-core/src/styles.css
@@ -69,7 +69,18 @@
 
 /* HttpOperation */
 
-.sl-elements .HttpOperation .JsonSchemaViewer .sl-markdown-viewer p, .sl-elements .HttpOperation__Parameters .sl-markdown-viewer p, .sl-elements .Model .JsonSchemaViewer .sl-markdown-viewer p {
+.sl-elements .HttpOperation .JsonSchemaViewer .sl-markdown-viewer p {
+  font-size: 12px;
+  line-height: 1.5em;
+}
+
+.sl-elements .HttpOperation__Parameters .sl-markdown-viewer p {
+
+  font-size: 12px;
+  line-height: 1.5em;
+}
+
+.sl-elements .Model .JsonSchemaViewer .sl-markdown-viewer p {
   font-size: 12px;
   line-height: 1.5em;
 }


### PR DESCRIPTION
Resolves #1562 

Also fixes some broken CSS that still has the old classname (`MarkdownViewer` instead of `sl-markdown-viewer`).