### PR TITLE
feat: tryit credentials policy

### DIFF
--- a/packages/elements-core/src/components/Docs/Docs.tsx
+++ b/packages/elements-core/src/components/Docs/Docs.tsx
@@ -43,6 +43,14 @@ interface BaseDocsProps {
   exportProps?: ExportButtonProps;
 
   /**
+   * Fetch credentials policy for TryIt component
+   * For more information: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+   * @default "omit"
+   */
+
+  tryItCredentialsPolicy?: 'omit' | 'include' | 'same-origin';
+
+  /**
    * Allows to customize the layout of Docs
    */
   layoutOptions?: {

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -19,7 +19,7 @@ import { Responses } from './Responses';
 export type HttpOperationProps = DocsComponentProps<IHttpOperation>;
 
 const HttpOperationComponent = React.memo<HttpOperationProps>(
-  ({ className, data: unresolvedData, uri, allowRouting = false, layoutOptions }) => {
+  ({ className, data: unresolvedData, uri, allowRouting = false, layoutOptions, tryItCredentialsPolicy }) => {
     const data = useResolvedObject(unresolvedData) as IHttpOperation;
 
     const mocking = React.useContext(MockingContext);
@@ -87,6 +87,7 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
           responseStatusCode={responseStatusCode}
           requestBodyIndex={requestBodyIndex}
           hideTryIt={layoutOptions?.hideTryIt}
+          tryItCredentialsPolicy={tryItCredentialsPolicy}
           mockUrl={mocking.hideMocking ? undefined : mocking.mockUrl}
         />
       </Box>

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -139,6 +139,30 @@ describe('TryIt', () => {
     expect(responseHeader).not.toBeInTheDocument();
   });
 
+  describe('Credentials policy', () => {
+    it('sets credentials correctly', async () => {
+      render(<TryItWithPersistence httpOperation={basicOperation} tryItCredentialsPolicy="same-origin" />);
+
+      const button = screen.getByRole('button', { name: /send/i });
+      userEvent.click(button);
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      const requestInit = fetchMock.mock.calls[0][1]!;
+      expect(requestInit.credentials).toEqual('same-origin');
+    });
+
+    it('use `omit` as default credentials policy', async () => {
+      render(<TryItWithPersistence httpOperation={basicOperation} />);
+
+      const button = screen.getByRole('button', { name: /send/i });
+      userEvent.click(button);
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      const requestInit = fetchMock.mock.calls[0][1]!;
+      expect(requestInit.credentials).toEqual('omit');
+    });
+  });
+
   describe('Parameter Handling', () => {
     it('Hides panel when there are no parameters', () => {
       render(<TryItWithPersistence httpOperation={basicOperation} />);

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -42,6 +42,13 @@ export interface TryItProps {
    */
   onRequestChange?: (currentRequest: HarRequest) => void;
   requestBodyIndex?: number;
+
+  /**
+   * Fetch credentials policy for TryIt component
+   * For more information: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+   * @default "omit"
+   */
+  tryItCredentialsPolicy?: 'omit' | 'include' | 'same-origin';
 }
 
 interface ResponseState {
@@ -60,7 +67,13 @@ interface ErrorState {
 
 const chosenServerAtom = atom<IServer | undefined>(undefined);
 
-export const TryIt: React.FC<TryItProps> = ({ httpOperation, mockUrl, onRequestChange, requestBodyIndex }) => {
+export const TryIt: React.FC<TryItProps> = ({
+  httpOperation,
+  mockUrl,
+  onRequestChange,
+  requestBodyIndex,
+  tryItCredentialsPolicy,
+}) => {
   const isDark = useThemeIsDark();
 
   const [response, setResponse] = React.useState<ResponseState | ErrorState | undefined>();
@@ -139,6 +152,7 @@ export const TryIt: React.FC<TryItProps> = ({ httpOperation, mockUrl, onRequestC
         mockData,
         auth: operationAuthValue,
         chosenServer,
+        credentials: tryItCredentialsPolicy,
       });
       let response: Response | undefined;
       try {

--- a/packages/elements-core/src/components/TryIt/build-request.ts
+++ b/packages/elements-core/src/components/TryIt/build-request.ts
@@ -41,7 +41,7 @@ export async function buildFetchRequest({
   mockData,
   auth,
   chosenServer,
-  credentials,
+  credentials = 'omit',
 }: BuildRequestInput): Promise<Parameters<typeof fetch>> {
   const server = chosenServer || httpOperation.servers?.[0];
   const chosenServerUrl = server && getServerUrlWithDefaultValues(server);

--- a/packages/elements-core/src/components/TryIt/build-request.ts
+++ b/packages/elements-core/src/components/TryIt/build-request.ts
@@ -30,6 +30,7 @@ interface BuildRequestInput {
   mockData?: MockData;
   auth?: HttpSecuritySchemeWithValues;
   chosenServer?: IServer;
+  credentials?: 'omit' | 'include' | 'same-origin';
 }
 
 export async function buildFetchRequest({
@@ -40,6 +41,7 @@ export async function buildFetchRequest({
   mockData,
   auth,
   chosenServer,
+  credentials,
 }: BuildRequestInput): Promise<Parameters<typeof fetch>> {
   const server = chosenServer || httpOperation.servers?.[0];
   const chosenServerUrl = server && getServerUrlWithDefaultValues(server);
@@ -73,7 +75,7 @@ export async function buildFetchRequest({
   return [
     url.toString(),
     {
-      credentials: 'omit',
+      credentials,
       method: httpOperation.method.toUpperCase(),
       headers,
       body: shouldIncludeBody ? body : undefined,

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -36,9 +36,25 @@ export type NodeContentProps = {
    * @default false
    */
   hideExport?: boolean;
+
+  /**
+   * Fetch credentials policy for TryIt component
+   * For more information: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+   * @default "omit"
+   */
+
+  tryItCredentialsPolicy?: 'omit' | 'include' | 'same-origin';
 };
 
-export const NodeContent = ({ node, Link, hideTryIt, hideTryItPanel, hideMocking, hideExport }: NodeContentProps) => {
+export const NodeContent = ({
+  node,
+  Link,
+  hideTryIt,
+  hideTryItPanel,
+  hideMocking,
+  hideExport,
+  tryItCredentialsPolicy,
+}: NodeContentProps) => {
   return (
     <PersistenceContextProvider>
       <NodeLinkContext.Provider value={[node, Link]}>
@@ -66,6 +82,7 @@ export const NodeContent = ({ node, Link, hideTryIt, hideTryItPanel, hideMocking
                     }
                   : undefined
               }
+              tryItCredentialsPolicy={tryItCredentialsPolicy}
             />
           </MockingProvider>
         </MarkdownComponentsProvider>

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -57,6 +57,14 @@ export interface StoplightProjectProps extends RoutingProps {
    * @default false
    */
   collapseTableOfContents?: boolean;
+
+  /**
+   * Fetch credentials policy for TryIt component
+   * For more information: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+   * @default "omit"
+   */
+
+  tryItCredentialsPolicy?: 'omit' | 'include' | 'same-origin';
 }
 
 const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
@@ -65,6 +73,7 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
   hideMocking,
   hideExport,
   collapseTableOfContents = false,
+  tryItCredentialsPolicy,
 }) => {
   const { branchSlug = '', nodeSlug = '' } = useParams<{ branchSlug?: string; nodeSlug: string }>();
   const history = useHistory();
@@ -103,7 +112,14 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
     elem = <NotFound />;
   } else {
     elem = (
-      <NodeContent node={node} Link={Link} hideTryIt={hideTryIt} hideMocking={hideMocking} hideExport={hideExport} />
+      <NodeContent
+        node={node}
+        Link={Link}
+        hideTryIt={hideTryIt}
+        hideMocking={hideMocking}
+        hideExport={hideExport}
+        tryItCredentialsPolicy={tryItCredentialsPolicy}
+      />
     );
   }
 

--- a/packages/elements-dev-portal/src/web-components/components.ts
+++ b/packages/elements-dev-portal/src/web-components/components.ts
@@ -11,4 +11,5 @@ export const StoplightProjectElement = createElementClass(StoplightProject, {
   router: { type: 'string' },
   platformUrl: { type: 'string' },
   collapseTableOfContents: { type: 'boolean' },
+  tryItCredentialsPolicy: { type: 'string' },
 });

--- a/packages/elements/src/components/API/APIWithSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithSidebarLayout.tsx
@@ -22,6 +22,7 @@ type SidebarLayoutProps = {
   hideInternal?: boolean;
   hideExport?: boolean;
   exportProps?: ExportButtonProps;
+  tryItCredentialsPolicy?: 'omit' | 'include' | 'same-origin';
 };
 
 export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
@@ -32,6 +33,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
   hideInternal,
   hideExport,
   exportProps,
+  tryItCredentialsPolicy,
 }) => {
   const container = React.useRef<HTMLDivElement>(null);
   const tree = React.useMemo(
@@ -91,6 +93,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
           location={location}
           allowRouting
           exportProps={exportProps}
+          tryItCredentialsPolicy={tryItCredentialsPolicy}
         />
       )}
     </SidebarLayout>

--- a/packages/elements/src/components/API/APIWithStackedLayout.tsx
+++ b/packages/elements/src/components/API/APIWithStackedLayout.tsx
@@ -15,18 +15,24 @@ import { useLocation } from 'react-router-dom';
 import { OperationNode, ServiceNode } from '../../utils/oas/types';
 import { computeTagGroups, TagGroup } from './utils';
 
+type TryItCredentialsPolicy = 'omit' | 'include' | 'same-origin';
+
 type StackedLayoutProps = {
   serviceNode: ServiceNode;
   hideTryIt?: boolean;
   hideExport?: boolean;
   exportProps?: ExportButtonProps;
+  tryItCredentialsPolicy?: TryItCredentialsPolicy;
 };
 
 const itemMatchesHash = (hash: string, item: OperationNode) => {
   return hash.substr(1) === `${item.name}-${item.data.method}`;
 };
 
-const TryItContext = React.createContext<{ hideTryIt?: boolean }>({ hideTryIt: false });
+const TryItContext = React.createContext<{ hideTryIt?: boolean; tryItCredentialsPolicy?: TryItCredentialsPolicy }>({
+  hideTryIt: false,
+  tryItCredentialsPolicy: 'omit',
+});
 TryItContext.displayName = 'TryItContext';
 
 export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({
@@ -34,12 +40,13 @@ export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({
   hideTryIt,
   hideExport,
   exportProps,
+  tryItCredentialsPolicy,
 }) => {
   const location = useLocation();
   const { groups } = computeTagGroups(serviceNode);
 
   return (
-    <TryItContext.Provider value={{ hideTryIt }}>
+    <TryItContext.Provider value={{ hideTryIt, tryItCredentialsPolicy }}>
       <Flex w="full" flexDirection="col" m="auto" className="sl-max-w-4xl">
         <Box w="full" borderB>
           <Docs
@@ -50,6 +57,7 @@ export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({
             location={location}
             layoutOptions={{ showPoweredByLink: true, hideExport }}
             exportProps={exportProps}
+            tryItCredentialsPolicy={tryItCredentialsPolicy}
           />
         </Box>
 
@@ -119,7 +127,7 @@ const Item = React.memo<{ item: OperationNode }>(({ item }) => {
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
   const color = HttpMethodColors[item.data.method] || 'gray';
   const isDeprecated = !!item.data.deprecated;
-  const { hideTryIt } = React.useContext(TryItContext);
+  const { hideTryIt, tryItCredentialsPolicy } = React.useContext(TryItContext);
 
   const onClick = React.useCallback(() => setIsExpanded(!isExpanded), [isExpanded]);
 
@@ -182,7 +190,7 @@ const Item = React.memo<{ item: OperationNode }>(({ item }) => {
                 />
               </TabPanel>
               <TabPanel>
-                <TryItWithRequestSamples httpOperation={item.data} />
+                <TryItWithRequestSamples httpOperation={item.data} tryItCredentialsPolicy={tryItCredentialsPolicy} />
               </TabPanel>
             </TabPanels>
           </Tabs>

--- a/packages/elements/src/containers/API.tsx
+++ b/packages/elements/src/containers/API.tsx
@@ -73,6 +73,14 @@ export interface CommonAPIProps extends RoutingProps {
    * @default false
    */
   hideExport?: boolean;
+
+  /**
+   * Fetch credentials policy for TryIt component
+   * For more information: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+   * @default "omit"
+   */
+
+  tryItCredentialsPolicy?: 'omit' | 'include' | 'same-origin';
 }
 
 const propsAreWithDocument = (props: APIProps): props is APIPropsWithDocument => {
@@ -80,7 +88,16 @@ const propsAreWithDocument = (props: APIProps): props is APIPropsWithDocument =>
 };
 
 export const APIImpl: React.FC<APIProps> = props => {
-  const { layout, apiDescriptionUrl = '', logo, hideTryIt, hideSchemas, hideInternal, hideExport } = props;
+  const {
+    layout,
+    apiDescriptionUrl = '',
+    logo,
+    hideTryIt,
+    hideSchemas,
+    hideInternal,
+    hideExport,
+    tryItCredentialsPolicy,
+  } = props;
   const apiDescriptionDocument = propsAreWithDocument(props) ? props.apiDescriptionDocument : undefined;
 
   const { data: fetchedDocument, error } = useQuery(
@@ -142,6 +159,7 @@ export const APIImpl: React.FC<APIProps> = props => {
           hideTryIt={hideTryIt}
           hideExport={hideExport}
           exportProps={exportProps}
+          tryItCredentialsPolicy={tryItCredentialsPolicy}
         />
       ) : (
         <APIWithSidebarLayout
@@ -152,6 +170,7 @@ export const APIImpl: React.FC<APIProps> = props => {
           hideInternal={hideInternal}
           hideExport={hideExport}
           exportProps={exportProps}
+          tryItCredentialsPolicy={tryItCredentialsPolicy}
         />
       )}
     </InlineRefResolverProvider>

--- a/packages/elements/src/web-components/components.ts
+++ b/packages/elements/src/web-components/components.ts
@@ -13,4 +13,5 @@ export const ApiElement = createElementClass(API, {
   hideInternal: { type: 'boolean' },
   hideExport: { type: 'boolean' },
   logo: { type: 'string' },
+  tryItCredentialsPolicy: { type: 'string' },
 });


### PR DESCRIPTION
Addresses https://github.com/stoplightio/elements/issues/1548 
Based on @haseebeqx PR at https://github.com/stoplightio/elements/pull/1585

Adds support for setting credential policy in TryIt by adding the optional `tryItCredentialsPolicy` property.

@haseebeqx your PR is great, thanks for contribution. I've moved it here so it's not based on the fork and did some small changes:
- added similar property for `elements-dev-portal`
- removed redundant `tryItCredentialsPolicy` from `StackedLayout` - we're using TryIt separately there
- setting default value to `omit` in `build-request`
- added basic tests