### PR TITLE
chore: release 7.3.8

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.3.7",
+  "version": "7.3.8",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [


### PR DESCRIPTION
releases fix for: https://github.com/stoplightio/elements/issues/1805.

PR that it releases is: https://github.com/stoplightio/elements/pull/1830