### PR TITLE
fix: do not include prefer header with no mock data

### DIFF
--- a/packages/elements-core/src/components/TryIt/Mocking/mocking-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Mocking/mocking-utils.ts
@@ -22,7 +22,10 @@ export function getMockData(
 export function buildPreferHeader(
   { code, example, dynamic }: PreferHeaderProps,
   httpOperation: IHttpOperation,
-): Record<'Prefer', string> {
+): Record<'Prefer', string> | undefined {
+  if (!code) {
+    return undefined;
+  }
   const isCodeSupported = supportsResponseCode(httpOperation, code);
   const isExampleSupported = isCodeSupported && supportsExample(httpOperation, code, example);
 

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -676,6 +676,36 @@ describe('TryIt', () => {
       ]);
     });
 
+    it('Invokes request with no Prefer header if mock data is not selected', async () => {
+      render(<TryItWithPersistence httpOperation={basicOperation} mockUrl="https://mock-todos.stoplight.io" />);
+
+      const mockingButton = screen.getByRole('button', { name: /mocking/i });
+
+      userEvent.click(mockingButton);
+
+      let enableItem = await screen.getByRole('menuitemcheckbox', { name: 'Enabled' });
+      expect(enableItem).toBeInTheDocument();
+      userEvent.click(enableItem);
+
+      clickSend();
+
+      await waitFor(() => expect(screen.getByRole('button', { name: /send/i })).toBeEnabled());
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+      expect(fetchMock.mock.calls).toEqual([
+        [
+          'https://mock-todos.stoplight.io/todos',
+          expect.objectContaining({
+            method: 'GET',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }),
+        ],
+      ]);
+    });
+
     it('Persists mocking options between operations', async () => {
       const { rerender } = render(
         <MosaicProvider>


### PR DESCRIPTION
Addresses https://github.com/stoplightio/elements/issues/1757

Prevents adding `Prefer` header when no mocking options are selected

![Screenshot 2021-09-24 at 11 31 49](https://user-images.githubusercontent.com/14196079/134652710-0dccfb36-1e45-4874-a345-44d1497e5dd1.png)


