### PR TITLE
feat: add codegen to embedded request maker

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -38,6 +38,6 @@
     "@angular/compiler-cli": "^12.0.4",
     "@angular/language-service": "^12.0.5",
     "angular-http-server": "^1.10.0",
-    "typescript": "^4.2.4"
+    "typescript": "4.2.4"
   }
 }

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
@@ -71,7 +71,7 @@ export const CodeComponent: CustomComponentMapping['code'] = props => {
     }
 
     return (
-      <TryIt httpOperation={isHttpOperation(parsedValue) ? parsedValue : parseHttpRequest(parsedValue)} embedded />
+      <TryIt httpOperation={isHttpOperation(parsedValue) ? parsedValue : parseHttpRequest(parsedValue)} embeddedInMd />
     );
   }
 

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
@@ -70,7 +70,9 @@ export const CodeComponent: CustomComponentMapping['code'] = props => {
       return null;
     }
 
-    return <TryIt httpOperation={isHttpOperation(parsedValue) ? parsedValue : parseHttpRequest(parsedValue)} />;
+    return (
+      <TryIt httpOperation={isHttpOperation(parsedValue) ? parsedValue : parseHttpRequest(parsedValue)} embedded />
+    );
   }
 
   const DefaultCode = DefaultSMDComponents.code!;

--- a/packages/elements-core/src/components/RequestSamples/RequestSamples.tsx
+++ b/packages/elements-core/src/components/RequestSamples/RequestSamples.tsx
@@ -13,6 +13,10 @@ export interface RequestSamplesProps {
    * The HTTP request to generate code for.
    */
   request: Request;
+  /**
+   * True when embedded in TryIt
+   */
+  embedded?: boolean;
 }
 
 const selectedLanguageAtom = persistAtom<string>('RequestSamples_selectedLanguage', atom('Shell'));
@@ -25,7 +29,7 @@ const fallbackText = 'Unable to generate code example';
  *
  * The programming language can be selected by the user and is remembered across instances and remounts.
  */
