### PR TITLE
chore: release

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.1.11",
+  "version": "7.1.12",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
-    "@stoplight/elements-core": "~7.1.11",
+    "@stoplight/elements-core": "~7.1.12",
     "@stoplight/markdown-viewer": "^5.1.3",
     "@stoplight/mosaic": "^1",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.0.9';
+export const appVersion = '1.0.10';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.0.6",
+  "version": "7.0.7",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -49,7 +49,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.31",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "@stoplight/elements-core": "~7.1.11",
+    "@stoplight/elements-core": "~7.1.12",
     "@stoplight/http-spec": "^4.2.2",
     "@stoplight/json": "^3.10.0",
     "@stoplight/mosaic": "^1",


### PR DESCRIPTION
- @stoplight/elements-core@7.1.12
- @stoplight/elements-dev-portal@1.0.10
- @stoplight/elements@7.0.7

**Changes:**
Documentation additions (#1659) 
Docs: Pricing callout for dev portal (#1660)
Update CODEOWNERS (#1675)
feat: models export button (#1666)
feat: same type security schemes (#1671)
fix: increase padding in docs (#1670)
chore: don't show duplicate schema description for non-objects (#1668)
feat: display multiple servers in service overview page (#1669)
fix: jsv padding in markdown file (#1667)
chore: node type (#1679)