### PR TITLE
feat: allow pausing getNodes query by passing prop

### DIFF
--- a/packages/elements-dev-portal/src/hooks/useGetNodes.ts
+++ b/packages/elements-dev-portal/src/hooks/useGetNodes.ts
@@ -10,16 +10,19 @@ export function useGetNodes({
   workspaceId,
   branchSlug,
   projectIds,
+  pause,
 }: {
   search: string;
   workspaceId?: string;
   branchSlug?: string;
   projectIds?: string[];
+  pause?: boolean;
 }) {
   const { platformUrl, platformAuthToken } = React.useContext(PlatformContext);
   const [debounceSearch] = useDebounce(search, 500);
   return useQuery(
     ['workspaceNodes', workspaceId, branchSlug, projectIds, debounceSearch, platformUrl, platformAuthToken],
     () => getNodes({ workspaceId, branchSlug, projectIds, search: debounceSearch, platformUrl, platformAuthToken }),
+    { enabled: pause ? false : true },
   );
 }

--- a/packages/elements-dev-portal/src/hooks/useGetNodes.ts
+++ b/packages/elements-dev-portal/src/hooks/useGetNodes.ts
@@ -23,6 +23,6 @@ export function useGetNodes({
   return useQuery(
     ['workspaceNodes', workspaceId, branchSlug, projectIds, debounceSearch, platformUrl, platformAuthToken],
     () => getNodes({ workspaceId, branchSlug, projectIds, search: debounceSearch, platformUrl, platformAuthToken }),
-    { enabled: pause ? false : true },
+    { enabled: !pause ? true : false },
   );
 }


### PR DESCRIPTION
A part of https://github.com/stoplightio/platform-internal/pull/8024

This allows to put the `useGetNodes` in the `idle` state when we explicitly tell it to (more about pausing queries in https://react-query.tanstack.com/guides/disabling-queries)

We could of course make the hook be in `idle` until `search` isn't falsy but this would change the current, default behavior of this hook. With this change we don't, you need to explicitely state if you want to pause the query or not. I was trying to mimick the behavior of `urql(..., { pause })` option