### PR TITLE
fix: default values for optional parameters

### DIFF
--- a/packages/elements-core/src/__fixtures__/operations/multipart-formdata-post.ts
+++ b/packages/elements-core/src/__fixtures__/operations/multipart-formdata-post.ts
@@ -30,7 +30,11 @@ export const httpOperation: IHttpOperation = {
               completed: {
                 type: 'boolean',
               },
-              someEnum: {
+              someRequiredEnum: {
+                type: 'string',
+                enum: ['a', 'b', 'c'],
+              },
+              someOptionalEnum: {
                 type: 'string',
                 enum: ['a', 'b', 'c'],
               },
@@ -39,7 +43,7 @@ export const httpOperation: IHttpOperation = {
                 contentMediaType: 'application/octet-stream',
               },
             },
-            required: ['name', 'completed'],
+            required: ['name', 'completed', 'someRequiredEnum'],
           },
         },
       ],

--- a/packages/elements-core/src/__fixtures__/operations/put-todos.ts
+++ b/packages/elements-core/src/__fixtures__/operations/put-todos.ts
@@ -333,6 +333,7 @@ export const httpOperation: IHttpOperation = {
         deprecated: true,
         description: 'How many string todos to limit?',
         name: 'value',
+        required: true,
         style: HttpParamStyles.Form,
       },
       {
@@ -358,6 +359,7 @@ export const httpOperation: IHttpOperation = {
           enum: ['something', 'another'],
         },
         name: 'type',
+        required: true,
         style: HttpParamStyles.SpaceDelimited,
       },
       {

--- a/packages/elements-core/src/__fixtures__/operations/request-body.ts
+++ b/packages/elements-core/src/__fixtures__/operations/request-body.ts
@@ -46,7 +46,7 @@ export const requestBody: IHttpOperation = {
               completed: { type: 'boolean' },
               someEnum: { type: 'string', enum: ['a', 'b', 'c'] },
             },
-            required: ['name', 'completed'],
+            required: ['name', 'completed', 'someEnum'],
           },
         },
       ],

--- a/packages/elements-core/src/__fixtures__/operations/urlencoded-post.ts
+++ b/packages/elements-core/src/__fixtures__/operations/urlencoded-post.ts
@@ -30,12 +30,16 @@ export const httpOperation: IHttpOperation = {
               completed: {
                 type: 'boolean',
               },
-              someEnum: {
+              someRequiredEnum: {
+                type: 'string',
+                enum: ['a', 'b', 'c'],
+              },
+              someOptionalEnum: {
                 type: 'string',
                 enum: ['a', 'b', 'c'],
               },
             },
-            required: ['name', 'completed'],
+            required: ['name', 'completed', 'someRequiredEnum'],
           },
         },
       ],

