### PR TITLE
chore: release elements-dev-portal 1.4.0

### DIFF
--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [


### PR DESCRIPTION
Release:
- `elements-dev-portal`: 1.4.0

fix: remove unnecessary logic (#1774)
feat: allow pausing getNodes query by passing prop (#1773)