### PR TITLE
fix: file upload

### DIFF
--- a/packages/elements-core/src/__fixtures__/operations/base64-file-upload.ts
+++ b/packages/elements-core/src/__fixtures__/operations/base64-file-upload.ts
@@ -26,7 +26,7 @@ export const httpOperation: IHttpOperation = {
             properties: {
               someFile: {
                 type: 'string',
-                format: 'base64',
+                contentEncoding: 'base64',
               },
             },
           },

--- a/packages/elements-core/src/__fixtures__/operations/multipart-formdata-post.ts
+++ b/packages/elements-core/src/__fixtures__/operations/multipart-formdata-post.ts
@@ -36,7 +36,7 @@ export const httpOperation: IHttpOperation = {
               },
               someFile: {
                 type: 'string',
-                format: 'binary',
+                contentMediaType: 'application/octet-stream',
               },
             },
             required: ['name', 'completed'],

--- a/packages/elements-core/src/components/TryIt/Body/request-body-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Body/request-body-utils.ts
@@ -51,7 +51,7 @@ const createMultipartRequestBody: RequestBodyCreator = async ({ mediaTypeContent
 
     if (typeof schema !== 'object') continue;
 
-    if (parameterSupportsFileUpload({ schema }) && schema.format === 'base64' && value instanceof File) {
+    if (parameterSupportsFileUpload({ schema }) && schema.contentEncoding === 'base64' && value instanceof File) {
       try {
         formData.append(key, await fileToBase64(value));
       } catch {

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -33,8 +33,8 @@ export function exampleOptions(parameter: ParameterSpec) {
 export function parameterSupportsFileUpload(parameter: Pick<ParameterSpec, 'schema'>) {
   return (
     parameter.schema?.type === 'string' &&
-    parameter.schema.format !== undefined &&
-    ['binary', 'base64'].includes(parameter.schema.format)
+    (parameter.schema?.contentEncoding === 'base64' ||
+      parameter.schema?.contentMediaType === 'application/octet-stream')
   );
 }
 


### PR DESCRIPTION
Closes #1649 

Test with yaml:

```
openapi: 3.0.0
info:
    title: Some API
    description: This is a description
    contact:
        email: some@email.com
    version: 1.0.0
servers:
    - url: '/v1/api'
      description: Develop
tags:
    - name: media
paths:
    /media:
        post:
            operationId: create_media
            tags:
                - media
            summary: Create media
            security:
                - API Key: []
            requestBody:
                content:
                    multipart/form-data:
                        schema:
                            type: object
                            properties:
                                metadata:
                                    type: string
                                image:
                                    type: string
                                    format: binary
                        encoding:
                            image:
                                contentType: image/png, image/jpeg
            responses:
                '200':
                    description: |
                        Media created successfully.
                    content:
                        application/json:
                            schema:
                                type: string
components:
    securitySchemes:
        API Key:
            name: x-api-key
            type: apiKey
            in: header
security:
    - API Key: []
```

Reasoning for change:

Http-spec library is transforming binary and base64 schemas in the following way:

<img width="677" alt="Screenshot 2021-08-24 at 16 13 01" src="https://user-images.githubusercontent.com/7916523/130632546-5cefe76b-fdbb-46a8-98f8-6ee63c70c345.png">
