### PR TITLE
fix: support examples with and without value prop

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.2.5",
+  "version": "7.2.6",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/utils/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration.ts
@@ -64,10 +64,11 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7): Example[] =
     });
   } else if (isPlainObject(schema?.['x-examples'])) {
     for (const [label, example] of Object.entries(schema['x-examples'])) {
-      if (isPlainObject(example) && example.hasOwnProperty('value')) {
+      if (isPlainObject(example)) {
+        const val = example.hasOwnProperty('value') && Object.keys(example).length === 1 ? example.value : example;
         examples.push({
           label,
-          data: safeStringify(example.value, undefined, 2) ?? '',
+          data: safeStringify(val, undefined, 2) ?? '',
         });
       }
     }


### PR DESCRIPTION
For https://github.com/stoplightio/platform-internal/issues/7698

`x-examples` can be defined with and without `value` and both should be supported:

```json
{
  "title": "User",
  "type": "object",
  "description": "",
  "x-examples": {
    "Alice Smith": {
      "id": 142,
      "firstName": "Alice",
      "lastName": "Smith",
      "email": "alice.smith@gmail.com",
      "dateOfBirth": "1997-10-31",
      "emailVerified": true,
      "signUpDate": "2019-08-24"
    },
    "example-2": {
      "value": {
        "id": 0,
        "firstName": "n",
        "lastName": "string",
        "email": "user@example.com",
        "dateOfBirth": "1997-10-31",
        "emailVerified": true,
        "createDate": "2019-08-24"
      }
    },
  },
  "properties": {
    "id": {
      "type": "integer",
      "description": "Unique identifier for the given user."
    },
    "firstName": {
      "type": "string"
    },
    "lastName": {
      "type": "string"
    },
    "email": {
      "type": "string",
      "format": "email"
    },
    "dateOfBirth": {
      "type": "string",
      "format": "date",
      "example": "1997-10-31"
    },
    "emailVerified": {
      "type": "boolean",
      "description": "Set to true if the user's email has been verified."
    },
    "createDate": {
      "type": "string",
      "format": "date",
      "description": "The date that the user was created."
    }
  }
}
```
