### PR TITLE
chore: bump markdown viewer version

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -52,7 +52,7 @@
     "@stoplight/json-schema-sampler": "0.2.0",
     "@stoplight/json-schema-viewer": "^4.0.3",
     "@stoplight/markdown": "^3.0.0",
-    "@stoplight/markdown-viewer": "^5.1.3",
+    "@stoplight/markdown-viewer": "^5.2.1",
     "@stoplight/mosaic": "^1.2.4",
     "@stoplight/mosaic-code-editor": "^1.2.4",
     "@stoplight/mosaic-code-viewer": "^1.2.4",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
     "@stoplight/elements-core": "~7.2.0",
-    "@stoplight/markdown-viewer": "^5.1.3",
+    "@stoplight/markdown-viewer": "^5.2.1",
     "@stoplight/mosaic": "^1.2.4",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3482,10 +3482,10 @@
   dependencies:
     wolfy87-eventemitter "~5.2.8"
 
-"@stoplight/markdown-viewer@^5.1.3":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-5.2.0.tgz#2da789c0bd41b08192013e777eb7d2c28cb6ae63"
-  integrity sha512-56fKp4E6PNOn6wAZ+iC2S2ugxJNxb/IAjLsLdPZLv2yktq9oQtJ+OjJXbuCLf2PHdIsioU/kl0z9w506dHLyYA==
+"@stoplight/markdown-viewer@^5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-5.2.1.tgz#2e64120fc0f4aa8da48bfa7bee21d6133395b707"
+  integrity sha512-ak54wDs0qzhH2HbUzm8h3Jw494czOpYBiHPto6vbHI0htjYMXx8nT3NoEi66lGpczESNFIk+1VK7ambIS0ovnQ==
   dependencies:
     "@stoplight/markdown" "^3.0.0"
     "@stoplight/react-error-boundary" "^1.1.0"


### PR DESCRIPTION
Related to [#7591](https://app.zenhub.com/workspaces/-team-pierogi-platoon-610871b8d6e5310013071b72/issues/stoplightio/platform-internal/7591)

Before:
<img width="1093" alt="Screen Shot 2021-08-23 at 11 04 17 AM" src="https://user-images.githubusercontent.com/47359669/130480182-d5d85577-5337-4fd6-aafb-c1f2787b334c.png">



After:

<img width="1131" alt="Screen Shot 2021-08-23 at 10 57 59 AM" src="https://user-images.githubusercontent.com/47359669/130480210-35f10aa3-705b-47af-a918-703a7d959f5f.png">


