### PR TITLE
fix: group http ops and models together

### DIFF
--- a/packages/elements-utils/package.json
+++ b/packages/elements-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-utils",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "homepage": "https://github.com/stoplightio/elements",
   "bugs": "https://github.com/stoplightio/elements/issues",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/elements-utils/src/toc/__tests__/toc.test.ts
+++ b/packages/elements-utils/src/toc/__tests__/toc.test.ts
@@ -144,19 +144,17 @@ describe('toc', () => {
               items: [
                 {
                   type: 'group',
+                  title: 'raz',
+                  items: [{ type: 'item', title: 'b', uri: '/reference/openapi.json/definitions/b' }],
+                },
+                {
+                  type: 'group',
                   items: [{ type: 'item', title: 'Operation', uri: '/reference/openapi.json/paths/~1test/get' }],
                   title: 'zwei',
                 },
                 {
                   type: 'group',
-                  items: [
-                    {
-                      type: 'group',
-                      title: 'raz',
-                      items: [{ type: 'item', title: 'b', uri: '/reference/openapi.json/definitions/b' }],
-                    },
-                    { type: 'item', title: 'c', uri: '/reference/openapi.json/definitions/c' },
-                  ],
+                  items: [{ type: 'item', title: 'c', uri: '/reference/openapi.json/definitions/c' }],
                   title: 'Schemas',
                 },
               ],
@@ -736,26 +734,14 @@ describe('toc', () => {
                     type: 'item',
                     uri: '/openapi.yaml/~1path',
                   },
+                  {
+                    title: 'The Model',
+                    type: 'item',
+                    uri: '/openapi.yaml/~1components~1model',
+                  },
                 ],
                 title: 'api',
                 type: 'group',
-              },
-              {
-                title: 'Schemas',
-                type: 'group',
-                items: [
-                  {
-                    title: 'api',
-                    type: 'group',
-                    items: [
-                      {
-                        title: 'The Model',
-                        type: 'item',
-                        uri: '/openapi.yaml/~1components~1model',
-                      },
-                    ],
-                  },
-                ],
               },
             ],
           },
