### PR TITLE
fix: allow large specs to load schema

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -49,7 +49,7 @@
     "@fortawesome/react-fontawesome": "^0.1.11",
     "@stoplight/json": "^3.10.0",
     "@stoplight/json-schema-ref-parser": "^9.0.5",
-    "@stoplight/json-schema-sampler": "0.2.0",
+    "@stoplight/json-schema-sampler": "0.2.1",
     "@stoplight/json-schema-viewer": "^4.3.1",
     "@stoplight/markdown": "^3.1.1",
     "@stoplight/markdown-viewer": "^5.3.2",

--- a/packages/elements-core/src/utils/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration.ts
@@ -78,13 +78,16 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7): Example[] =
     return examples;
   }
 
-  const generated = Sampler.sample(schema);
+  const generated = Sampler.sample(schema, {
+    skipNonRequired: true,
+  });
+
   return generated !== null
     ? [
-        {
-          label: 'default',
-          data: safeStringify(generated, undefined, 2) ?? '',
-        },
-      ]
+      {
+        label: 'default',
+        data: safeStringify(generated, undefined, 2) ?? '',
+      },
+    ]
     : [{ label: 'default', data: '' }];
 };

--- a/packages/elements-core/src/utils/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration.ts
@@ -84,10 +84,10 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7): Example[] =
 
   return generated !== null
     ? [
-      {
-        label: 'default',
-        data: safeStringify(generated, undefined, 2) ?? '',
-      },
-    ]
+        {
+          label: 'default',
+          data: safeStringify(generated, undefined, 2) ?? '',
+        },
+      ]
     : [{ label: 'default', data: '' }];
 };

--- a/packages/elements-core/src/utils/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration.ts
@@ -79,7 +79,7 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7): Example[] =
   }
 
   const generated = Sampler.sample(schema, {
-    skipNonRequired: true,
+    maxSampleDepth: 4,
   });
 
   return generated !== null

--- a/yarn.lock
+++ b/yarn.lock
@@ -3442,10 +3442,10 @@
     fastestsmallesttextencoderdecoder "^1.0.22"
     isomorphic-fetch "^3.0.0"
 
-"@stoplight/json-schema-sampler@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-sampler/-/json-schema-sampler-0.2.0.tgz#31215818ad0c571852fd201955a21a25bc0b77c2"
-  integrity sha512-FKMyGU8beAQCtNmuMNOxbMWDPJGVqSQqv5ESnId2O9Arzo7jPd3QUB6E95MnEcuKVaIQd2mk+d0+Isi7gJOJcA==
+"@stoplight/json-schema-sampler@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-sampler/-/json-schema-sampler-0.2.1.tgz#6c5fd8e17598ee573cc908935bd81dd0165d6a57"
+  integrity sha512-TtF9qJleGEcyPuG77c93MLAVNVvZKUPTQpvIaki5cIrJjWsFDBjAAzv6J2AGJEcY8YQscvZQRfv8eJ/ClwZOSA==
   dependencies:
     "@types/json-schema" "^7.0.7"
     json-pointer "^0.6.1"


### PR DESCRIPTION
Addresses #[7923](https://app.zenhub.com/workspaces/-team-pierogi-platoon-610871b8d6e5310013071b72/issues/stoplightio/platform-internal/7923)

Before: page becomes unresponsive when clicking around to models with circular refs

After:
![2021-09-16 11 41 45](https://user-images.githubusercontent.com/47359669/133653025-aeecc888-92ee-4883-a5a5-bc5a5584105d.gif)