### PR TITLE
chore: release

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.3.3",
+  "version": "7.3.4",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
-    "@stoplight/elements-core": "~7.3.3",
+    "@stoplight/elements-core": "~7.3.4",
     "@stoplight/markdown-viewer": "^5.3.2",
     "@stoplight/mosaic": "^1.2.4",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.3.1';
+export const appVersion = '1.4.1';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.3.3",
+  "version": "7.3.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -49,7 +49,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.31",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "@stoplight/elements-core": "~7.3.3",
+    "@stoplight/elements-core": "~7.3.4",
     "@stoplight/http-spec": "^4.2.2",
     "@stoplight/json": "^3.10.0",
     "@stoplight/mosaic": "1.5.0",


### PR DESCRIPTION
elements-core@7.3.4
elements@7.3.4
elements-dev-portal@1.4.1

Changes:
fix: skip content type for multipart request (#1778)
Adds search to TOC (#1771)
chore: release elements-dev-portal 1.4.0 (#1775)
fix: remove unnecessary logic (#1774)
feat: allow pausing getNodes query by passing prop (#1773)