@@ -825,6 +811,12 @@ describe('toc', () => {
           type: NodeType.Model,
           tags: ['api'],
         },
+        {
+          uri: '/openapi.yaml/~1components~1model',
+          name: 'Untagged Model',
+          type: NodeType.Model,
+          tags: [],
+        },
       ]);
 
       expect(toc).toEqual({
@@ -880,6 +872,11 @@ describe('toc', () => {
                     type: 'item',
                     uri: '/openapi.yaml/~1apath',
                   },
+                  {
+                    title: 'The Model',
+                    type: 'item',
+                    uri: '/openapi.yaml/~1components~1model',
+                  },
                 ],
                 title: 'api',
                 type: 'group',
@@ -889,15 +886,9 @@ describe('toc', () => {
                 type: 'group',
                 items: [
                   {
-                    title: 'api',
-                    type: 'group',
-                    items: [
-                      {
-                        title: 'The Model',
-                        type: 'item',
-                        uri: '/openapi.yaml/~1components~1model',
-                      },
-                    ],
+                    title: 'Untagged Model',
+                    type: 'item',
+                    uri: '/openapi.yaml/~1components~1model',
                   },
                 ],
               },
@@ -958,7 +949,7 @@ describe('toc', () => {
           uri: '/openapi-a.yaml/~1components~1model',
           name: 'The Model',
           type: NodeType.Model,
-          tags: ['api'],
+          tags: ['newtag'],
         },
       ]);
 
@@ -985,19 +976,13 @@ describe('toc', () => {
                 type: 'group',
               },
               {
-                title: 'Schemas',
+                title: 'newtag',
                 type: 'group',
                 items: [
                   {
-                    title: 'api',
-                    type: 'group',
-                    items: [
-                      {
-                        title: 'The Model',
-                        type: 'item',
-                        uri: '/openapi-a.yaml/~1components~1model',
-                      },
-                    ],
+                    title: 'The Model',
+                    type: 'item',
+                    uri: '/openapi-a.yaml/~1components~1model',
                   },
                 ],
               },
@@ -1269,22 +1254,10 @@ describe('toc', () => {
                     title: 'The Op',
                     uri: '/openapi.yaml/~1zpath',
                   },
-                ],
-              },
-              {
-                type: 'group',
-                title: 'Schemas',
-                items: [
                   {
-                    title: 'api',
-                    type: 'group',
-                    items: [
-                      {
-                        type: 'item',
-                        title: 'The Model',
-                        uri: '/openapi.yaml/~1components~1model',
-                      },
-                    ],
+                    type: 'item',
+                    title: 'The Model',
+                    uri: '/openapi.yaml/~1components~1model',
                   },
                 ],
               },
@@ -1353,7 +1326,7 @@ describe('toc', () => {
             uri: '/openapi-2.yaml/~1components~1model',
             name: 'The Model 2',
             type: NodeType.Model,
-            tags: ['api'],
+            tags: [],
           },
         ],
         toc,
@@ -1378,22 +1351,10 @@ describe('toc', () => {
                         title: 'The Op 1',
                         uri: '/openapi-1.yaml/~1path',
                       },
-                    ],
-                  },
-                  {
-                    type: 'group',
-                    title: 'Schemas',
-                    items: [
                       {
-                        title: 'api',
-                        type: 'group',
-                        items: [
-                          {
-                            type: 'item',
-                            title: 'The Model 1',
-                            uri: '/openapi-1.yaml/~1components~1model',
-                          },
-                        ],
+                        type: 'item',
+                        title: 'The Model 1',
+                        uri: '/openapi-1.yaml/~1components~1model',
                       },
                     ],
                   },
@@ -1420,15 +1381,9 @@ describe('toc', () => {
                     title: 'Schemas',
                     items: [
                       {
-                        title: 'api',
-                        type: 'group',
-                        items: [
-                          {
-                            type: 'item',
-                            title: 'The Model 2',
-                            uri: '/openapi-2.yaml/~1components~1model',
-                          },
-                        ],
+                        type: 'item',
+                        title: 'The Model 2',
+                        uri: '/openapi-2.yaml/~1components~1model',
                       },
                     ],
                   },
@@ -1509,22 +1464,10 @@ describe('toc', () => {
                         title: 'The Op',
                         uri: '/openapi.yaml/~1path',
                       },
-                    ],
-                  },
-                  {
-                    type: 'group',
-                    title: 'Schemas',
-                    items: [
                       {
-                        type: 'group',
-                        title: 'api',
-                        items: [
-                          {
-                            type: 'item',
-                            title: 'The Model',
-                            uri: '/openapi.yaml/~1components~1model',
-                          },
-                        ],
+                        type: 'item',
+                        title: 'The Model',
+                        uri: '/openapi.yaml/~1components~1model',
                       },
                     ],
                   },

--- a/packages/elements-utils/src/toc/toc.ts
+++ b/packages/elements-utils/src/toc/toc.ts
@@ -245,9 +245,12 @@ function appendHttpServiceItemsToToC(toc: ITableOfContents) {
     { httpOperations, models }: { httpOperations: NodeData[]; models: NodeData[] },
     serviceTagNames: string[],
   ) => {
-    const { groups, others } = httpOperations.reduce<{
+    const all = [...httpOperations.map(i => ({ ...i, t: 'http' })), ...models.map(i => ({ ...i, t: 'model' }))];
+
+    const { groups, ungroupedModels, ungroupedOperations } = all.reduce<{
       groups: { [key: string]: Group };
-      others: Item[];
+      ungroupedOperations: Item[];
+      ungroupedModels: NodeData[];
     }>(
       (result, subNode) => {
         const [tagName] = subNode.tags || [];
@@ -269,15 +272,19 @@ function appendHttpServiceItemsToToC(toc: ITableOfContents) {
             };
           }
         } else {
-          result.others.push(item);
+          if (subNode.t === 'http') {
+            result.ungroupedOperations.push(item);
+          } else {
+            result.ungroupedModels.push(subNode);
+          }
         }
 
         return result;
       },
-      { groups: {}, others: [] },
+      { groups: {}, ungroupedOperations: [], ungroupedModels: [] },
     );
 
-    others.forEach(item => toc.items.push(item));
+    ungroupedOperations.forEach(item => toc.items.push(item));
 
     const tagNamesLC = serviceTagNames.map(tn => tn.toLowerCase());
 
@@ -298,7 +305,7 @@ function appendHttpServiceItemsToToC(toc: ITableOfContents) {
       })
       .forEach(([, group]) => toc.items.push(group));
 
-    appendModelsToToc(toc, 'group')(models);
+    appendModelsToToc(toc, 'group')(ungroupedModels);
   };
 }
 


### PR DESCRIPTION
For #1662

In addition to changes made in https://github.com/stoplightio/elements/pull/1693 I have added ability to group http operations and models together as requested here https://github.com/stoplightio/platform-internal/pull/7729#issuecomment-904864820