### PR TITLE
fix (elements-dev-portal): anchor tags stripped from uri

### DIFF
--- a/packages/elements-core/src/components/MosaicTableOfContents/types.ts
+++ b/packages/elements-core/src/components/MosaicTableOfContents/types.ts
@@ -10,7 +10,6 @@ export type TableOfContentsProps = {
 export type CustomLinkComponent = React.ComponentType<{
   to: string;
   className?: string;
-  hash?: string;
   children: React.ReactNode;
 }>;
 

--- a/packages/elements-core/src/index.ts
+++ b/packages/elements-core/src/index.ts
@@ -8,6 +8,7 @@ export {
   DefaultSMDComponents,
   MarkdownComponentsProvider,
 } from './components/MarkdownViewer/CustomComponents/Provider';
+export { ReactRouterMarkdownLink } from './components/MarkdownViewer/CustomComponents/ReactRouterLink';
 export { TableOfContents } from './components/MosaicTableOfContents';
 export {
   CustomLinkComponent,

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -127,6 +127,7 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
     );
 
     if (edge) {
+      console.log('Edge Found ', edge);
       return <Link to={`${edge.slug}${hash && `#${hash}`}`}>{children}</Link>;
     }
   }

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -127,11 +127,7 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
     );
 
     if (edge) {
-      return (
-        <Link to={edge.slug} hash={hash}>
-          {children}
-        </Link>
-      );
+      return <Link to={`${edge.slug}${hash && `#${hash}`}`}>{children}</Link>;
     }
   }
 

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -127,7 +127,6 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
     );
 
     if (edge) {
-      console.log('Edge Found ', edge);
       return <Link to={`${edge.slug}${hash && `#${hash}`}`}>{children}</Link>;
     }
   }

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -130,9 +130,6 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
     elem = (
       <NodeContent
         node={node}
-        // Link={({ children, ...props }) => {
-        //   return <a href={props.to}>{children}</a>;
-        // }}
         Link={ReactRouterMarkdownLink!}
         hideTryIt={hideTryIt}
         hideMocking={hideMocking}

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -8,6 +8,7 @@ import {
   withQueryClientProvider,
   withStyles,
 } from '@stoplight/elements-core';
+import { ReactRouterMarkdownLink } from '@stoplight/elements-core/components/MarkdownViewer/CustomComponents/ReactRouterLink';
 import { flow } from 'lodash';
 import * as React from 'react';
 import { Link, Redirect, Route, useHistory, useParams } from 'react-router-dom';
@@ -129,9 +130,10 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
     elem = (
       <NodeContent
         node={node}
-        Link={({ children, ...props }) => {
-          return <a href={props.to}>{children}</a>;
-        }}
+        // Link={({ children, ...props }) => {
+        //   return <a href={props.to}>{children}</a>;
+        // }}
+        Link={ReactRouterMarkdownLink!}
         hideTryIt={hideTryIt}
         hideMocking={hideMocking}
         hideExport={hideExport}

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -1,5 +1,6 @@
 import {
   findFirstNode,
+  ReactRouterMarkdownLink,
   RoutingProps,
   SidebarLayout,
   useRouter,
@@ -8,7 +9,6 @@ import {
   withQueryClientProvider,
   withStyles,
 } from '@stoplight/elements-core';
-import { ReactRouterMarkdownLink } from '@stoplight/elements-core/components/MarkdownViewer/CustomComponents/ReactRouterLink';
 import { flow } from 'lodash';
 import * as React from 'react';
 import { Link, Redirect, Route, useHistory, useParams } from 'react-router-dom';

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -129,7 +129,9 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
     elem = (
       <NodeContent
         node={node}
-        Link={Link}
+        Link={({ children, ...props }) => {
+          return <a href={props.to}>{children}</a>;
+        }}
         hideTryIt={hideTryIt}
         hideMocking={hideMocking}
         hideExport={hideExport}

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.4.3';
+export const appVersion = '1.4.7';


### PR DESCRIPTION
Addresses #8606

Anchor tags were not appended to links if those links were pointing to another document. Links are now appended, but scrolling to the anchor position is not working. This seems to be a known bug when using react-router-dom:
https://github.com/remix-run/react-router/issues/394#issuecomment-220221604

To test:

Option 1:
1. Checkout branch
2. Create two articles. In one article, create a top header and a bottom header located somewhere else down the page.
2. In your second article, link to the top header and the bottom header.
3. You will notice the anchor tags are appended to the outbound links, but the scrolling to the anchor position is not working

https://user-images.githubusercontent.com/52048026/141879149-60a7b490-56f6-417c-a4bc-2d75f7090e9f.mov

Option 2:
1. Checkout branch:
2. CD into packages/elements-dev-portal and run `yarn storybook`
3. Select NodeContent/Create Todo
4. Use the following information in the Controls section to the right:

```
nodeSlug: ZG9jOjg3NDE4NA-article-two
projectId: cHJqOjExNzIxMg
platformUrl: https://dojo-stg-v2.stoplight.io
```

You will notice the links have the anchor tags, but the links are not clickable


https://user-images.githubusercontent.com/52048026/141879186-1e2103d2-a152-482e-a91c-91ff8cc99c4e.mov



