### PR TITLE
fix: use custom code component in mdv provider

### DIFF
--- a/packages/elements-core/.storybook/preview.jsx
+++ b/packages/elements-core/.storybook/preview.jsx
@@ -2,7 +2,7 @@ export * from '../../../.storybook/preview';
 
 import * as React from "react";
 import {subscribeTheme, Provider as MosaicProvider} from "@stoplight/mosaic";
-import {PersistenceContextProvider, Styled} from "../src";
+import {PersistenceContextProvider, Styled, MarkdownComponentsProvider} from "../src";
 import '../src/styles.css';
 
 
@@ -25,8 +25,12 @@ const PersistenceBoundaryDecorator = (Story) => (
   <PersistenceContextProvider><Story /></PersistenceContextProvider>
 );
 
+const MarkdownComponentsProviderDecorator = (Story) => (
+  <MarkdownComponentsProvider><Story /></MarkdownComponentsProvider>
+);
+
 const StyledDecorator = (Story) => (
   <Styled><Story/></Styled>
 );
 
-export const decorators = [ThemeProvider, MosaicProviderDecorator, PersistenceBoundaryDecorator, StyledDecorator];
+export const decorators = [ThemeProvider, MosaicProviderDecorator, PersistenceBoundaryDecorator, StyledDecorator, MarkdownComponentsProviderDecorator];

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/Provider.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/Provider.tsx
@@ -5,6 +5,8 @@ import {
 } from '@stoplight/markdown-viewer';
 import * as React from 'react';
 
+import { CodeComponent } from './CodeComponent';
+
 export type CustomComponentMapping = MDVCustomComponentMapping;
 
 export { DefaultSMDComponents };
@@ -16,5 +18,5 @@ interface MarkdownComponentsProviderProps {
  * Provides components to markdown-viewer.
  */
 export const MarkdownComponentsProvider: React.FC<MarkdownComponentsProviderProps> = ({ value, children }) => {
-  return <MarkdownViewerProvider components={value}>{children}</MarkdownViewerProvider>;
+  return <MarkdownViewerProvider components={{ code: CodeComponent!, ...value }}>{children}</MarkdownViewerProvider>;
 };


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/8048
Addresses: https://github.com/stoplightio/platform-internal/issues/8047

When [cleaning up](https://github.com/stoplightio/elements/pull/1754/files) markdown viewer providers we didn't add custom code component, and markdown viewer doesn't provide it itself. The result was that the default code component was used and both `json_schema` and `http` types weren't there.

This PR adds code component to provider default props and makes `elements-core` storybook use it. 

`elements-dev-portal` is already using that provider in `NodeContent` so no need to change anything there.