### PR TITLE
fix: skip content type for multipart request

### DIFF
--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -401,7 +401,7 @@ describe('TryIt', () => {
       });
 
       it('Sets correct content type', () => {
-        expect(headers.get('Content-Type')).toBe(mimeType);
+        expect(headers.get('Content-Type')).toBe(mimeType === 'multipart/form-data' ? null : mimeType);
       });
 
       it('Sends user input', () => {

--- a/packages/elements-core/src/components/TryIt/build-request.ts
+++ b/packages/elements-core/src/components/TryIt/build-request.ts
@@ -84,7 +84,10 @@ export async function buildFetchRequest({
   const body = typeof bodyInput === 'object' ? await createRequestBody(mediaTypeContent, bodyInput) : bodyInput;
 
   const headers = {
-    'Content-Type': mediaTypeContent?.mediaType ?? 'application/json',
+    // do not include multipart/form-data - browser handles its content type and boundary
+    ...(mediaTypeContent?.mediaType !== 'multipart/form-data' && {
+      'Content-Type': mediaTypeContent?.mediaType ?? 'application/json',
+    }),
     ...Object.fromEntries(headersWithAuth.map(nameAndValueObjectToPair)),
     ...mockData?.header,
   };


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/7851

The bug was occurring because we were including `content-type` header to every fetch request. The result, in this case, was`multipart/form-data` with no boundary which was failing. 
The solution is to not include content type at all and let browser handle it along with the boundary.
