### PR TITLE
fix(build): mjs/nextjs 12/swc compatibility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,5 +4,11 @@ module.exports = {
     'no-console': 'off',
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'off',
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: ['lodash/*', '@fortawesome/free-solid-svg-icons/*'],
+      },
+    ],
   },
 };

--- a/demo/src/constants.ts
+++ b/demo/src/constants.ts
@@ -28,7 +28,7 @@ export const EXAMPLE_SPECS = [
   },
   {
     text: 'Linode',
-    value: 'https://api.apis.guru/v2/specs/linode.com/4.86.1/openapi.yaml',
+    value: 'https://api.apis.guru/v2/specs/linode.com/4.97.2/openapi.yaml',
   },
   {
     text: 'Netlify',

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -60,7 +60,7 @@
     "@stoplight/yaml": "^4.2.2",
     "classnames": "^2.2.6",
     "httpsnippet": "^1.24.0",
-    "jotai": "1.2.2",
+    "jotai": "1.3.9",
     "json-schema": "^0.3.0",
     "lodash": "^4.17.19",
     "nanoid": "^3.1.20",
@@ -75,7 +75,7 @@
     "xml-formatter": "^2.4.0"
   },
   "devDependencies": {
-    "@stoplight/scripts": "9.1.0",
+    "@stoplight/scripts": "9.2.0",
     "@testing-library/dom": "^7.26.5",
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/react": "^11.1.1",

--- a/packages/elements-core/src/components/Docs/HttpOperation/Request.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Request.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from '@stoplight/mosaic';
 import { HttpSecurityScheme, IHttpOperation } from '@stoplight/types';
 import { useAtom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
-import flatten from 'lodash/flatten';
+import { flatten } from 'lodash';
 import * as React from 'react';
 
 import { HttpMethodColors } from '../../../constants';

--- a/packages/elements-core/src/components/Docs/HttpService/SecuritySchemes.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/SecuritySchemes.tsx
@@ -1,6 +1,6 @@
 import { Box, Panel, PanelProps } from '@stoplight/mosaic';
 import { HttpSecurityScheme } from '@stoplight/types';
-import sortBy from 'lodash/sortBy';
+import { sortBy } from 'lodash';
 import React from 'react';
 
 import { getReadableSecurityName, shouldIncludeKey } from '../../../utils/oas/security';

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
@@ -1,4 +1,5 @@
 import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
+import { DefaultSMDComponents } from '@stoplight/markdown-viewer';
 import { Box, Flex, Icon } from '@stoplight/mosaic';
 import { HttpParamStyles, IHttpOperation, IHttpRequest, NodeType } from '@stoplight/types';
 import { isObject } from 'lodash';
@@ -12,7 +13,7 @@ import { JSONSchema } from '../../../types';
 import { isHttpOperation, isJSONSchema } from '../../../utils/guards';
 import { getOriginalObject } from '../../../utils/ref-resolving/resolvedObject';
 import { TryIt } from '../../TryIt';
-import { CustomComponentMapping, DefaultSMDComponents } from './Provider';
+import { CustomComponentMapping } from './Provider';
 
 type PartialHttpRequest = Pick<IHttpRequest, 'method' | 'url'> & Partial<IHttpRequest>;
 
@@ -49,6 +50,8 @@ const SchemaAndDescription = ({ title: titleProp, schema }: ISchemaAndDescriptio
     </Box>
   );
 };
+
+export { DefaultSMDComponents };
 
 export const CodeComponent: CustomComponentMapping['code'] = props => {
   const { title, jsonSchema, http, children } = props;

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/Provider.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/Provider.tsx
@@ -1,6 +1,5 @@
 import {
   CustomComponentMapping as MDVCustomComponentMapping,
-  DefaultSMDComponents,
   MarkdownViewerProvider,
 } from '@stoplight/markdown-viewer';
 import * as React from 'react';
@@ -9,7 +8,6 @@ import { CodeComponent } from './CodeComponent';
 
 export type CustomComponentMapping = MDVCustomComponentMapping;
 
-export { DefaultSMDComponents };
 interface MarkdownComponentsProviderProps {
   value: Partial<CustomComponentMapping> | undefined;
 }

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -1,7 +1,7 @@
 import { safeStringify } from '@stoplight/json';
 import { IHttpParam, INodeExample, INodeExternalExample } from '@stoplight/types';
 import { JSONSchema7Definition, JSONSchema7Type } from 'json-schema';
-import _, { isObject, map } from 'lodash';
+import { isObject, keyBy, map, mapValues } from 'lodash';
 
 export type ParameterSpec = Pick<IHttpParam, 'name' | 'examples' | 'schema' | 'required'>;
 const booleanOptions = [
@@ -81,10 +81,8 @@ const getInitialValueForParameter = (parameter: ParameterSpec) => {
 };
 
 export const initialParameterValues: (params: readonly ParameterSpec[]) => Record<string, string> = params => {
-  return _.chain(params)
-    .keyBy((param: ParameterSpec) => param.name)
-    .mapValues(param => getInitialValueForParameter(param))
-    .value();
+  const paramsByName = keyBy(params, (param: ParameterSpec) => param.name);
+  return mapValues(paramsByName, param => getInitialValueForParameter(param));
 };
 
 export function mapSchemaPropertiesToParameters(

--- a/packages/elements-core/src/components/TryIt/Response/Response.tsx
+++ b/packages/elements-core/src/components/TryIt/Response/Response.tsx
@@ -1,4 +1,4 @@
-import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle';
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import { safeParse, safeStringify } from '@stoplight/json';
 import { Box, Button, Flex, Icon, Image, Link, Menu, MenuItems, Panel } from '@stoplight/mosaic';
 import { CodeViewer } from '@stoplight/mosaic-code-viewer';

--- a/packages/elements-core/src/index.ts
+++ b/packages/elements-core/src/index.ts
@@ -3,9 +3,9 @@ export { DeprecatedBadge } from './components/Docs/HttpOperation/Badges';
 export { ExportButton, ExportButtonProps } from './components/Docs/HttpService/ExportButton';
 export { SidebarLayout } from './components/Layout/SidebarLayout';
 export { Logo } from './components/Logo';
+export { DefaultSMDComponents } from './components/MarkdownViewer/CustomComponents/CodeComponent';
 export {
   CustomComponentMapping,
-  DefaultSMDComponents,
   MarkdownComponentsProvider,
 } from './components/MarkdownViewer/CustomComponents/Provider';
 export { ReactRouterMarkdownLink } from './components/MarkdownViewer/CustomComponents/ReactRouterLink';

--- a/packages/elements-core/src/utils/securitySchemes.ts
+++ b/packages/elements-core/src/utils/securitySchemes.ts
@@ -1,6 +1,5 @@
 import { HttpSecurityScheme, IOauth2Flow, IOauth2SecurityScheme, IOauthFlowObjects } from '@stoplight/types';
-import entries from 'lodash/entries';
-import keys from 'lodash/keys';
+import { entries, keys } from 'lodash';
 
 import {
   isOauth2AuthorizationCodeFlow,

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -60,7 +60,7 @@
     "use-debounce": "^6.0.1"
   },
   "devDependencies": {
-    "@stoplight/scripts": "9.1.0",
+    "@stoplight/scripts": "9.2.0",
     "@testing-library/dom": "^7.26.5",
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/react": "^11.1.1",
@@ -86,5 +86,10 @@
   },
   "exports": {
     "./styles.min.css": "./styles.min.css"
+  },
+  "rollup": {
+    "bundleDeps": [
+      "use-debounce"
+    ]
   }
 }

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -1,4 +1,4 @@
-import { faSearch } from '@fortawesome/free-solid-svg-icons/faSearch';
+import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import {
   NodeTypeColors,
   NodeTypeIconDefs,

--- a/packages/elements-utils/package.json
+++ b/packages/elements-utils/package.json
@@ -28,6 +28,6 @@
     "lodash": "^4.17.19"
   },
   "devDependencies": {
-    "@stoplight/scripts": "9.1.0"
+    "@stoplight/scripts": "9.2.0"
   }
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -52,6 +52,7 @@
     "@stoplight/json": "^3.10.0",
     "@stoplight/mosaic": "^1.12.4",
     "@stoplight/types": "^12.0.0",
+    "@stoplight/yaml": "^4.2.2",
     "classnames": "^2.2.6",
     "file-saver": "^2.0.5",
     "lodash": "^4.17.19",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -59,7 +59,7 @@
     "react-router-dom": "^5.2.0"
   },
   "devDependencies": {
-    "@stoplight/scripts": "9.1.0",
+    "@stoplight/scripts": "9.2.0",
     "@testing-library/dom": "^7.26.5",
     "@testing-library/jest-dom": "^5.11.5",
     "@testing-library/react": "^11.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3258,6 +3258,26 @@
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
 
+"@rollup/plugin-node-resolve@^13.0.6":
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.6.tgz#29629070bb767567be8157f575cfa8f2b8e9ef77"
+  integrity sha512-sFsPDMPd4gMqnh2gS0uIxELnoRUp5kBl5knxD2EO0778G1oOJv4G1vyT2cpWz75OU2jDVcXhjVUuTAczGyFNKA==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
+"@rollup/pluginutils@4.x", "@rollup/pluginutils@^4.1.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.1.1.tgz#1d4da86dd4eded15656a57d933fda2b9a08d47ec"
+  integrity sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==
+  dependencies:
+    estree-walker "^2.0.1"
+    picomatch "^2.2.2"
+
 "@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -3265,14 +3285,6 @@
   dependencies:
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
-    picomatch "^2.2.2"
-
-"@rollup/pluginutils@^4.1.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.1.1.tgz#1d4da86dd4eded15656a57d933fda2b9a08d47ec"
-  integrity sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==
-  dependencies:
-    estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
 "@samverschueren/stream-to-observable@^0.3.0":
@@ -3755,10 +3767,10 @@
   dependencies:
     "@sentry/react" "^6.13.2"
 
-"@stoplight/scripts@9.1.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/scripts/-/scripts-9.1.0.tgz#6b2c059fe150bcd34a055d870c4746057b48dad2"
-  integrity sha512-IKVHv8JJUb/oPveuv7DEiDDfii+3GOzQIoWPMwQz18NaVyLPp9v+jHSkAAa8euDiwtXeiJw2MdPQRXIsVbJJOg==
+"@stoplight/scripts@9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/scripts/-/scripts-9.2.0.tgz#a89007cdcfa958b02f49d038730ba87d52fbc205"
+  integrity sha512-Jh6L6sf0fCaHjohHGk2k/5ZHheFKoQSzw8mOxNXcnqKH6oBiuWo37QkCVmgHya6jXpHjeGAjYZilUz9i43Uhng==
   dependencies:
     "@commitlint/cli" "8.3.5"
     "@commitlint/config-conventional" "8.3.4"
@@ -3767,6 +3779,8 @@
     "@oclif/plugin-help" "2.2.3"
     "@rollup/plugin-commonjs" "^19.0.0"
     "@rollup/plugin-json" "^4.1.0"
+    "@rollup/plugin-node-resolve" "^13.0.6"
+    "@rollup/pluginutils" "4.x"
     "@semantic-release/commit-analyzer" "8.0.1"
     "@semantic-release/git" "9.0.0"
     "@semantic-release/github" "7.0.3"
@@ -3776,10 +3790,12 @@
     commitizen "4.0.3"
     cz-conventional-changelog "3.1.x"
     esm "^3.2.25"
+    estree-walker "2.x"
     find-up "^4.1.0"
     husky "4.2.3"
     inquirer "7.0.4"
     lint-staged "10.0.7"
+    magic-string "0.25.x"
     rimraf "3.0.2"
     rollup "^2.47.0"
     rollup-plugin-terser "^7.0.2"
@@ -5086,6 +5102,13 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/retry@^0.12.0":
   version "0.12.1"
@@ -6947,6 +6970,11 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+builtin-modules@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
+  integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -10023,15 +10051,15 @@ estree-to-babel@^3.1.0:
     "@babel/types" "^7.2.0"
     c8 "^7.6.0"
 
+estree-walker@2.x, estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
   integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
-
-estree-walker@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
-  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -12764,6 +12792,11 @@ is-map@^2.0.2:
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.2.tgz#00922db8c9bf73e81b7a335827bc2a43f2b91127"
   integrity sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
 is-negative-zero@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
@@ -13705,10 +13738,10 @@ joi@^17.4.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
-jotai@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.2.2.tgz#631fd7ad44e9ac26cdf9874d52282c1cfe032807"
-  integrity sha512-iqkkUdWsH2Mk4HY1biba/8kA77+8liVBy8E0d8Nce29qow4h9mzdDhpTasAruuFYPycw6JvfZgL5RB0JJuIZjw==
+jotai@1.3.9:
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.3.9.tgz#d65a7069b949a3a74f9e069d3e3f06f99be02817"
+  integrity sha512-b6DvH9gf+7TfjaboCO54g+C0yhaakIaUBtjLf0dk1p15FWCzNw/93sezdXy9cCaZ8qcEdMLJcjBwQlORmIq29g==
 
 js-sha3@0.8.0:
   version "0.8.0"
@@ -14909,7 +14942,7 @@ magic-error@0.0.1:
   resolved "https://registry.yarnpkg.com/magic-error/-/magic-error-0.0.1.tgz#95ebe658ca4a86f1aebda390cab6ea50d41bfa2a"
   integrity sha512-1+N1ET8cbC5bfLQZcRojClzgK2gbUt9keTMr9OJeuXnQKWsfwRRRICuMA3HKaCIXFEgKzxivuMGCNKD7cdU5pg==
 
-magic-string@^0.25.7:
+magic-string@0.25.x, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==


### PR DESCRIPTION
Adjustments such that the build output can be used in mjs environments such as NextJS v12.

- chore(demo): fix linode spec link
- fix: circular import
- fix: do not use `_.chain`, mjs compat and it breaks tree-shaking
- fix: root FA/lodash imports for mjs compat (also added an eslint rule to enforce this pattern)