### PR TITLE
chore: remove lodash/fp methods

### DIFF
--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -1,8 +1,7 @@
 import { safeStringify } from '@stoplight/json';
 import { IHttpParam, INodeExample, INodeExternalExample } from '@stoplight/types';
 import { JSONSchema7Definition, JSONSchema7Type } from 'json-schema';
-import { isObject, map } from 'lodash';
-import { keyBy, mapValues, pipe } from 'lodash/fp';
+import _, { isObject, map } from 'lodash';
 
 export type ParameterSpec = Pick<IHttpParam, 'name' | 'examples' | 'schema' | 'required'>;
 const booleanOptions = [
@@ -81,10 +80,12 @@ const getInitialValueForParameter = (parameter: ParameterSpec) => {
   return getValueForParameter(parameter);
 };
 
-export const initialParameterValues: (params: readonly ParameterSpec[]) => Record<string, string> = pipe(
-  keyBy((param: ParameterSpec) => param.name),
-  mapValues(getInitialValueForParameter),
-);
+export const initialParameterValues: (params: readonly ParameterSpec[]) => Record<string, string> = params => {
+  return _.chain(params)
+    .keyBy((param: ParameterSpec) => param.name)
+    .mapValues(param => getInitialValueForParameter(param))
+    .value();
+};
 
 export function mapSchemaPropertiesToParameters(
   properties: { [key: string]: JSONSchema7Definition },

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -8,7 +8,7 @@ import {
   withStyles,
 } from '@stoplight/elements-core';
 import { Box, Flex, Icon, Input, ListBox, ListBoxItem, Modal, ModalProps } from '@stoplight/mosaic';
-import { pipe } from 'lodash/fp';
+import { flow } from 'lodash';
 import * as React from 'react';
 
 import { NodeSearchResult } from '../../types';
@@ -124,7 +124,7 @@ const SearchImpl = ({ search, searchResults, isOpen, onClose, onClick, onSearch 
   );
 };
 
-export const Search = pipe(
+export const Search = flow(
   withStyles,
   withPersistenceBoundary,
   withMosaicProvider,

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -8,7 +8,7 @@ import {
   withQueryClientProvider,
   withStyles,
 } from '@stoplight/elements-core';
-import { pipe } from 'lodash/fp';
+import { flow } from 'lodash';
 import * as React from 'react';
 import { Link, Redirect, Route, useHistory, useParams } from 'react-router-dom';
 
@@ -201,7 +201,7 @@ const StoplightProjectRouter = ({ platformUrl, basePath = '/', router, ...props 
 /**
  * The StoplightProject component displays a traditional documentation UI for an existing Stoplight Project.
  */
-export const StoplightProject = pipe(
+export const StoplightProject = flow(
   withStyles,
   withPersistenceBoundary,
   withMosaicProvider,

--- a/packages/elements-utils/src/toc/toc.ts
+++ b/packages/elements-utils/src/toc/toc.ts
@@ -1,27 +1,26 @@
 import { dirname, sep } from '@stoplight/path';
 import { NodeType } from '@stoplight/types';
-import { escapeRegExp, partial, sortBy } from 'lodash';
-import { pipe } from 'lodash/fp';
+import { escapeRegExp, flow, partial, sortBy } from 'lodash';
 
 import { Group, isDivider, isGroup, isItem, ITableOfContents, Item, NodeData, TableOfContentItem } from './types';
 
 type SchemaType = 'divider' | 'group';
 
 export function generateProjectToC(searchResults: NodeData[]) {
-  return pipe(
+  return flow(
     () => searchResults,
     groupNodesByType,
     ({ articles, models, httpServices, httpOperations }) => {
       const toc: ITableOfContents = { items: [] };
 
       // Articles
-      pipe(() => articles, sortArticlesByTypeAndPath, appendArticlesToToC(toc))();
+      flow(() => articles, sortArticlesByTypeAndPath, appendArticlesToToC(toc))();
 
       if (httpServices.length > 0) {
         toc.items.push({ type: 'divider', title: 'APIS' });
       }
 
-      pipe(
+      flow(
         () => httpServices,
         httpServices =>
           appendHttpServicesToToC(toc)({
@@ -38,21 +37,21 @@ export function generateProjectToC(searchResults: NodeData[]) {
 }
 
 export function generateTocSkeleton(searchResults: NodeData[]) {
-  return pipe(
+  return flow(
     () => searchResults,
     groupNodesByType,
     ({ articles, models, httpServices }) => {
       const toc: ITableOfContents = { items: [] };
 
       // Articles
-      pipe(() => articles, sortArticlesByTypeAndPath, appendArticlesToToC(toc))();
+      flow(() => articles, sortArticlesByTypeAndPath, appendArticlesToToC(toc))();
 
       // HTTP Services
       toc.items.push({ type: 'divider', title: 'APIS' });
-      pipe(() => httpServices, appendHttpServicesItemsToToC(toc))();
+      flow(() => httpServices, appendHttpServicesItemsToToC(toc))();
 
       // Models
-      pipe(() => models, appendModelsToToc(toc))();
+      flow(() => models, appendModelsToToc(toc))();
 
       return toc;
     },
@@ -90,7 +89,7 @@ function cleanToc(toc: ITableOfContents) {
 
 export function resolveHttpServices(searchResults: NodeData[], toc: ITableOfContents) {
   cleanToc(toc);
-  pipe(
+  flow(
     () => searchResults,
     groupNodesByType,
     ({ models, httpServices, httpOperations }) => {
@@ -199,7 +198,7 @@ export function appendArticlesToToC(toc: ITableOfContents) {
   return (articles: NodeData[]) => {
     return articles.reduce<ITableOfContents>(
       (toc, article) =>
-        pipe(partial(getDirsFromUri, article.uri), findOrCreateArticleGroup(toc), group => {
+        flow(partial(getDirsFromUri, article.uri), findOrCreateArticleGroup(toc), group => {
           group.items.push({ type: 'item', title: article.name, uri: article.uri });
           return toc;
         })(),
@@ -339,7 +338,7 @@ export function appendHttpServicesToToC(toc: ITableOfContents) {
       tocNode = { type: 'group', title: httpService.name, items: [], uri: httpService.uri };
       toc.items.push(tocNode);
 
-      pipe(
+      flow(
         () => ({
           httpOperations,
           models,

--- a/packages/elements/src/containers/API.spec.tsx
+++ b/packages/elements/src/containers/API.spec.tsx
@@ -8,7 +8,7 @@ import {
 } from '@stoplight/elements-core';
 import { render, screen } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
-import { pipe } from 'lodash/fp';
+import { flow } from 'lodash';
 import * as React from 'react';
 import { Route, Router } from 'react-router';
 
@@ -16,7 +16,7 @@ import { InstagramAPI } from '../__fixtures__/api-descriptions/Instagram';
 import { simpleApiWithoutDescription } from '../__fixtures__/api-descriptions/simpleApiWithoutDescription';
 import { API, APIImpl } from './API';
 
-export const APIWithoutRouter = pipe(
+export const APIWithoutRouter = flow(
   withStyles,
   withPersistenceBoundary,
   withMosaicProvider,

--- a/packages/elements/src/containers/API.tsx
+++ b/packages/elements/src/containers/API.tsx
@@ -11,7 +11,7 @@ import {
   withStyles,
 } from '@stoplight/elements-core';
 import { Box, Flex, Icon } from '@stoplight/mosaic';
-import { pipe } from 'lodash/fp';
+import { flow } from 'lodash';
 import * as React from 'react';
 import { useQuery } from 'react-query';
 
@@ -187,7 +187,7 @@ export const APIImpl: React.FC<APIProps> = props => {
   );
 };
 
-export const API = pipe(
+export const API = flow(
   withRouter,
   withStyles,
   withPersistenceBoundary,


### PR DESCRIPTION
Resolves: #1809

Replaces `lodash/fp` methods with those from `lodash`