### PR TITLE
chore: shrink version badge

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
@@ -59,6 +59,7 @@ export const SecurityBadge: React.FC<{
 export const VersionBadge: React.FC<{ value: string; backgroundColor?: string }> = ({ value, backgroundColor }) => (
   <Badge
     appearance="solid"
+    size="sm"
     style={{
       backgroundColor: backgroundColor || badgeDefaultBackgroundColor,
       border: 'none',


### PR DESCRIPTION
Addresses styling part of https://github.com/stoplightio/elements/issues/1638

Makes version badge smaller using mosaic properties. We could shrink it more if needed by styling manually. 

@mnaumanali94 the default badge color you mentioned is the exact same color used in the ToC background so we can't use it for version badges. We need one value that looks fine in light and dark mode. 

<img width="224" alt="Screenshot 2021-08-25 at 20 28 24" src="https://user-images.githubusercontent.com/14196079/130845500-41ddf78b-7905-4939-84b2-448212b6e2a0.png">
<img width="219" alt="Screenshot 2021-08-25 at 20 28 35" src="https://user-images.githubusercontent.com/14196079/130845515-59335307-9809-4156-bc42-ad825401c5e4.png">