--- a/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
+++ b/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
@@ -18,6 +18,7 @@ interface FormDataBodyProps {
 export const FormDataBody: React.FC<FormDataBodyProps> = ({ specification, values, onChangeValues }) => {
   const schema = specification.schema;
   const parameters = schema?.properties;
+  const required = schema?.required;
 
   React.useEffect(() => {
     if (parameters === undefined) {
@@ -33,7 +34,7 @@ export const FormDataBody: React.FC<FormDataBodyProps> = ({ specification, value
     <Panel defaultIsOpen>
       <Panel.Titlebar>Body</Panel.Titlebar>
       <Panel.Content className="sl-overflow-y-auto ParameterGrid OperationParametersContent">
-        {mapSchemaPropertiesToParameters(parameters).map(parameter => {
+        {mapSchemaPropertiesToParameters(parameters, required).map(parameter => {
           const supportsFileUpload = parameterSupportsFileUpload(parameter);
           const value = values[parameter.name];
 

--- a/packages/elements-core/src/components/TryIt/Body/request-body-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Body/request-body-utils.ts
@@ -79,7 +79,8 @@ export const useBodyParameterState = (mediaTypeContent: IMediaTypeContent | unde
       return {};
     }
     const properties = mediaTypeContent?.schema?.properties ?? {};
-    const parameters = mapSchemaPropertiesToParameters(properties);
+    const required = mediaTypeContent?.schema?.required;
+    const parameters = mapSchemaPropertiesToParameters(properties, required);
     return initialParameterValues(parameters);
   }, [isFormDataBody, mediaTypeContent]);
 

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
@@ -13,7 +13,6 @@ describe('Parameter Utils', () => {
       const parameters = initialParameterValues(allParameters);
 
       expect(parameters).toMatchObject({
-        limit: '1',
         type: 'something',
         value: '1',
         'account-id': 'example id',

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -70,9 +70,8 @@ const getValueForParameter = (parameter: ParameterSpec) => {
 
 const getInitialValueForParameter = (parameter: ParameterSpec) => {
   const isRequired = !!parameter.required;
-  const isEnum = !!parameter.schema?.enum;
 
-  if (!isEnum && !isRequired) return '';
+  if (!isRequired) return '';
 
   return getValueForParameter(parameter);
 };
@@ -82,10 +81,14 @@ export const initialParameterValues: (params: readonly ParameterSpec[]) => Recor
   mapValues(getInitialValueForParameter),
 );
 
-export function mapSchemaPropertiesToParameters(properties: { [key: string]: JSONSchema7Definition }) {
+export function mapSchemaPropertiesToParameters(
+  properties: { [key: string]: JSONSchema7Definition },
+  required: string[] | undefined,
+) {
   return Object.entries(properties).map(([name, schema]) => ({
     name,
     schema: typeof schema !== 'boolean' ? schema : undefined,
     examples: typeof schema !== 'boolean' && schema.examples ? [{ key: 'example', value: schema.examples }] : undefined,
+    ...(required?.includes(name) && { required: true }),
   }));
 }

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -83,7 +83,7 @@ export const initialParameterValues: (params: readonly ParameterSpec[]) => Recor
 
 export function mapSchemaPropertiesToParameters(
   properties: { [key: string]: JSONSchema7Definition },
-  required?: string[],
+  required: string[] | undefined,
 ) {
   return Object.entries(properties).map(([name, schema]) => ({
     name,

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -1,6 +1,6 @@
 import { safeStringify } from '@stoplight/json';
 import { IHttpParam, INodeExample, INodeExternalExample } from '@stoplight/types';
-import { JSONSchema7Definition } from 'json-schema';
+import { JSONSchema7Definition, JSONSchema7Type } from 'json-schema';
 import { isObject, map } from 'lodash';
 import { keyBy, mapValues, pipe } from 'lodash/fp';
 
@@ -11,11 +11,16 @@ const booleanOptions = [
   { label: 'True', value: 'true' },
 ];
 
+function enumOptions(enumValues: JSONSchema7Type[], required?: boolean) {
+  const options = map(enumValues, v => ({ value: Number.isNaN(Number(v)) ? String(v) : Number(v) }));
+  return required ? options : [{ label: 'Not Set', value: '' }, ...options];
+}
+
 export function parameterOptions(parameter: ParameterSpec) {
   return parameter.schema?.type === 'boolean'
     ? booleanOptions
     : parameter.schema?.enum !== undefined
-    ? map(parameter.schema.enum, v => ({ value: Number.isNaN(Number(v)) ? String(v) : Number(v) }))
+    ? enumOptions(parameter.schema.enum, parameter.required)
     : null;
 }
 

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -83,7 +83,7 @@ export const initialParameterValues: (params: readonly ParameterSpec[]) => Recor
 
 export function mapSchemaPropertiesToParameters(
   properties: { [key: string]: JSONSchema7Definition },
-  required: string[] | undefined,
+  required?: string[],
 ) {
   return Object.entries(properties).map(([name, schema]) => ({
     name,

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -233,7 +233,7 @@ describe('TryIt', () => {
 
       // query params
       const limitField = screen.getByLabelText('limit');
-      expect(limitField).toHaveTextContent('1');
+      expect(limitField).toHaveTextContent('select an option');
 
       const typeField = screen.getByLabelText('type');
       expect(typeField).toHaveTextContent('something');
@@ -412,8 +412,11 @@ describe('TryIt', () => {
         expect(body.get('completed')).toBe('');
       });
 
-      it('Sets untouched enums to their first value', () => {
-        expect(body.get('someEnum')).toBe('a');
+      it('Sets untouched required enums to their first value', () => {
+        expect(body.get('someRequiredEnum')).toBe('a');
+      });
+      it('Does not set untouched optional enums', () => {
+        expect(body.get('someOptionalEnum')).toBe('');
       });
     });
 

--- a/packages/elements-dev-portal/src/handlers/getTableOfContents.ts
+++ b/packages/elements-dev-portal/src/handlers/getTableOfContents.ts
@@ -12,7 +12,6 @@ export const getTableOfContents = async ({
   platformUrl?: string;
   platformAuthToken?: string;
 }): Promise<ProjectTableOfContents> => {
-  console.log('version: ', appVersion);
   const branchQuery = branchSlug ? `?branch=${branchSlug}` : '';
   const response = await fetch(`${platformUrl}/api/v1/projects/${projectId}/table-of-contents${branchQuery}`, {
     headers: {


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/7664

Removes default value from optional enum parameters.
Adds `required` property when mapping from JsonSchema to OpenApi parameter schema.


Simple API document for testing: [api](https://github.com/stoplightio/platform-internal/files/7016097/5547.zip)