### PR TITLE
chore(core): do not log example generation failures

### DIFF
--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
@@ -93,7 +93,6 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7): Example[] =
         ]
       : [{ label: 'default', data: '' }];
   } catch (e) {
-    console.error(e);
     return [{ label: '', data: `Example cannot be created for this schema\n${e}` }];
   }
 };


### PR DESCRIPTION
This `console.error` call heavily pollutes Sentry.
![image](https://user-images.githubusercontent.com/9273484/143886350-31c97ab1-2386-4802-a1c7-3b248cd0b493.png)
We don't really need to call `console.error`, as in most cases it's an error on the user end. Moreover, the message is displayed to the end-user, therefore they know that an error occurred without looking into the console.

