### PR TITLE
chore: don't show duplicate schema description for non-objects

### DIFF
--- a/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
@@ -6,6 +6,7 @@ import { Model } from './Model';
 
 const exampleSchema: JSONSchema7 = {
   type: 'object',
+  description: 'example schema description',
   properties: {
     propA: {
       type: 'string',
@@ -20,5 +21,17 @@ describe('Model', () => {
 
     expect(screen.getByRole('heading', { name: /example/i })).toBeInTheDocument();
     expect(container).toHaveTextContent('"propA": "valueA"');
+  });
+
+  it('displays description at top of doc for objects', async () => {
+    const { container } = render(<Model data={exampleSchema} />);
+
+    expect(container).toHaveTextContent(/example schema description/i);
+  });
+
+  it('does not display description at top of doc for non-objects', async () => {
+    const description = screen.queryByRole('textbox');
+
+    expect(description).not.toBeInTheDocument();
   });
 });

--- a/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
@@ -15,6 +15,11 @@ const exampleSchema: JSONSchema7 = {
   },
 };
 
+const exampleStringSchema: JSONSchema7 = {
+  type: 'string',
+  description: 'example schema description that should only show once :)',
+};
+
 describe('Model', () => {
   it('displays examples', async () => {
     const { container } = render(<Model data={exampleSchema} />);
@@ -24,12 +29,16 @@ describe('Model', () => {
   });
 
   it('displays description at top of doc for objects', async () => {
-    const { container } = render(<Model data={exampleSchema} />);
+    render(<Model data={exampleSchema} />);
+    const description = screen.queryAllByText('example schema description');
+    const textboxDescription = screen.getByRole('textbox');
 
-    expect(container).toHaveTextContent(/example schema description/i);
+    expect(description).toHaveLength(1);
+    expect(textboxDescription).toHaveTextContent('example schema description');
   });
 
   it('does not display description at top of doc for non-objects', async () => {
+    render(<Model data={exampleStringSchema} />);
     const description = screen.queryByRole('textbox');
 
     expect(description).not.toBeInTheDocument();

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -45,7 +45,7 @@ const ModelComponent: React.FC<ModelProps> = ({ data: unresolvedData, className,
 
   const description = (
     <>
-      {data.description && <MarkdownViewer className="sl-mb-6" markdown={data.description} />}
+      {data.description && data.type === 'object' && <MarkdownViewer className="sl-mb-6" markdown={data.description} />}
       <JsonSchemaViewer resolveRef={resolveRef} schema={getOriginalObject(data)} />
     </>
   );

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -45,7 +45,9 @@ const ModelComponent: React.FC<ModelProps> = ({ data: unresolvedData, className,
 
   const description = (
     <>
-      {data.description && data.type === 'object' && <MarkdownViewer className="sl-mb-6" markdown={data.description} />}
+      {data.description && data.type === 'object' && (
+        <MarkdownViewer className="sl-mb-6" role="textbox" markdown={data.description} />
+      )}
       <JsonSchemaViewer resolveRef={resolveRef} schema={getOriginalObject(data)} />
     </>
   );


### PR DESCRIPTION
Addresses #7386

Gets rid of duplicate description for schemas that aren't objects. 
If data.type is an object, should show description. If it's not, don't show description. 


<img width="1576" alt="Screen Shot 2021-08-05 at 2 33 21 PM" src="https://user-images.githubusercontent.com/47359669/128410145-7650de67-898d-4b4e-88bb-de755b14722b.png">

vs. 

<img width="1570" alt="Screen Shot 2021-08-05 at 2 33 48 PM" src="https://user-images.githubusercontent.com/47359669/128410296-0c2371d8-4fea-4679-aacb-528f954f759c.png">


