### PR TITLE
chore: weekly maintenance PR should always run on latest 'main' commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
       - run:
           command: |
             git checkout main
+            git pull --ff-only
             export BRANCH_NAME=feat/lockfile-maintenance-ci-job-$(date +"%m-%d-%Y") && git checkout -b $BRANCH_NAME
             yarn upgrade
             git add yarn.lock


### PR DESCRIPTION
Normally this doesn't matter, but I wanted to be able to "re-run" failed lockfile maintenance jobs, in which case it matters that you're running on the latest commit.