### PR TITLE
feat: support for optional parameters

### DIFF
--- a/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
+++ b/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
@@ -58,7 +58,7 @@ export const FormDataBody: React.FC<FormDataBodyProps> = ({ specification, value
               key={parameter.name}
               parameter={parameter}
               value={typeof value === 'string' ? value : undefined}
-              onChange={(value: string | number) =>
+              onChangeValue={(value: string | number) =>
                 onChangeValues({ ...values, [parameter.name]: typeof value === 'number' ? String(value) : value })
               }
             />

--- a/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
+++ b/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
@@ -58,7 +58,7 @@ export const FormDataBody: React.FC<FormDataBodyProps> = ({ specification, value
               key={parameter.name}
               parameter={parameter}
               value={typeof value === 'string' ? value : undefined}
-              onChangeValue={(value: string | number) =>
+              onChange={(value: string | number) =>
                 onChangeValues({ ...values, [parameter.name]: typeof value === 'number' ? String(value) : value })
               }
             />

--- a/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
@@ -30,9 +30,9 @@ export const OperationParameters: React.FC<OperationParametersProps> = ({
             key={parameter.name}
             parameter={parameter}
             value={values[parameter.name]}
+            onChange={(value: string | number) => onChangeValue(parameter.name, String(value))}
             validate={validate}
             isDisabled={disabledParameters.includes(parameter.name)}
-            onChange={(value: string | number) => onChangeValue(parameter.name, String(value))}
             toggleDisabled={() => toggleDisabled(parameter.name)}
           />
         ))}

--- a/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
@@ -8,6 +8,8 @@ interface OperationParametersProps<P extends keyof any = string> {
   parameters: readonly ParameterSpec[];
   values: Record<P, string>;
   onChangeValue: (parameterName: P, newValue: string) => void;
+  toggleDisabled: (parameterName: P) => void;
+  disabledParameters: string[];
   validate?: boolean;
 }
 
@@ -15,6 +17,8 @@ export const OperationParameters: React.FC<OperationParametersProps> = ({
   parameters,
   values,
   onChangeValue,
+  toggleDisabled,
+  disabledParameters,
   validate,
 }) => {
   return (
@@ -26,8 +30,10 @@ export const OperationParameters: React.FC<OperationParametersProps> = ({
             key={parameter.name}
             parameter={parameter}
             value={values[parameter.name]}
-            onChange={(value: string | number) => onChangeValue(parameter.name, String(value))}
+            onChangeValue={(value: string | number) => onChangeValue(parameter.name, String(value))}
             validate={validate}
+            isDisabled={disabledParameters.includes(parameter.name)}
+            onChangeDisabled={() => toggleDisabled(parameter.name)}
           />
         ))}
       </Panel.Content>

--- a/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
@@ -32,8 +32,8 @@ export const OperationParameters: React.FC<OperationParametersProps> = ({
             value={values[parameter.name]}
             validate={validate}
             isDisabled={disabledParameters.includes(parameter.name)}
-            onChangeValue={(value: string | number) => onChangeValue(parameter.name, String(value))}
-            onChangeDisabled={() => toggleDisabled(parameter.name)}
+            onChange={(value: string | number) => onChangeValue(parameter.name, String(value))}
+            toggleDisabled={() => toggleDisabled(parameter.name)}
           />
         ))}
       </Panel.Content>

--- a/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
@@ -8,7 +8,7 @@ interface OperationParametersProps<P extends keyof any = string> {
   parameters: readonly ParameterSpec[];
   values: Record<P, string>;
   disabledParameters: string[];
-  onChangeValue: (parameterName: P, newValue: string) => void;
+  onChange: (parameterName: P, newValue: string) => void;
   toggleDisabled: (parameterName: P) => void;
   validate?: boolean;
 }
@@ -16,7 +16,7 @@ interface OperationParametersProps<P extends keyof any = string> {
 export const OperationParameters: React.FC<OperationParametersProps> = ({
   parameters,
   values,
-  onChangeValue,
+  onChange,
   toggleDisabled,
   disabledParameters,
   validate,
@@ -32,7 +32,7 @@ export const OperationParameters: React.FC<OperationParametersProps> = ({
             value={values[parameter.name]}
             validate={validate}
             isDisabled={disabledParameters.includes(parameter.name)}
-            onChangeValue={(value: string | number) => onChangeValue(parameter.name, String(value))}
+            onChangeValue={(value: string | number) => onChange(parameter.name, String(value))}
             onChangeDisabled={() => toggleDisabled(parameter.name)}
           />
         ))}

--- a/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
@@ -8,7 +8,7 @@ interface OperationParametersProps<P extends keyof any = string> {
   parameters: readonly ParameterSpec[];
   values: Record<P, string>;
   disabledParameters: string[];
-  onChange: (parameterName: P, newValue: string) => void;
+  onChangeValue: (parameterName: P, newValue: string) => void;
   toggleDisabled: (parameterName: P) => void;
   validate?: boolean;
 }
@@ -16,7 +16,7 @@ interface OperationParametersProps<P extends keyof any = string> {
 export const OperationParameters: React.FC<OperationParametersProps> = ({
   parameters,
   values,
-  onChange,
+  onChangeValue,
   toggleDisabled,
   disabledParameters,
   validate,
@@ -32,7 +32,7 @@ export const OperationParameters: React.FC<OperationParametersProps> = ({
             value={values[parameter.name]}
             validate={validate}
             isDisabled={disabledParameters.includes(parameter.name)}
-            onChangeValue={(value: string | number) => onChange(parameter.name, String(value))}
+            onChangeValue={(value: string | number) => onChangeValue(parameter.name, String(value))}
             onChangeDisabled={() => toggleDisabled(parameter.name)}
           />
         ))}

--- a/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
@@ -7,9 +7,9 @@ import { ParameterEditor } from './ParameterEditor';
 interface OperationParametersProps<P extends keyof any = string> {
   parameters: readonly ParameterSpec[];
   values: Record<P, string>;
+  disabledParameters: string[];
   onChangeValue: (parameterName: P, newValue: string) => void;
   toggleDisabled: (parameterName: P) => void;
-  disabledParameters: string[];
   validate?: boolean;
 }
 
@@ -30,9 +30,9 @@ export const OperationParameters: React.FC<OperationParametersProps> = ({
             key={parameter.name}
             parameter={parameter}
             value={values[parameter.name]}
-            onChangeValue={(value: string | number) => onChangeValue(parameter.name, String(value))}
             validate={validate}
             isDisabled={disabledParameters.includes(parameter.name)}
+            onChangeValue={(value: string | number) => onChangeValue(parameter.name, String(value))}
             onChangeDisabled={() => toggleDisabled(parameter.name)}
           />
         ))}

--- a/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
@@ -73,8 +73,14 @@ export const ParameterEditor: React.FC<ParameterProps> = ({
                 onChange={onChange}
               />
             )}
-            {isDisabled !== undefined && (
-              <Input type="checkbox" checked={!isDisabled} w={3} onChange={toggleDisabled} />
+            {parameter.required && isDisabled !== undefined && (
+              <Input
+                type="checkbox"
+                checked={!isDisabled}
+                w={3}
+                onChange={toggleDisabled}
+                disabled={parameter.required}
+              />
             )}
           </Flex>
         )}

--- a/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
@@ -73,7 +73,7 @@ export const ParameterEditor: React.FC<ParameterProps> = ({
                 onChange={onChange}
               />
             )}
-            {parameter.required && isDisabled !== undefined && (
+            {!parameter.required && isDisabled !== undefined && (
               <Input
                 type="checkbox"
                 checked={!isDisabled}

--- a/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
@@ -14,16 +14,16 @@ interface ParameterProps {
   parameter: ParameterSpec;
   value?: string;
   isDisabled?: boolean;
-  onChangeValue: SelectProps['onChange'];
-  onChangeDisabled?: () => void;
+  onChange: SelectProps['onChange'];
+  toggleDisabled?: () => void;
   validate?: boolean;
 }
 
 export const ParameterEditor: React.FC<ParameterProps> = ({
   parameter,
   value,
-  onChangeValue,
-  onChangeDisabled,
+  onChange,
+  toggleDisabled,
   isDisabled,
   validate,
 }) => {
@@ -48,7 +48,7 @@ export const ParameterEditor: React.FC<ParameterProps> = ({
             aria-label={parameter.name}
             options={parameterValueOptions}
             value={value || ''}
-            onChange={onChangeValue}
+            onChange={onChange}
           />
         ) : (
           <Flex flex={1}>
@@ -62,7 +62,7 @@ export const ParameterEditor: React.FC<ParameterProps> = ({
               required
               intent={requiredButEmpty ? 'danger' : 'default'}
               value={value || ''}
-              onChange={e => onChangeValue && onChangeValue(e.currentTarget.value)}
+              onChange={e => onChange && onChange(e.currentTarget.value)}
             />
             {examples && (
               <Select
@@ -70,11 +70,11 @@ export const ParameterEditor: React.FC<ParameterProps> = ({
                 flex={1}
                 value={selectedExample.value}
                 options={examples}
-                onChange={onChangeValue}
+                onChange={onChange}
               />
             )}
             {isDisabled !== undefined && (
-              <Input type="checkbox" checked={!isDisabled} w={3} onChange={onChangeDisabled} />
+              <Input type="checkbox" checked={!isDisabled} w={3} onChange={toggleDisabled} />
             )}
           </Flex>
         )}

--- a/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
@@ -13,9 +13,9 @@ import {
 interface ParameterProps {
   parameter: ParameterSpec;
   value?: string;
+  isDisabled?: boolean;
   onChangeValue: SelectProps['onChange'];
-  onChangeDisabled: () => void;
-  isDisabled: boolean;
+  onChangeDisabled?: () => void;
   validate?: boolean;
 }
 
@@ -73,7 +73,9 @@ export const ParameterEditor: React.FC<ParameterProps> = ({
                 onChange={onChangeValue}
               />
             )}
-            <Input type="checkbox" checked={!isDisabled} w={3} onChange={onChangeDisabled} />
+            {isDisabled !== undefined && (
+              <Input type="checkbox" checked={!isDisabled} w={3} onChange={onChangeDisabled} />
+            )}
           </Flex>
         )}
       </div>

--- a/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
@@ -13,11 +13,20 @@ import {
 interface ParameterProps {
   parameter: ParameterSpec;
   value?: string;
-  onChange: SelectProps['onChange'];
+  onChangeValue: SelectProps['onChange'];
+  onChangeDisabled: () => void;
+  isDisabled: boolean;
   validate?: boolean;
 }
 
-export const ParameterEditor: React.FC<ParameterProps> = ({ parameter, value, onChange, validate }) => {
+export const ParameterEditor: React.FC<ParameterProps> = ({
+  parameter,
+  value,
+  onChangeValue,
+  onChangeDisabled,
+  isDisabled,
+  validate,
+}) => {
   const inputId = useUniqueId(`id_${parameter.name}_`);
   const parameterValueOptions = parameterOptions(parameter);
   const examples = exampleOptions(parameter);
@@ -39,7 +48,7 @@ export const ParameterEditor: React.FC<ParameterProps> = ({ parameter, value, on
             aria-label={parameter.name}
             options={parameterValueOptions}
             value={value || ''}
-            onChange={onChange}
+            onChange={onChangeValue}
           />
         ) : (
           <Flex flex={1}>
@@ -53,7 +62,7 @@ export const ParameterEditor: React.FC<ParameterProps> = ({ parameter, value, on
               required
               intent={requiredButEmpty ? 'danger' : 'default'}
               value={value || ''}
-              onChange={e => onChange && onChange(e.currentTarget.value)}
+              onChange={e => onChangeValue && onChangeValue(e.currentTarget.value)}
             />
             {examples && (
               <Select
@@ -61,9 +70,10 @@ export const ParameterEditor: React.FC<ParameterProps> = ({ parameter, value, on
                 flex={1}
                 value={selectedExample.value}
                 options={examples}
-                onChange={onChange}
+                onChange={onChangeValue}
               />
             )}
+            <Input type="checkbox" checked={!isDisabled} w={3} onChange={onChangeDisabled} />
           </Flex>
         )}
       </div>

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -90,6 +90,8 @@ export const TryIt: React.FC<TryItProps> = ({
   const mediaTypeContent = httpOperation.request?.body?.contents?.[requestBodyIndex ?? 0];
 
   const { allParameters, updateParameterValue, parameterValuesWithDefaults } = useRequestParameters(httpOperation);
+  const [disabledParameters, setDisabledParameters] = React.useState<string[]>([]);
+
   const [mockingOptions, setMockingOptions] = useMockingOptions();
 
   const [bodyParameterValues, setBodyParameterValues, formDataState] = useBodyParameterState(mediaTypeContent);
@@ -129,6 +131,7 @@ export const TryIt: React.FC<TryItProps> = ({
       buildHarRequest({
         mediaTypeContent,
         parameterValues: parameterValuesWithDefaults,
+        disabledParameters,
         httpOperation,
         bodyInput: formDataState.isFormDataBody ? bodyParameterValues : textRequestBody,
         auth: operationAuthValue,
@@ -162,6 +165,7 @@ export const TryIt: React.FC<TryItProps> = ({
     chosenServer,
     corsProxy,
     embeddedInMd,
+    disabledParameters,
   ]);
 
   const handleSendRequest = async () => {
@@ -175,6 +179,7 @@ export const TryIt: React.FC<TryItProps> = ({
       const request = await buildFetchRequest({
         parameterValues: parameterValuesWithDefaults,
         httpOperation,
+        disabledParameters,
         mediaTypeContent,
         bodyInput: formDataState.isFormDataBody ? bodyParameterValues : textRequestBody,
         mockData,
@@ -225,6 +230,14 @@ export const TryIt: React.FC<TryItProps> = ({
           parameters={allParameters}
           values={parameterValuesWithDefaults}
           onChangeValue={updateParameterValue}
+          disabledParameters={disabledParameters}
+          toggleDisabled={parameterName => {
+            if (disabledParameters.includes(parameterName)) {
+              setDisabledParameters(disabledParameters.filter(n => n !== parameterName));
+            } else {
+              setDisabledParameters([...disabledParameters, parameterName]);
+            }
+          }}
           validate={validateParameters}
         />
       )}

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -229,7 +229,7 @@ export const TryIt: React.FC<TryItProps> = ({
         <OperationParameters
           parameters={allParameters}
           values={parameterValuesWithDefaults}
-          onChangeValue={updateParameterValue}
+          onChange={updateParameterValue}
           disabledParameters={disabledParameters}
           toggleDisabled={parameterName => {
             if (disabledParameters.includes(parameterName)) {

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -229,7 +229,7 @@ export const TryIt: React.FC<TryItProps> = ({
         <OperationParameters
           parameters={allParameters}
           values={parameterValuesWithDefaults}
-          onChange={updateParameterValue}
+          onChangeValue={updateParameterValue}
           disabledParameters={disabledParameters}
           toggleDisabled={parameterName => {
             if (disabledParameters.includes(parameterName)) {


### PR DESCRIPTION
Addresses: stoplightio/platform-internal#9109

I'm not sure how this should look (there is no design for it) and I've never really worked on `TryIt` component so I don't know if I'm missing something. But I played with it and it works, so I think it's at least good enough for a review from "elements people" (@mpodlasin @mallachari ) 🙂 

There is more work to be done in UI, but as I said, I'm not sure if I should even do it like this (@mnaumanali94 ?):

<img width="331" alt="Screenshot 2021-12-20 at 16 41 41" src="https://user-images.githubusercontent.com/1868852/146795648-7d33c214-0411-4e7e-9bcd-f8d615d2998b.png">

