### PR TITLE
Fix: increase padding in docs

### DIFF
--- a/packages/elements-core/src/components/Docs/Article/index.tsx
+++ b/packages/elements-core/src/components/Docs/Article/index.tsx
@@ -17,8 +17,8 @@ const ArticleComponent = React.memo<ArticleProps>(({ data }) => {
   if (tree === null) return null;
 
   return (
-    <Flex w="full" pos="relative" ref={setContainer}>
-      <Box style={{ width: 0 }} flex={1}>
+    <Flex className="sl-elements-article" w="full" pos="relative" ref={setContainer}>
+      <Box className="sl-elements-article-content" style={{ width: 0 }} flex={1}>
         <MarkdownViewer markdown={tree} />
       </Box>
       <ArticleHeadings tree={tree} container={container} />

--- a/packages/elements-core/src/styles.css
+++ b/packages/elements-core/src/styles.css
@@ -69,18 +69,18 @@
 
 /* HttpOperation */
 
-.sl-elements .HttpOperation .JsonSchemaViewer .MarkdownViewer p {
+.sl-elements .HttpOperation .JsonSchemaViewer .sl-markdown-viewer p {
   font-size: 12px;
   line-height: 1.5em;
 }
 
-.sl-elements .HttpOperation__Parameters .MarkdownViewer p {
+.sl-elements .HttpOperation__Parameters .sl-markdown-viewer p {
 
   font-size: 12px;
   line-height: 1.5em;
 }
 
-.sl-elements .Model .JsonSchemaViewer .MarkdownViewer p {
+.sl-elements .Model .JsonSchemaViewer .sl-markdown-viewer p {
   font-size: 12px;
   line-height: 1.5em;
 }

--- a/packages/elements-dev-portal/src/styles.css
+++ b/packages/elements-dev-portal/src/styles.css
@@ -1,12 +1,13 @@
 @import "../../elements-core/src/styles.css";
 
 .sl-elements-article {
-    justify-content: space-evenly;
-    padding-left: 60px;
-    padding-right: 60px;
-  }
+  justify-content: space-evenly;
+}
   
-  .sl-elements-article-content {
-    max-width: 800px;
-  }
-  
+.sl-elements-article-content {
+  max-width: 700px;
+}
+
+.ArticleHeadings {
+  max-width: 300px;
+}

--- a/packages/elements-dev-portal/src/styles.css
+++ b/packages/elements-dev-portal/src/styles.css
@@ -1,1 +1,12 @@
 @import "../../elements-core/src/styles.css";
+
+.sl-elements-article {
+    justify-content: space-evenly;
+    padding-left: 60px;
+    padding-right: 60px;
+  }
+  
+  .sl-elements-article-content {
+    max-width: 800px;
+  }
+  


### PR DESCRIPTION
A part of: https://github.com/stoplightio/elements/issues/1618

This adds some class names to the `Docs/Article` component and later applies custom styling to this component in `elements-dev-portal`. I decided not to modify the `Article` component directly in order to make it more customizable for other usages.

**Before**


https://user-images.githubusercontent.com/58433203/128506785-cd574528-1501-4fc8-9ac8-d723a9c66efe.mov



**After**

https://user-images.githubusercontent.com/58433203/128506554-fefa9215-f744-45cc-948f-971cb5d27a75.mov

