### PR TITLE
 fix(elements-core): removed hideExamples prop

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/Body.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Body.tsx
@@ -60,7 +60,6 @@ export const Body = ({ body, onChange }: BodyProps) => {
           resolveRef={refResolver}
           schema={getOriginalObject(schema)}
           viewMode="write"
-          hideExamples
           renderRootTreeLines
         />
       )}

--- a/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
@@ -103,7 +103,6 @@ const Response = ({ response, onMediaTypeChange }: ResponseProps) => {
               schema={getOriginalObject(schema)}
               resolveRef={refResolver}
               viewMode="read"
-              hideExamples
               parentCrumbs={['responses', response.code]}
               renderRootTreeLines
             />

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.6.2';
+export const appVersion = '1.6.3';


### PR DESCRIPTION
Removal of hideExamples prop allows for the examples in studio to be shown.

To test:
1. Create an API style guide in studio. 
2. In properties, type a string
3. In JSV, your example should be shown

**NOTE:** I can provide a branch to the yalc'd `elements-core` into platform if needed

![image](https://user-images.githubusercontent.com/52048026/146225447-6faa4fff-f87a-4556-bd42-58b97faeb17d.png)

![image](https://user-images.githubusercontent.com/52048026/146225478-ab45e37d-650c-46e0-a7af-b2930c7f3ddd.png)

![image](https://user-images.githubusercontent.com/52048026/146225503-b0f27721-d7fc-4f2f-b65b-d847026035cd.png)
