### PR TITLE
fix: maxHeight for panels

### DIFF
--- a/packages/elements-core/src/components/RequestSamples/RequestSamples.tsx
+++ b/packages/elements-core/src/components/RequestSamples/RequestSamples.tsx
@@ -87,7 +87,7 @@ export const RequestSamples = React.memo<RequestSamplesProps>(({ request }) => {
         <CodeViewer
           aria-label={requestSample ?? fallbackText}
           noCopyButton
-          maxHeight="510"
+          maxHeight="400px"
           language={mosaicCodeViewerLanguage}
           value={requestSample || fallbackText}
         />

--- a/packages/elements-core/src/components/TryIt/Body/RequestBody.tsx
+++ b/packages/elements-core/src/components/TryIt/Body/RequestBody.tsx
@@ -21,7 +21,14 @@ export const RequestBody: React.FC<RequestBodyProps> = ({ examples, requestBody,
         Body
       </Panel.Titlebar>
       <Panel.Content className="TextRequestBody">
-        <CodeEditor onChange={onChange} language="json" value={requestBody} showLineNumbers padding={0} />
+        <CodeEditor
+          onChange={onChange}
+          language="json"
+          value={requestBody}
+          showLineNumbers
+          padding={0}
+          style={{ maxHeight: '400px' }}
+        />
       </Panel.Content>
     </Panel>
   );

--- a/packages/elements-core/src/components/TryIt/Body/RequestBody.tsx
+++ b/packages/elements-core/src/components/TryIt/Body/RequestBody.tsx
@@ -21,14 +21,7 @@ export const RequestBody: React.FC<RequestBodyProps> = ({ examples, requestBody,
         Body
       </Panel.Titlebar>
       <Panel.Content className="TextRequestBody">
-        <CodeEditor
-          onChange={onChange}
-          language="json"
-          value={requestBody}
-          showLineNumbers
-          padding={0}
-          style={{ maxHeight: '400px' }}
-        />
+        <CodeEditor onChange={onChange} language="json" value={requestBody} showLineNumbers padding={0} />
       </Panel.Content>
     </Panel>
   );


### PR DESCRIPTION
Should address #1664 specifically request sample panel was unnecessarily long. Request body looks to already be fixed.

before: 
![Screen Shot 2021-08-23 at 10 35 45 AM](https://user-images.githubusercontent.com/47359669/130475657-e1e00a91-0363-45ae-99f6-58857cecd6cf.png)


after:
![Screen Shot 2021-08-23 at 10 35 22 AM](https://user-images.githubusercontent.com/47359669/130475692-ac50da16-d154-4fec-8ecb-1dceef0986aa.png)
