### PR TITLE
feat: In MarkdownViewer TryIt, parse path parameters based on provided url

### DIFF
--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.spec.ts
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.spec.ts
@@ -54,7 +54,7 @@ describe('parseHttpRequest', () => {
   it('parses HttpRequest parameters', () => {
     const request: IHttpRequest = {
       method: 'post',
-      url: '/todos',
+      url: '/todos/{id}',
       baseUrl: 'http://test',
       query: {
         limit: ['10'],
@@ -70,11 +70,12 @@ describe('parseHttpRequest', () => {
     expect(httpOperation).toMatchObject({
       id: '?http-operation-id?',
       method: 'post',
-      path: '/todos',
+      path: '/todos/{id}',
       servers: [{ url: 'http://test' }],
       request: {
         query: [{ name: 'limit', style: HttpParamStyles.Form, schema: { default: '10' } }],
         headers: [{ name: 'apikey', style: HttpParamStyles.Simple, schema: { default: '123' } }],
+        path: [{ name: 'id', style: HttpParamStyles.Simple, required: true }],
         body: { contents: [{ mediaType: 'application/json', schema: { default: '{}' } }] },
       },
     });

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
@@ -79,6 +79,7 @@ export const CodeComponent: CustomComponentMapping['code'] = props => {
 
 export function parseHttpRequest(data: PartialHttpRequest): IHttpOperation {
   const uri = URI(data.url);
+  const pathParam = data.url.match(/[^{\}]+(?=})/g);
   return {
     id: '?http-operation-id?',
     method: data.method,
@@ -94,6 +95,11 @@ export function parseHttpRequest(data: PartialHttpRequest): IHttpOperation {
         name: key,
         style: HttpParamStyles.Simple,
         schema: { default: value },
+      })),
+      path: pathParam?.map(name => ({
+        name,
+        style: HttpParamStyles.Simple,
+        required: true,
       })),
       ...(data.body
         ? { body: { contents: [{ mediaType: 'application/json', schema: { default: data.body } }] } }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9274,7 +9274,7 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -12717,7 +12717,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -15013,11 +15013,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseisequal@^3.0.0:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz#d8025f76339d29342767dcc887ce5cb95a5b51f1"
@@ -15035,29 +15030,17 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
 
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -15198,11 +15181,6 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"


### PR DESCRIPTION
A part of: https://github.com/stoplightio/platform-internal/issues/7388

This PR adds a posibility to enter the value of path parameters, which are now available in inline TryIt/RequestMaker (in MarkdownViewer) based on the names extracted from url e.g.

```
$baseUrl/hello/{param1}/welcome/{path2}
```

Will allow to pass values for `param1` and `param2`

All of this is utilizing and modifying existing `parseHttpRequest` function which expects data of type `PartialHttpRequest` - path parameters are not specified there per se, as they normaly are in OAS document (where you need path param both in url and a corresponding path param object).

There's a limitation here that we only allow to pass values, but do not show examples, expected data format (`string`, `number`, etc.) or prepopulate the `TryIt` with a path param value based on the `json` file passed to it.

Please let me know if you think I should update the `parseHttpRequest` to accept more robust data than `PartialHttpRequest` or is this good enough.

### **Before**

https://user-images.githubusercontent.com/58433203/129169151-35c9445b-2085-4fc2-b869-2ed20ca703f5.mov

### **After**

https://user-images.githubusercontent.com/58433203/129169196-cb192160-6cc9-4757-9b47-a6f766c1e5e0.mov

