### PR TITLE
fix: merging titles in schemas with nested allofs

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -50,7 +50,7 @@
     "@stoplight/json": "^3.10.0",
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.2",
-    "@stoplight/json-schema-viewer": "^4.3.1",
+    "@stoplight/json-schema-viewer": "^4.3.3",
     "@stoplight/markdown": "^3.1.1",
     "@stoplight/markdown-viewer": "^5.3.2",
     "@stoplight/mosaic": "^1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3549,10 +3549,10 @@
     type-is "^1.6.18"
     urijs "~1.19.2"
 
-"@stoplight/json-schema-merge-allof@^0.7.5":
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-merge-allof/-/json-schema-merge-allof-0.7.6.tgz#39efac12a497ed29a06ae48e0141885634a045a4"
-  integrity sha512-xLbJC2VOd9AxO1VvvgyP/mWOqZbeg6mLpYzlzU4egDTTIrTsSqtv+yFakpPciuuMlOmJU/KzZK9C5AbMgE+VgQ==
+"@stoplight/json-schema-merge-allof@^0.7.7":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-merge-allof/-/json-schema-merge-allof-0.7.7.tgz#d79ca8729aa5d6420e40cc545b1854b518b9240f"
+  integrity sha512-3QrZ+2hhTvsPAjl8HD9rQI3MPHSCl/kCf0rEkKM4YjLumDsfX1TSrhESDIt4lSzpSdNyT2oXSJx0ADVGE2gTyA==
   dependencies:
     compute-lcm "^1.1.0"
     json-schema-compare "^0.2.2"
@@ -3579,25 +3579,25 @@
     "@types/json-schema" "^7.0.7"
     json-pointer "^0.6.1"
 
-"@stoplight/json-schema-tree@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-tree/-/json-schema-tree-2.1.1.tgz#d4f157a32081f579fddfd2d3d598c79a591e94b7"
-  integrity sha512-NAO3vHHnEzNy4oShzHS6RVuyks4FBhleRVsz9r3o1aGRYqZxkjVo4ICihldB3zr2Q/8L4i1NucT60JlBYU09RQ==
+"@stoplight/json-schema-tree@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-tree/-/json-schema-tree-2.1.2.tgz#8896de9ac86a50349b1b18680dd72dfd18fe3f87"
+  integrity sha512-vku6rfILxyQOYlWT2pd+mAQuoA4apzvzGrZY9CEhgu0U2dvuZwtYMAcaSN4TL+UuiJdUsD345QrXNv4gxcabVg==
   dependencies:
     "@stoplight/json" "^3.12.0"
-    "@stoplight/json-schema-merge-allof" "^0.7.5"
+    "@stoplight/json-schema-merge-allof" "^0.7.7"
     "@stoplight/lifecycle" "^2.3.2"
     "@types/json-schema" "^7.0.7"
     magic-error "0.0.1"
 
-"@stoplight/json-schema-viewer@^4.3.1":
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.3.2.tgz#f6b8f43ccf08efcbd8f05555e80d11b2318d206f"
-  integrity sha512-IBch2Jcwi35r+V0WnZf5FCeCmYJewO4aAAqk+ykOgjT294N+uJ8eK4lWYboJP+r2NYJPnkbebH5WwbL/EuQ5TQ==
+"@stoplight/json-schema-viewer@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.3.3.tgz#fbee20e7853a95c51d0f27fce37fa5923c7eff48"
+  integrity sha512-DOLa+TBhdOXl0M0sMy4nQZ6fr/OHcDVwjT3uWWwmlVPCBErtse6QOH7kMo7TCJhNR91JHI9zuUEClaxmJBt+YA==
   dependencies:
     "@fortawesome/free-solid-svg-icons" "^5.15.2"
     "@stoplight/json" "^3.10.0"
-    "@stoplight/json-schema-tree" "^2.1.1"
+    "@stoplight/json-schema-tree" "^2.1.2"
     "@stoplight/react-error-boundary" "^2.0.0"
     "@types/json-schema" "^7.0.7"
     classnames "^2.2.6"


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/8463
Bumps `json-schema-viewer`.

Fixes merging nested `allOf` combiners where titles were always picked from the last element making schemas with nested `allOf`s have incorrect titles.

Example of api document with mentioned nested combiners:
```
openapi: 3.1.0
info:
  title: Combiners
  version: '1.0'
servers:
  - url: 'http://localhost:3000'
paths:
  /user:
    get:
      summary: Get user
      operationId: get-user
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                anyOf:
                  - allOf:
                      - type: object
                        properties:
                          test:
                            type: string
                      - $ref: '#/components/schemas/User'
                  - allOf:
                      - type: object
                        properties:
                          test:
                            type: string
                      - $ref: '#/components/schemas/Account'
components:
  schemas:
    User:
      title: User
      description: ''
      examples:
        - id: 142
          firstName: Alice
          lastName: Smith
          email: alice.smith@gmail.com
          dateOfBirth: '1997-10-31'
          emailVerified: true
          signUpDate: '2019-08-24'
      allOf:
        - type: object
          properties:
            userId:
              type: integer
              description: Unique identifier for the given user.
          required:
            - userId
        - $ref: '#/components/schemas/Object'
    Object:
      title: InnerObject
      type: object
      properties:
        name:
          type: string
    Account:
      title: Account
      allOf:
        - type: object
          properties:
            id:
              type: string
        - $ref: '#/components/schemas/Object'

```

