### PR TITLE
chore: bump JSV version

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",
@@ -50,7 +50,7 @@
     "@stoplight/json": "^3.10.0",
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.0",
-    "@stoplight/json-schema-viewer": "^4.2.0",
+    "@stoplight/json-schema-viewer": "^4.2.1",
     "@stoplight/markdown": "^3.0.0",
     "@stoplight/markdown-viewer": "^5.2.1",
     "@stoplight/mosaic": "^1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3448,10 +3448,10 @@
     "@types/json-schema" "^7.0.7"
     magic-error "0.0.1"
 
-"@stoplight/json-schema-viewer@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.2.0.tgz#8646882f02183a5bfa08f265bc0e4dc9708c8be0"
-  integrity sha512-FaBswZs331oG2e5ixitnpllb3HMZxREotJpJslJpQGXZmi8IEsgksDCzs8Dsbkss/TDQkfigHd4i3exJ4I8TfA==
+"@stoplight/json-schema-viewer@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.2.1.tgz#6af80df0e8e632190b4e306566ef729b4bc6b90e"
+  integrity sha512-q9Iq2nl2Qouxyr91C4n3GDnqS21tcTKqY6NO7ckCa80WY8L2Yz5ji/jfW0S+iLhLIvLMEdW0loOkKZjXVHy4zQ==
   dependencies:
     "@fortawesome/free-solid-svg-icons" "^5.15.2"
     "@stoplight/json" "^3.10.0"


### PR DESCRIPTION
For #1665
JSV PR: https://github.com/stoplightio/json-schema-viewer/pull/163

I've tested it using elements storybook, by adding `test` property in `User` schema

```yaml
test:
  type: array
  items:
    enum: 
      - p1
      - p2
      - p3
```

**Before**

<img width="722" alt="Screenshot 2021-08-25 at 12 45 34" src="https://user-images.githubusercontent.com/1868852/130778534-2008dd63-77f5-48c4-923b-c81c8534de31.png">

**After**

<img width="740" alt="Screenshot 2021-08-25 at 12 47 11" src="https://user-images.githubusercontent.com/1868852/130778555-6e30c481-552f-4c35-b43a-76bd446f7b80.png">
