### PR TITLE
fix(embedded-tryit): require parameter when a default is provided

### DIFF
--- a/packages/elements-core/src/__fixtures__/articles/kitchen-sink.md
+++ b/packages/elements-core/src/__fixtures__/articles/kitchen-sink.md
@@ -275,33 +275,13 @@ be the http object to be rendered.
 ```
 ````
 
-### Request from Http Operation
-
-<!-- type: http -->
-
-```json
-{
-  "$ref": "../../reference/todos/openapi.v1.json/paths/~1todos/get"
-}
-```
-
-````md
-<!-- type: http -->
-
-```json
-{
-  "$ref": "../../reference/todos/openapi.v1.json/paths/~1todos/get"
-}
-```
-````
-
 ### From a remote Http Operation
 
 <!-- type: http -->
 
 ```json
 {
-  "$ref": "https://stoplight.io/api/nodes.raw?srn=gh/stoplightio/sample-specs/reference/giphy/giphy.yaml/paths/~1gifs~1search/get"
+  "$ref": "https://stoplight.io/api/v1/projects/demo/external-api/nodes/zoom.yaml/paths/~1meetings~1%7BmeetingId%7D/get?deref=optimizedBundle"
 }
 ```
 
@@ -310,7 +290,7 @@ be the http object to be rendered.
 
 ```json
 {
-  "$ref": "https://stoplight.io/api/nodes.raw?srn=gh/stoplightio/sample-specs/reference/giphy/giphy.yaml/paths/~1gifs~1search/get"
+  "$ref": "https://stoplight.io/api/v1/projects/demo/external-api/nodes/zoom.yaml/paths/~1meetings~1%7BmeetingId%7D/get?deref=optimizedBundle"
 }
 ```
 ````

--- a/packages/elements-core/src/__fixtures__/articles/multiple-try-its.md
+++ b/packages/elements-core/src/__fixtures__/articles/multiple-try-its.md
@@ -1,28 +1,54 @@
 ---
-title: Stoplight Flavored Markdown
+title: Using the TODO API
 ---
 
+1. Create a TODO
+
 ```json http
 {
-  "method": "get",
-  "url": "https://todos.stoplight.io/todos"
+  "method": "post",
+  "url": "/todos",
+  "baseUrl": "https://todos.stoplight.io",
+  "headers": {},
+  "query": {
+    "api_key": ["123"],
+  },
+  "body": {
+    "name": "Fetch this TODO",
+    "completed": false
+  }
 }
 ```
 
-Yo, yo
+2. Use the "id" from the previous response to fetch the TODO
+
 
 ```json http
 {
   "method": "get",
-  "url": "https://amazing.website.com/todos"
+  "url": "/todos/{id}",
+  "baseUrl": "https://todos.stoplight.io",
+  "headers": {},
+  "query": {
+    "api_key": ["123"],
+  }
 }
 ```
 
-Yo, yo, yo
+3. Update the TODO to be completed
 
 ```json http
 {
-  "method": "get",
-  "url": "https://google.com/some-url"
+  "method": "put",
+  "url": "/todos/{id}",
+  "baseUrl": "https://todos.stoplight.io",
+  "headers": {},
+  "query": {
+    "api_key": ["123"],
+  },
+  "body": {
+    "name": "[Completed] Fetch this TODO",
+    "completed": true
+  }
 }
 ```

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.spec.ts
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.spec.ts
@@ -58,6 +58,7 @@ describe('parseHttpRequest', () => {
       baseUrl: 'http://test',
       query: {
         limit: ['10'],
+        skip: [],
       },
       headers: {
         apikey: '123',
@@ -73,8 +74,11 @@ describe('parseHttpRequest', () => {
       path: '/todos/{id}',
       servers: [{ url: 'http://test' }],
       request: {
-        query: [{ name: 'limit', style: HttpParamStyles.Form, schema: { default: '10' } }],
-        headers: [{ name: 'apikey', style: HttpParamStyles.Simple, schema: { default: '123' } }],
+        query: [
+          { name: 'limit', style: HttpParamStyles.Form, schema: { default: '10' }, required: true },
+          { name: 'skip', style: HttpParamStyles.Form, schema: {}, required: false },
+        ],
+        headers: [{ name: 'apikey', style: HttpParamStyles.Simple, schema: { default: '123' }, required: true }],
         path: [{ name: 'id', style: HttpParamStyles.Simple, required: true }],
         body: { contents: [{ mediaType: 'application/json', schema: { default: '{}' } }] },
       },

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
@@ -77,7 +77,7 @@ export const CodeComponent: CustomComponentMapping['code'] = props => {
     return (
       <PersistenceContextProvider>
         <TryIt
-          httpOperation={isPartialHttpRequest(parsedValue) ? parseHttpRequest(parsedValue) : parsedValue}
+          httpOperation={isHttpOperation(parsedValue) ? parsedValue : parseHttpRequest(parsedValue)}
           embeddedInMd
         />
       </PersistenceContextProvider>

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
@@ -98,7 +98,7 @@ export function parseHttpRequest(data: PartialHttpRequest): IHttpOperation {
     servers: [{ url: uri.is('absolute') ? uri.origin() : data.baseUrl || '' }],
     request: {
       query: Object.entries(data.query || {}).map(([key, value]) => {
-        const defaultVal = Array.isArray(value) && value.length > 0 ? value[0] : value;
+        const defaultVal = Array.isArray(value) ? value[0] : value;
         return {
           name: key,
           style: HttpParamStyles.Form,

--- a/packages/elements-core/src/components/MarkdownViewer/MarkdownViewer.spec.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/MarkdownViewer.spec.tsx
@@ -123,7 +123,7 @@ describe('MarkdownViewer', () => {
   "headers": {},
   "query": {
     "api_key": ["dc6zaTOxFJmzC"],
-    "limit": ["1"],
+    "limit": [],
     "q": ["cats"]
   }
 }
@@ -137,7 +137,17 @@ describe('MarkdownViewer', () => {
       );
 
       expect(screen.getByText('http://api.giphy.com/v1/gifs/search')).toBeInTheDocument();
+
+      // has default
       expect(screen.getByText('api_key*')).toBeInTheDocument();
+      expect(screen.getByLabelText('api_key')).toHaveProperty('value', 'dc6zaTOxFJmzC');
+
+      expect(screen.getByText('q*')).toBeInTheDocument();
+      expect(screen.getByLabelText('q')).toHaveProperty('value', 'cats');
+
+      // no default
+      expect(screen.getByText('limit')).toBeInTheDocument();
+      expect(screen.getByLabelText('limit')).toHaveProperty('value', '');
 
       unmount();
     });

--- a/packages/elements-core/src/components/MarkdownViewer/MarkdownViewer.spec.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/MarkdownViewer.spec.tsx
@@ -137,7 +137,7 @@ describe('MarkdownViewer', () => {
       );
 
       expect(screen.getByText('http://api.giphy.com/v1/gifs/search')).toBeInTheDocument();
-      expect(screen.getByText('api_key')).toBeInTheDocument();
+      expect(screen.getByText('api_key*')).toBeInTheDocument();
 
       unmount();
     });


### PR DESCRIPTION
Fixes https://github.com/stoplightio/platform-internal/issues/9443

-  If a default value is provided with the embedded request maker, we will now mark it as required so the default value will be set.
- Update "multiple try it" storybook example to be a realistic use case. Can see "api_key" default is now set automatically


<img width="1366" alt="Screen Shot 2021-12-16 at 11 46 41 AM" src="https://user-images.githubusercontent.com/7423098/146422806-9e8da2c0-1419-45e7-b3ba-7123c0a272df.png">
