### PR TITLE
fix(try-it): escape quotes in parameter examples

### DIFF
--- a/packages/elements-core/src/__fixtures__/operations/put-todos.ts
+++ b/packages/elements-core/src/__fixtures__/operations/put-todos.ts
@@ -427,6 +427,24 @@ export const httpOperation: IHttpOperation = {
         },
         style: HttpParamStyles.Simple,
       },
+      {
+        schema: {
+          type: 'string',
+          description: 'Quote or no quote',
+        },
+        name: 'quote',
+        style: HttpParamStyles.Simple,
+        examples: [
+          {
+            value: '',
+            key: 'no quote',
+          },
+          {
+            value: '"',
+            key: 'quote',
+          },
+        ],
+      },
     ],
     path: [
       {

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -43,7 +43,12 @@ export function parameterSupportsFileUpload(parameter: Pick<ParameterSpec, 'sche
 }
 
 function exampleValue(example: INodeExample | INodeExternalExample) {
-  return 'value' in example ? String(example.value) : String(example.externalValue);
+  const value = 'value' in example ? example.value : example.externalValue;
+  return escapeQuotes(String(value));
+}
+
+function escapeQuotes(value: string) {
+  return value.replace(/"/g, '\\"');
 }
 
 export function getPlaceholderForParameter(parameter: ParameterSpec) {

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -277,6 +277,9 @@ describe('TryIt', () => {
       const messageIdField = screen.getByLabelText('message-id-select');
       chooseOption(messageIdField, 'example 2');
 
+      const quoteField = screen.getByLabelText('quote-select');
+      chooseOption(quoteField, 'quote');
+
       // click send
       clickSend();
 
@@ -296,6 +299,9 @@ describe('TryIt', () => {
       expect(headers.get('account-id')).toBe('account-id-default 1999');
       expect(headers.get('message-id')).toBe('another example');
       expect(headers.get('optional_header')).toBeNull();
+
+      // assert that quote is escaped
+      expect(headers.get('quote')).toBe('\\"');
     });
 
     it('Persists parameter values between operations', async () => {


### PR DESCRIPTION
Addresses https://github.com/stoplightio/elements/issues/1857

The reason for elements breaking was a quote in one of the examples: `FF_SEGMENT_RPT_LABELS("ANN_R",0,-1AY,BUS,SEG)` which crashes in mosaic Select due to failure in executing query selector for `data-key="{value_with_quote}"` property.

Escaping quotes (just like in JSV) makes it work. The downside is that it changes the original value. 
Another solution could be escaping it only for the Select component and resetting the original value after selecting but that might be a bit over-engineered way.
