### PR TITLE
chore: bump jsv to show more combiners

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -48,7 +48,7 @@
     "@stoplight/json": "^3.10.0",
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.2",
-    "@stoplight/json-schema-viewer": "^4.4.2",
+    "@stoplight/json-schema-viewer": "^4.5.0",
     "@stoplight/markdown": "^3.1.1",
     "@stoplight/markdown-viewer": "^5.3.2",
     "@stoplight/mosaic": "^1.15.2",


### PR DESCRIPTION
# Elements Default PR Template

Bumps JSV to address [9513](https://app.zenhub.com/workspaces/-team-pierogi-platoon-610871b8d6e5310013071b72/issues/stoplightio/platform-internal/9513)

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](https://github.com/stoplightio/elements/blob/main/CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](https://github.com/stoplightio/elements/blob/main/CONTRIBUTING.md#releasing-elements)


Here's a screenshot from elements-core storybook as sanity check:
![Screen Shot 2022-01-05 at 10 59 06 AM](https://user-images.githubusercontent.com/47359669/148257901-1c6a3f61-bd2e-44e2-8b93-8c0d9de08a22.png)
