### PR TITLE
fix: apiDescriptionDocument input in storybook

### DIFF
--- a/packages/elements/src/containers/API.stories.tsx
+++ b/packages/elements/src/containers/API.stories.tsx
@@ -42,13 +42,13 @@ APIWithJSONProvidedDirectly.storyName = 'Direct JSON Input (Zoom)';
 
 export const APIWithoutDescription = Template.bind({});
 APIWithoutDescription.args = {
-  apiDescriptionDocument: simpleApiWithoutDescription,
+  apiDescriptionDocument: JSON.stringify(simpleApiWithoutDescription, undefined, 2),
 };
 APIWithoutDescription.storyName = 'API Without Description';
 
 export const APIWithInternalOperations = Template.bind({});
 APIWithInternalOperations.args = {
-  apiDescriptionDocument: simpleApiWithInternalOperations,
+  apiDescriptionDocument: JSON.stringify(simpleApiWithInternalOperations, undefined, 2),
 };
 APIWithInternalOperations.storyName = 'API With Internal Operations';
 

--- a/packages/elements/src/containers/API.stories.tsx
+++ b/packages/elements/src/containers/API.stories.tsx
@@ -42,13 +42,13 @@ APIWithJSONProvidedDirectly.storyName = 'Direct JSON Input (Zoom)';
 
 export const APIWithoutDescription = Template.bind({});
 APIWithoutDescription.args = {
-  apiDescriptionDocument: JSON.stringify(simpleApiWithoutDescription, undefined, 2),
+  apiDescriptionDocument: JSON.stringify(simpleApiWithoutDescription, null, 2),
 };
 APIWithoutDescription.storyName = 'API Without Description';
 
 export const APIWithInternalOperations = Template.bind({});
 APIWithInternalOperations.args = {
-  apiDescriptionDocument: JSON.stringify(simpleApiWithInternalOperations, undefined, 2),
+  apiDescriptionDocument: JSON.stringify(simpleApiWithInternalOperations, null, 2),
 };
 APIWithInternalOperations.storyName = 'API With Internal Operations';
 


### PR DESCRIPTION
I've noticed that some fields in storybook are not displayed properly, which makes testing and debugging a bit more difficult (at least for me):

Before:

<img width="395" alt="Screenshot 2021-09-28 at 11 32 53" src="https://user-images.githubusercontent.com/7916523/135062547-11a3a9e8-adc1-450d-a15e-bb292fd03527.png">

After:

<img width="528" alt="Screenshot 2021-09-28 at 11 31 02" src="https://user-images.githubusercontent.com/7916523/135062579-21e9e5fb-b018-4b61-827a-5976b6f081ff.png">
