### PR TITLE
fix: external scrollbar

### DIFF
--- a/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
+++ b/packages/elements-core/src/components/MosaicTableOfContents/TableOfContents.tsx
@@ -26,13 +26,14 @@ const ActiveIdContext = React.createContext<string | undefined>(undefined);
 const LinkContext = React.createContext<CustomLinkComponent | undefined>(undefined);
 
 export const TableOfContents = React.memo<TableOfContentsProps>(
-  ({ tree, activeId, Link, maxDepthOpenByDefault, onLinkClick }) => {
+  ({ tree, activeId, Link, maxDepthOpenByDefault, externalScrollbar = false, onLinkClick }) => {
     const container = React.useRef<HTMLDivElement>(null);
     const child = React.useRef<HTMLDivElement>(null);
 
     React.useEffect(() => {
       const tocHasScrollbar =
-        container.current && child.current && container.current.offsetHeight < child.current.offsetHeight;
+        externalScrollbar ||
+        (container.current && child.current && container.current.offsetHeight < child.current.offsetHeight);
 
       if (activeId && typeof window !== 'undefined' && tocHasScrollbar) {
         const elem = window.document.getElementById(getHtmlIdFromItemId(activeId));

--- a/packages/elements-core/src/components/MosaicTableOfContents/types.ts
+++ b/packages/elements-core/src/components/MosaicTableOfContents/types.ts
@@ -3,6 +3,7 @@ export type TableOfContentsProps = {
   activeId: string;
   Link: CustomLinkComponent;
   maxDepthOpenByDefault?: number;
+  externalScrollbar?: boolean;
   onLinkClick?(): void;
 };
 

--- a/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
@@ -13,6 +13,7 @@ export type TableOfContentsProps = BoxProps<'div'> & {
   tableOfContents: ProjectTableOfContents;
   Link: CustomLinkComponent;
   collapseTableOfContents?: boolean;
+  externalScrollbar?: boolean;
   onLinkClick?(): void;
 };
 
@@ -21,6 +22,7 @@ export const TableOfContents = ({
   activeId,
   Link,
   collapseTableOfContents = false,
+  externalScrollbar,
   onLinkClick,
   ...boxProps
 }: TableOfContentsProps) => {
@@ -32,6 +34,7 @@ export const TableOfContents = ({
           activeId={activeId}
           Link={Link}
           maxDepthOpenByDefault={collapseTableOfContents ? 0 : 1}
+          externalScrollbar={externalScrollbar}
           onLinkClick={onLinkClick}
         />
       </Flex>


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/7661

ToC in the platform doesn't use its own scrollbar like the elements or elements-dev-portal version, it rather uses higher-level one. This means that the default mechanism to detect whether ToC is using scrollbar doesn't affect here. 

This PR adds an optional property to ToC to indicate that there's an external scrollbar and we can scroll to active item.
Platform PR will need to add that property to ToC container.