### PR TITLE
chore: show description and other scheme details

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
@@ -140,6 +140,16 @@ describe('HttpService', () => {
       expect(description).toBeInTheDocument();
     });
 
+    it('should render both custom description and other scheme details', () => {
+      render(<SecuritySchemes schemes={[{ ...oauth, description: 'A custom description' }]} />);
+
+      const description = screen.getByText('A custom description');
+      const implicit = screen.getByText('Implicit OAuth Flow');
+
+      expect(description).toBeInTheDocument();
+      expect(implicit).toBeInTheDocument();
+    });
+
     it('should render oauth flows for default description', () => {
       render(<SecuritySchemes schemes={[oauth]} />);
 

--- a/packages/elements-core/src/components/Docs/HttpService/SecuritySchemes.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/SecuritySchemes.tsx
@@ -41,7 +41,10 @@ export const SecuritySchemes: React.FC<SecuritySchemesProps> = ({ schemes, defau
               <span role="heading">{getReadableSecurityName(scheme, shouldIncludeKey(schemes, scheme.type))}</span>
             </Panel.Titlebar>
             <Panel.Content>
-              <MarkdownViewer style={{ fontSize: 12 }} markdown={scheme.description || getDefaultDescription(scheme)} />
+              <MarkdownViewer
+                style={{ fontSize: 12 }}
+                markdown={`${scheme.description || ''}\n\n` + getDefaultDescription(scheme)}
+              />
             </Panel.Content>
           </Panel>
         ))}


### PR DESCRIPTION
Addresses [#7586](https://app.zenhub.com/workspaces/-team-pierogi-platoon-610871b8d6e5310013071b72/issues/stoplightio/platform-internal/7586)

When a custom description is added to a security scheme, it shows that description as well as other existing information. 

<img width="462" alt="Screen Shot 2021-08-18 at 1 07 00 PM" src="https://user-images.githubusercontent.com/47359669/129949748-e6e4eae1-5bc9-4ff4-ac2e-65445c600a0c.png">
