### PR TITLE
chore: release elements

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.3.9",
+  "version": "7.3.10",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
-    "@stoplight/elements-core": "~7.3.9",
+    "@stoplight/elements-core": "~7.3.10",
     "@stoplight/markdown-viewer": "^5.3.2",
     "@stoplight/mosaic": "^1.12.4",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-utils/package.json
+++ b/packages/elements-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-utils",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "homepage": "https://github.com/stoplightio/elements",
   "bugs": "https://github.com/stoplightio/elements/issues",
   "author": "Stoplight <support@stoplight.io>",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.3.10",
+  "version": "7.3.11",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -49,7 +49,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.31",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "@stoplight/elements-core": "~7.3.9",
+    "@stoplight/elements-core": "~7.3.10",
     "@stoplight/http-spec": "^4.2.2",
     "@stoplight/json": "^3.10.0",
     "@stoplight/mosaic": "^1.12.4",


### PR DESCRIPTION
elements-core: `7.3.9` -> `7.3.10`
elements: `7.3.10` -> `7.3.11`
elements-dev-portal: `1.4.6` -> `1.4.7`
elements-utils: `7.1.1` -> `7.1.2`

- chore: remove lodash/fp methods (#1850)