### PR TITLE
fix(dev-portal): add fetching state to search

### DIFF
--- a/examples/react-cra/src/components/Search.tsx
+++ b/examples/react-cra/src/components/Search.tsx
@@ -9,7 +9,7 @@ export type SearchProps = {
 export const Search = ({ projectIds }: SearchProps) => {
   const [search, setSearch] = React.useState('');
   const [open, setOpen] = React.useState(false);
-  const { data } = useGetNodes({
+  const { data, isFetching } = useGetNodes({
     search,
     projectIds,
   });
@@ -36,6 +36,7 @@ export const Search = ({ projectIds }: SearchProps) => {
         onClose={handleClose}
         isOpen={open}
         searchResults={data}
+        isFetching={isFetching}
       />
     </>
   );

--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -12,7 +12,7 @@ type SearchWrapperProps = { projectIds: string[]; workspaceId: string };
 const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
   const { isOpen, open, close } = useModalState();
   const [search, setSearch] = React.useState('');
-  const { data } = useGetNodes({
+  const { data, isFetching } = useGetNodes({
     search,
     projectIds,
     workspaceId,
@@ -46,6 +46,7 @@ const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
         isOpen={isOpen}
         onClose={handleClose}
         onClick={handleClick}
+        isFetching={isFetching}
       />
     </>
   );

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -20,9 +20,10 @@ export type SearchProps = {
   onClick: (result: NodeSearchResult) => void;
   isOpen?: boolean;
   onClose: ModalProps['onClose'];
+  isFetching: boolean;
 };
 
-const SearchImpl = ({ search, searchResults, isOpen, onClose, onClick, onSearch }: SearchProps) => {
+const SearchImpl = ({ search, searchResults, isOpen, onClose, onClick, onSearch, isFetching }: SearchProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
 
   const onChange = React.useCallback(e => onSearch(e.currentTarget.value), [onSearch]);
@@ -117,7 +118,7 @@ const SearchImpl = ({ search, searchResults, isOpen, onClose, onClick, onSearch 
         </ListBox>
       ) : (
         <Flex w="full" h={80} align="center" justify="center" m={-5}>
-          No search results
+          {isFetching ? <>Fetching results...</> : <>No search results</>}
         </Flex>
       )}
     </Modal>

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.4.3';
+export const appVersion = '1.4.7';


### PR DESCRIPTION
Currently when you type into the search box while the http request is being completed you see "No results found".

This PR uses the react-query `isFetching` boolean to show "Fetching results..." while the query is in progress.