### PR TITLE
chore: make angular dependabot updates more rare

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: /examples/angular
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
       time: '03:00'
     commit-message:


### PR DESCRIPTION
Relates to #1886 

Currently dependant spams us with angular 12 -> 13 updates on a weekly basis.

This PR makes them more rare.

To be reverted once #1886 is done.