### PR TITLE
fix: reuse mosaic, react-query context if possible

### DIFF
--- a/packages/elements-core/src/hoc/withMosaicProvider.spec.tsx
+++ b/packages/elements-core/src/hoc/withMosaicProvider.spec.tsx
@@ -1,0 +1,48 @@
+import { Provider as MosaicProvider, useMosaicContext } from '@stoplight/mosaic';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { withMosaicProvider } from './withMosaicProvider';
+
+describe('withMosaicProvider()', () => {
+  it('should re-use mosaic context if already present in tree, rather than creating a new provider', () => {
+    let mosaicContextFromParent: ReturnType<typeof useMosaicContext> | undefined;
+    let mosaicContextFromProvider: ReturnType<typeof useMosaicContext> | undefined;
+
+    const Page = withMosaicProvider(() => {
+      mosaicContextFromProvider = useMosaicContext();
+      return null;
+    });
+
+    const Parent = () => {
+      mosaicContextFromParent = useMosaicContext();
+
+      return <Page />;
+    };
+
+    render(
+      <MosaicProvider>
+        <Parent />
+      </MosaicProvider>,
+    );
+
+    expect(mosaicContextFromProvider).toBe(mosaicContextFromParent);
+  });
+
+  it('should create new mosaic context if not already present in tree', () => {
+    let mosaicContextFromProvider: ReturnType<typeof useMosaicContext> | undefined;
+
+    const Page = withMosaicProvider(() => {
+      mosaicContextFromProvider = useMosaicContext();
+      return null;
+    });
+
+    const Parent = () => {
+      return <Page />;
+    };
+
+    render(<Parent />);
+
+    expect(mosaicContextFromProvider).toHaveProperty('providerId');
+  });
+});

--- a/packages/elements-core/src/hoc/withMosaicProvider.tsx
+++ b/packages/elements-core/src/hoc/withMosaicProvider.tsx
@@ -8,7 +8,7 @@ export function withMosaicProvider<P>(WrappedComponent: React.ComponentType<P>):
     try {
       // if already have mosaic context in tree, use it rather than creating a new provider
       const mosaicContext = useMosaicContext();
-      if (mosaicContext) {
+      if (mosaicContext?.providerId) {
         return <WrappedComponent {...props} />;
       }
     } catch {

--- a/packages/elements-core/src/hoc/withMosaicProvider.tsx
+++ b/packages/elements-core/src/hoc/withMosaicProvider.tsx
@@ -1,10 +1,20 @@
-import { Provider as MosaicProvider } from '@stoplight/mosaic';
+import { Provider as MosaicProvider, useMosaicContext } from '@stoplight/mosaic';
 import React from 'react';
 
 import { getDisplayName } from './utils';
 
 export function withMosaicProvider<P>(WrappedComponent: React.ComponentType<P>): React.FC<P> {
   const WithMosaicProvider = (props: P) => {
+    try {
+      // if already have mosaic context in tree, use it rather than creating a new provider
+      const mosaicContext = useMosaicContext();
+      if (mosaicContext) {
+        return <WrappedComponent {...props} />;
+      }
+    } catch {
+      // no mosaic context yet in the tree (if `useMosaicContext` throws)
+    }
+
     return (
       <MosaicProvider style={{ height: '100%' }}>
         <WrappedComponent {...props} />

--- a/packages/elements-core/src/hoc/withQueryClientProvider.spec.tsx
+++ b/packages/elements-core/src/hoc/withQueryClientProvider.spec.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider, useQueryClient } from 'react-query';
+
+import { withQueryClientProvider } from './withQueryClientProvider';
+
+describe('withQueryClientProvider()', () => {
+  it('should re-use react-query context if already present in tree, rather than creating a new provider', () => {
+    const queryClientFromParent = new QueryClient();
+    let queryClientFromProvider: QueryClient | undefined;
+
+    const Page = withQueryClientProvider(() => {
+      queryClientFromProvider = useQueryClient();
+      return null;
+    });
+
+    render(
+      <QueryClientProvider client={queryClientFromParent}>
+        <Page />
+      </QueryClientProvider>,
+    );
+
+    expect(queryClientFromProvider).toBe(queryClientFromParent);
+  });
+
+  it('should create new react-query context if not already present in tree', () => {
+    let queryClientFromProvider: QueryClient | undefined;
+
+    const Page = withQueryClientProvider(() => {
+      queryClientFromProvider = useQueryClient();
+      return null;
+    });
+
+    render(<Page />);
+
+    expect(queryClientFromProvider).toBeInstanceOf(QueryClient);
+  });
+});

--- a/packages/elements-core/src/hoc/withQueryClientProvider.tsx
+++ b/packages/elements-core/src/hoc/withQueryClientProvider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider, useQueryClient } from 'react-query';
 
 import { getDisplayName } from './utils';
 
@@ -14,6 +14,14 @@ const queryClient = new QueryClient({
 
 export function withQueryClientProvider<P>(WrappedComponent: React.ComponentType<P>): React.FC<P> {
   const WithQueryClientProvider = (props: P) => {
+    try {
+      // if already have query client in tree, use it rather than creating a new provider
+      useQueryClient();
+      return <WrappedComponent {...props} />;
+    } catch {
+      // no query client yet in the tree (if `useQueryClient` throws)
+    }
+
     return (
       <QueryClientProvider client={queryClient}>
         <WrappedComponent {...props} />

--- a/packages/elements-dev-portal/src/components/DevPortalProvider/index.tsx
+++ b/packages/elements-dev-portal/src/components/DevPortalProvider/index.tsx
@@ -1,5 +1,4 @@
-import { withQueryClientProvider } from '@stoplight/elements-core';
-import { Provider as MosaicProvider } from '@stoplight/mosaic';
+import { withMosaicProvider, withQueryClientProvider } from '@stoplight/elements-core';
 import * as React from 'react';
 
 export type DevPortalProviderProps = {
@@ -14,11 +13,7 @@ const PlatformProvider: React.FC<DevPortalProviderProps> = ({
   platformAuthToken,
   children,
 }) => {
-  return (
-    <PlatformContext.Provider value={{ platformUrl, platformAuthToken }}>
-      <MosaicProvider>{children}</MosaicProvider>
-    </PlatformContext.Provider>
-  );
+  return <PlatformContext.Provider value={{ platformUrl, platformAuthToken }}>{children}</PlatformContext.Provider>;
 };
 
-export const DevPortalProvider = withQueryClientProvider(PlatformProvider);
+export const DevPortalProvider = withQueryClientProvider(withMosaicProvider(PlatformProvider));


### PR DESCRIPTION
If the application that elements is embedded into is already using mosaic or react-query, re-use those contexts rather than creating new ones.

Particularly applicable to platform - as it stands now we are creating excess contexts, and not respecting the options set on the parent contexts.