### PR TITLE
chore: remove unused swr dep

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -73,7 +73,6 @@
     "react-query": "^3.15.2",
     "react-router-dom": "^5.2.0",
     "react-router-hash-link": "^2.1.0",
-    "swr": "^0.3.0",
     "tslib": "^2.1.0",
     "unist-util-select": "^3.0.1",
     "urijs": "^1.19.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8947,11 +8947,6 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
-dequal@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
-  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
-
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -20928,13 +20923,6 @@ svgo@^2.3.0:
     csso "^4.2.0"
     nanocolors "^0.1.12"
     stable "^0.1.8"
-
-swr@^0.3.0:
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-0.3.11.tgz#f7f50ed26c06afea4249482cec504768a2272664"
-  integrity sha512-ya30LuRGK2R7eDlttnb7tU5EmJYJ+N6ytIOM2j0Hqs0qauJcDjVLDOGy7KmFeH5ivOwLHalFaIyYl2K+SGa7HQ==
-  dependencies:
-    dequal "2.0.2"
 
 symbol-observable@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
I noticed `swr` isn't used anymore. It was likely left over from v6 before we switched over to using `react-query`.

![image](https://user-images.githubusercontent.com/7423098/138795877-d0dbae18-eadb-4640-aaec-941dfa4156c8.png)