-export const RequestSamples = React.memo<RequestSamplesProps>(({ request }) => {
+export const RequestSamples = React.memo<RequestSamplesProps>(({ request, embedded = false }) => {
   const [selectedLanguage, setSelectedLanguage] = useAtom(selectedLanguageAtom);
   const [selectedLibrary, setSelectedLibrary] = useAtom(selectedLibraryAtom);
 
@@ -67,7 +71,7 @@ export const RequestSamples = React.memo<RequestSamplesProps>(({ request }) => {
   }, [selectedLanguage, selectedLibrary, setSelectedLanguage, setSelectedLibrary]);
 
   return (
-    <Panel rounded isCollapsible={false}>
+    <Panel rounded={embedded ? undefined : true} isCollapsible={embedded}>
       <Panel.Titlebar rightComponent={<CopyButton size="sm" copyValue={requestSample || ''} />}>
         <Box ml={-2}>
           <Menu

--- a/packages/elements-core/src/components/RequestSamples/RequestSamples.tsx
+++ b/packages/elements-core/src/components/RequestSamples/RequestSamples.tsx
@@ -16,7 +16,7 @@ export interface RequestSamplesProps {
   /**
    * True when embedded in TryIt
    */
-  embedded?: boolean;
+  embeddedInMd?: boolean;
 }
 
 const selectedLanguageAtom = persistAtom<string>('RequestSamples_selectedLanguage', atom('Shell'));
@@ -29,7 +29,7 @@ const fallbackText = 'Unable to generate code example';
  *
  * The programming language can be selected by the user and is remembered across instances and remounts.
  */
-export const RequestSamples = React.memo<RequestSamplesProps>(({ request, embedded = false }) => {
+export const RequestSamples = React.memo<RequestSamplesProps>(({ request, embeddedInMd = false }) => {
   const [selectedLanguage, setSelectedLanguage] = useAtom(selectedLanguageAtom);
   const [selectedLibrary, setSelectedLibrary] = useAtom(selectedLibraryAtom);
 
@@ -71,7 +71,7 @@ export const RequestSamples = React.memo<RequestSamplesProps>(({ request, embedd
   }, [selectedLanguage, selectedLibrary, setSelectedLanguage, setSelectedLibrary]);
 
   return (
-    <Panel rounded={embedded ? undefined : true} isCollapsible={embedded}>
+    <Panel rounded={embeddedInMd ? undefined : true} isCollapsible={embeddedInMd}>
       <Panel.Titlebar rightComponent={<CopyButton size="sm" copyValue={requestSample || ''} />}>
         <Box ml={-2}>
           <Menu

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -147,6 +147,13 @@ describe('TryIt', () => {
     expect(responseHeader).not.toBeInTheDocument();
   });
 
+  it('when embedded in markdown, shows request codegen', async () => {
+    render(<TryItWithPersistence httpOperation={basicOperation} embeddedInMd />);
+
+    const requestSamplePanel = await screen.findByText('Request Sample: Shell / cURL');
+    expect(requestSamplePanel).toBeVisible();
+  });
+
   describe('Parameter Handling', () => {
     it('Hides panel when there are no parameters', () => {
       render(<TryItWithPersistence httpOperation={basicOperation} />);

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -46,7 +46,7 @@ export interface TryItProps {
   /**
    * True when TryIt is embedded in Markdown doc
    */
-  embedded?: boolean;
+  embeddedInMd?: boolean;
   corsProxy?: string;
 }
 
@@ -71,7 +71,7 @@ export const TryIt: React.FC<TryItProps> = ({
   mockUrl,
   onRequestChange,
   requestBodyIndex,
-  embedded = false,
+  embeddedInMd = false,
   corsProxy,
 }) => {
   const isDark = useThemeIsDark();
@@ -109,7 +109,7 @@ export const TryIt: React.FC<TryItProps> = ({
 
   React.useEffect(() => {
     let isActive = true;
-    if (onRequestChange) {
+    if (onRequestChange || embeddedInMd) {
       buildHarRequest({
         mediaTypeContent,
         parameterValues: parameterValuesWithDefaults,
@@ -120,21 +120,8 @@ export const TryIt: React.FC<TryItProps> = ({
         chosenServer,
         corsProxy,
       }).then(request => {
-        if (isActive) onRequestChange(request);
-      });
-    }
-    if (embedded) {
-      buildHarRequest({
-        mediaTypeContent,
-        parameterValues: parameterValuesWithDefaults,
-        httpOperation,
-        bodyInput: formDataState.isFormDataBody ? bodyParameterValues : textRequestBody,
-        auth: operationAuthValue,
-        ...(mockingOptions.isEnabled && { mockData: getMockData(mockUrl, httpOperation, mockingOptions) }),
-        chosenServer,
-        corsProxy,
-      }).then(request => {
-        setRequestData(request);
+        if (onRequestChange && isActive) onRequestChange(request);
+        if (embeddedInMd) setRequestData(request);
       });
     }
     return () => {
@@ -152,6 +139,7 @@ export const TryIt: React.FC<TryItProps> = ({
     mockingOptions,
     chosenServer,
     corsProxy,
+    embeddedInMd,
   ]);
 
   const handleClick = async () => {
@@ -270,7 +258,7 @@ export const TryIt: React.FC<TryItProps> = ({
           )}
         </Panel.Content>
       </Panel>
-      {requestData && embedded && <RequestSamples request={requestData} embedded />}
+      {requestData && embeddedInMd && <RequestSamples request={requestData} embeddedInMd />}
       {response && !('error' in response) && <TryItResponse response={response} />}
       {response && 'error' in response && <ResponseError state={response} />}
     </Box>

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -109,22 +109,34 @@ export const TryIt: React.FC<TryItProps> = ({
 
   React.useEffect(() => {
     let isActive = true;
-    buildHarRequest({
-      mediaTypeContent,
-      parameterValues: parameterValuesWithDefaults,
-      httpOperation,
-      bodyInput: formDataState.isFormDataBody ? bodyParameterValues : textRequestBody,
-      auth: operationAuthValue,
-      ...(mockingOptions.isEnabled && { mockData: getMockData(mockUrl, httpOperation, mockingOptions) }),
-      chosenServer,
-      corsProxy,
-    }).then(request => {
-      setRequestData(request);
-      if (onRequestChange) {
+    if (onRequestChange) {
+      buildHarRequest({
+        mediaTypeContent,
+        parameterValues: parameterValuesWithDefaults,
+        httpOperation,
+        bodyInput: formDataState.isFormDataBody ? bodyParameterValues : textRequestBody,
+        auth: operationAuthValue,
+        ...(mockingOptions.isEnabled && { mockData: getMockData(mockUrl, httpOperation, mockingOptions) }),
+        chosenServer,
+        corsProxy,
+      }).then(request => {
         if (isActive) onRequestChange(request);
-      }
-    });
-
+      });
+    }
+    if (embedded) {
+      buildHarRequest({
+        mediaTypeContent,
+        parameterValues: parameterValuesWithDefaults,
+        httpOperation,
+        bodyInput: formDataState.isFormDataBody ? bodyParameterValues : textRequestBody,
+        auth: operationAuthValue,
+        ...(mockingOptions.isEnabled && { mockData: getMockData(mockUrl, httpOperation, mockingOptions) }),
+        chosenServer,
+        corsProxy,
+      }).then(request => {
+        setRequestData(request);
+      });
+    }
     return () => {
       isActive = false;
     };

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -109,24 +109,25 @@ export const TryIt: React.FC<TryItProps> = ({
 
   React.useEffect(() => {
     let isActive = true;
-    async function fetchRequest() {
-      let harRequest = await buildHarRequest({
-        mediaTypeContent,
-        parameterValues: parameterValuesWithDefaults,
-        httpOperation,
-        bodyInput: formDataState.isFormDataBody ? bodyParameterValues : textRequestBody,
-        auth: operationAuthValue,
-        ...(mockingOptions.isEnabled && { mockData: getMockData(mockUrl, httpOperation, mockingOptions) }),
-        chosenServer,
-        corsProxy,
-      });
-      setRequestData(harRequest);
-      if (isActive && onRequestChange) onRequestChange(harRequest);
-      return () => {
-        isActive = false;
-      };
-    }
-    fetchRequest();
+    buildHarRequest({
+      mediaTypeContent,
+      parameterValues: parameterValuesWithDefaults,
+      httpOperation,
+      bodyInput: formDataState.isFormDataBody ? bodyParameterValues : textRequestBody,
+      auth: operationAuthValue,
+      ...(mockingOptions.isEnabled && { mockData: getMockData(mockUrl, httpOperation, mockingOptions) }),
+      chosenServer,
+      corsProxy,
+    }).then(request => {
+      setRequestData(request);
+      if (onRequestChange) {
+        if (isActive) onRequestChange(request);
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
     // disabling because we don't want to react on `onRequestChange` change
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [


### PR DESCRIPTION
Attempts to address #[7389](https://app.zenhub.com/workspaces/-team-pierogi-platoon-610871b8d6e5310013071b72/issues/stoplightio/platform-internal/7389)


The codegen panel is now sandwiched between the request and the response per this [figma](https://www.figma.com/file/IaSAr7tMvF9JSUz6bQ7cX3/Codegen?node-id=0%3A1) design


![2021-08-26 10 53 23](https://user-images.githubusercontent.com/47359669/130995348-ba4e8cfb-7823-4cc9-a6c5-54639ec665b2.gif)


I am not sure if I actually solved this because I'm not super familar with how all of these components work together, but I tried to get it to look as close to the figma design as possible. 

Also, Angular build for e2e was not working due to typescript version, so I updated it to play nicely, but not sure if that is an okay longterm solution.