### PR TITLE
fix(try-it): empty optional headers

### DIFF
--- a/packages/elements-core/src/__fixtures__/operations/put-todos.ts
+++ b/packages/elements-core/src/__fixtures__/operations/put-todos.ts
@@ -420,6 +420,13 @@ export const httpOperation: IHttpOperation = {
           },
         ],
       },
+      {
+        name: 'optional_header',
+        schema: {
+          type: 'string',
+        },
+        style: HttpParamStyles.Simple,
+      },
     ],
     path: [
       {

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -289,11 +289,13 @@ describe('TryIt', () => {
       expect(queryParams.get('limit')).toBe('3');
       expect(queryParams.get('value')).toBe('1');
       expect(queryParams.get('type')).toBe('another');
+      expect(queryParams.get('optional_value_with_default')).toBeNull();
       // assert that headers are passed
       const headers = new Headers(fetchMock.mock.calls[0][1]!.headers);
       expect(headers.get('Content-Type')).toBe('application/json');
       expect(headers.get('account-id')).toBe('account-id-default 1999');
       expect(headers.get('message-id')).toBe('another example');
+      expect(headers.get('optional_header')).toBeNull();
     });
 
     it('Persists parameter values between operations', async () => {

--- a/packages/elements-core/src/components/TryIt/build-request.ts
+++ b/packages/elements-core/src/components/TryIt/build-request.ts
@@ -71,9 +71,9 @@ export async function buildFetchRequest({
       ?.map(param => ({ name: param.name, value: parameterValues[param.name] ?? '' }))
       .filter(({ value }) => value.length > 0) ?? [];
 
-  const rawHeaders = filterOutAuthorizationParams(httpOperation.request?.headers ?? [], httpOperation.security).map(
-    header => ({ name: header.name, value: parameterValues[header.name] ?? '' }),
-  );
+  const rawHeaders = filterOutAuthorizationParams(httpOperation.request?.headers ?? [], httpOperation.security)
+    .map(header => ({ name: header.name, value: parameterValues[header.name] ?? '' }))
+    .filter(({ value }) => value.length > 0);
 
   const [queryParamsWithAuth, headersWithAuth] = runAuthRequestEhancements(auth, queryParams, rawHeaders);
 


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/9109

Filters out optional headers with no value provided when building request
