### PR TITLE
feat(DevPortal): search loading indicator

### DIFF
--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -12,11 +12,12 @@ type SearchWrapperProps = { projectIds: string[]; workspaceId: string };
 const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
   const { isOpen, open, close } = useModalState();
   const [search, setSearch] = React.useState('');
-  const { data } = useGetNodes({
+  const { data, isFetching } = useGetNodes({
     search,
     projectIds,
     workspaceId,
   });
+
   const { data: workspace } = useGetWorkspace({
     projectIds,
   });
@@ -40,6 +41,7 @@ const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
     <>
       <Input placeholder="Search..." onClick={open} />
       <Search
+        isLoading={isFetching}
         search={search}
         searchResults={data}
         onSearch={setSearch}

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -1,4 +1,4 @@
-import { faSearch } from '@fortawesome/free-solid-svg-icons';
+import { faSearch, faSpinner } from '@fortawesome/free-solid-svg-icons';
 import {
   NodeTypeColors,
   NodeTypeIconDefs,
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { NodeSearchResult } from '../../types';
 
 export type SearchProps = {
+  isLoading?: boolean;
   search?: string;
   searchResults?: NodeSearchResult[];
   onSearch: (search: string) => void;
@@ -22,7 +23,7 @@ export type SearchProps = {
   onClose: ModalProps['onClose'];
 };
 
-const SearchImpl = ({ search, searchResults, isOpen, onClose, onClick, onSearch }: SearchProps) => {
+const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick, onSearch }: SearchProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
 
   const onChange = React.useCallback(e => onSearch(e.currentTarget.value), [onSearch]);
@@ -55,7 +56,7 @@ const SearchImpl = ({ search, searchResults, isOpen, onClose, onClick, onSearch 
           appearance="minimal"
           borderB
           size="lg"
-          icon={<Box as={Icon} ml={1} icon={faSearch} />}
+          icon={<Box as={Icon} ml={1} icon={isLoading ? faSpinner : faSearch} spin={isLoading} />}
           autoFocus
           placeholder="Search..."
           value={search}

--- a/packages/elements-dev-portal/src/hooks/useGetNodes.ts
+++ b/packages/elements-dev-portal/src/hooks/useGetNodes.ts
@@ -21,8 +21,8 @@ export function useGetNodes({
   const { platformUrl, platformAuthToken } = React.useContext(PlatformContext);
   const [debounceSearch] = useDebounce(search, 500);
   return useQuery(
-    ['workspaceNodes', workspaceId, branchSlug, projectIds, debounceSearch, platformUrl, platformAuthToken],
+    ['workspaceNodes', platformUrl, platformAuthToken, workspaceId, branchSlug, projectIds, debounceSearch],
     () => getNodes({ workspaceId, branchSlug, projectIds, search: debounceSearch, platformUrl, platformAuthToken }),
-    { enabled: !pause },
+    { enabled: !pause, keepPreviousData: true },
   );
 }


### PR DESCRIPTION
Follow up to https://github.com/stoplightio/elements/pull/1880. Feel free to copy the changes to that PR too.

- Add loading spinner in place of search icon while fetching/loading
- Add `keepPreviousData` to `useGetNodes` hook to keep previous search data while we're searching

![2021-11-30 16 05 47](https://user-images.githubusercontent.com/7423098/144135846-39bd3b9c-4b97-4210-812e-44d6348f0cf6.gif)
