### PR TITLE
fix: encode uri components before calling platform

### DIFF
--- a/packages/elements-dev-portal/src/handlers/__tests__/getBranches.test.ts
+++ b/packages/elements-dev-portal/src/handlers/__tests__/getBranches.test.ts
@@ -1,0 +1,30 @@
+import fetchMock from 'jest-fetch-mock';
+
+import { getBranches } from '../getBranches';
+
+describe('getBranches', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    localStorage.clear();
+  });
+
+  it('should URI encode the parameters in the request URL', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        statusText: 'OK',
+        headers: [],
+      }),
+    );
+
+    await getBranches({
+      projectId: 'some/slash',
+    });
+
+    expect(fetchMock).toBeCalledWith('https://stoplight.io/api/v1/projects/some%2Fslash/branches', {
+      headers: expect.objectContaining({
+        'Stoplight-Elements-Version': expect.any(String),
+      }),
+    });
+  });
+});

--- a/packages/elements-dev-portal/src/handlers/__tests__/getNodeContent.test.ts
+++ b/packages/elements-dev-portal/src/handlers/__tests__/getNodeContent.test.ts
@@ -1,0 +1,35 @@
+import fetchMock from 'jest-fetch-mock';
+
+import { getNodeContent } from '../getNodeContent';
+
+describe('getNodeContent', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    localStorage.clear();
+  });
+
+  it('should URI encode the parameters in the request URL', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        statusText: 'OK',
+        headers: [],
+      }),
+    );
+
+    await getNodeContent({
+      nodeSlug: 'node&slug',
+      projectId: 'some/slash',
+      branchSlug: 'test+branch',
+    });
+
+    expect(fetchMock).toBeCalledWith(
+      'https://stoplight.io/api/v1/projects/some%2Fslash/nodes/node%26slug?branch=test%2Bbranch',
+      {
+        headers: expect.objectContaining({
+          'Stoplight-Elements-Version': expect.any(String),
+        }),
+      },
+    );
+  });
+});

--- a/packages/elements-dev-portal/src/handlers/__tests__/getNodes.test.ts
+++ b/packages/elements-dev-portal/src/handlers/__tests__/getNodes.test.ts
@@ -1,0 +1,38 @@
+import fetchMock from 'jest-fetch-mock';
+
+import { getNodes } from '../getNodes';
+
+describe('getNodes', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    localStorage.clear();
+  });
+
+  describe('with a provided workspace identifier', () => {
+    it('should URI encode the parameters in the request URL', async () => {
+      fetchMock.mockResolvedValue(
+        new Response('{}', {
+          status: 200,
+          statusText: 'OK',
+          headers: [],
+        }),
+      );
+
+      await getNodes({
+        workspaceId: 'my?workspace',
+        projectIds: ['some/slash'],
+        branchSlug: 'test+branch',
+        search: 'a?special&search',
+      });
+
+      expect(fetchMock).toBeCalledWith(
+        'https://stoplight.io/api/v1/workspaces/my%3Fworkspace/nodes?project_ids[0]=some%2Fslash&search=a%3Fspecial%26search&branchSlug=test%2Bbranch',
+        {
+          headers: expect.objectContaining({
+            'Stoplight-Elements-Version': expect.any(String),
+          }),
+        },
+      );
+    });
+  });
+});

--- a/packages/elements-dev-portal/src/handlers/__tests__/getTableOfContents.test.ts
+++ b/packages/elements-dev-portal/src/handlers/__tests__/getTableOfContents.test.ts
@@ -1,0 +1,34 @@
+import fetchMock from 'jest-fetch-mock';
+
+import { getTableOfContents } from '../getTableOfContents';
+
+describe('getTableOfContents', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    localStorage.clear();
+  });
+
+  it('should URI encode the parameters in the request URL', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        statusText: 'OK',
+        headers: [],
+      }),
+    );
+
+    await getTableOfContents({
+      projectId: 'some/slash',
+      branchSlug: 'test+branch',
+    });
+
+    expect(fetchMock).toBeCalledWith(
+      'https://stoplight.io/api/v1/projects/some%2Fslash/table-of-contents?branch=test%2Bbranch',
+      {
+        headers: expect.objectContaining({
+          'Stoplight-Elements-Version': expect.any(String),
+        }),
+      },
+    );
+  });
+});

--- a/packages/elements-dev-portal/src/handlers/__tests__/getWorkspace.test.ts
+++ b/packages/elements-dev-portal/src/handlers/__tests__/getWorkspace.test.ts
@@ -1,0 +1,30 @@
+import fetchMock from 'jest-fetch-mock';
+
+import { getWorkspace } from '../getWorkspace';
+
+describe('getWorkspace', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    localStorage.clear();
+  });
+
+  it('should URI encode the parameters in the request URL', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{}', {
+        status: 200,
+        statusText: 'OK',
+        headers: [],
+      }),
+    );
+
+    await getWorkspace({
+      projectIds: ['some/slash'],
+    });
+
+    expect(fetchMock).toBeCalledWith('https://stoplight.io/api/v1/projects/some%2Fslash', {
+      headers: expect.objectContaining({
+        'Stoplight-Elements-Version': expect.any(String),
+      }),
+    });
+  });
+});

--- a/packages/elements-dev-portal/src/handlers/getBranches.ts
+++ b/packages/elements-dev-portal/src/handlers/getBranches.ts
@@ -10,7 +10,8 @@ export const getBranches = async ({
   platformUrl?: string;
   platformAuthToken?: string;
 }): Promise<Branch[]> => {
-  const response = await fetch(`${platformUrl}/api/v1/projects/${projectId}/branches`, {
+  const encodedProjectId = encodeURIComponent(projectId);
+  const response = await fetch(`${platformUrl}/api/v1/projects/${encodedProjectId}/branches`, {
     headers: {
       'Stoplight-Elements-Version': appVersion,
       ...(platformAuthToken && { Authorization: `Bearer ${platformAuthToken}` }),

--- a/packages/elements-dev-portal/src/handlers/getNodeContent.ts
+++ b/packages/elements-dev-portal/src/handlers/getNodeContent.ts
@@ -25,13 +25,19 @@ export const getNodeContent = async ({
   platformAuthToken?: string;
 }): Promise<Node> => {
   const nodeId = getNodeIdFromSlug(nodeSlug);
-  const branchQuery = branchSlug ? `?branch=${branchSlug}` : '';
-  const response = await fetch(`${platformUrl}/api/v1/projects/${projectId}/nodes/${nodeId}${branchQuery}`, {
-    headers: {
-      'Stoplight-Elements-Version': appVersion,
-      ...(platformAuthToken && { Authorization: `Bearer ${platformAuthToken}` }),
+  const encodedNodeId = encodeURIComponent(nodeId);
+  const encodedProjectId = encodeURIComponent(projectId);
+  const encodedBranchSlug = branchSlug ? encodeURIComponent(branchSlug) : '';
+  const branchQuery = encodedBranchSlug ? `?branch=${encodedBranchSlug}` : '';
+  const response = await fetch(
+    `${platformUrl}/api/v1/projects/${encodedProjectId}/nodes/${encodedNodeId}${branchQuery}`,
+    {
+      headers: {
+        'Stoplight-Elements-Version': appVersion,
+        ...(platformAuthToken && { Authorization: `Bearer ${platformAuthToken}` }),
+      },
     },
-  });
+  );
   const data = await response.json();
 
   if (!response.ok) {

--- a/packages/elements-dev-portal/src/handlers/getNodes.ts
+++ b/packages/elements-dev-portal/src/handlers/getNodes.ts
@@ -20,7 +20,8 @@ export const getNodes = async ({
   let fetchedWorkspaceId = workspaceId || '';
 
   if (!workspaceId && projectIds?.length) {
-    const response = await fetch(`${platformUrl}/api/v1/projects/${projectIds[0]}`, {
+    const encodedProjectId = encodeURIComponent(projectIds[0]);
+    const response = await fetch(`${platformUrl}/api/v1/projects/${encodedProjectId}`, {
       headers: {
         'Stoplight-Elements-Version': appVersion,
         ...(platformAuthToken && { Authorization: `Bearer ${platformAuthToken}` }),
@@ -31,20 +32,28 @@ export const getNodes = async ({
   }
 
   if (projectIds && projectIds.length) {
-    queryParams.push(...projectIds.map((projectId, index) => `project_ids[${index}]=${projectId}`));
+    queryParams.push(
+      ...projectIds.map((projectId, index) => {
+        const encodedProjectId = encodeURIComponent(projectId);
+        return `project_ids[${index}]=${encodedProjectId}`;
+      }),
+    );
   }
 
   if (search) {
-    queryParams.push(`search=${search}`);
+    const encodedSearch = encodeURIComponent(search);
+    queryParams.push(`search=${encodedSearch}`);
   }
 
   if (branchSlug) {
-    queryParams.push(`branchSlug=${branchSlug}`);
+    const encodedBranchSlug = encodeURIComponent(branchSlug);
+    queryParams.push(`branchSlug=${encodedBranchSlug}`);
   }
 
   const query = queryParams.length ? `?${queryParams.join('&')}` : '';
 
-  const response = await fetch(`${platformUrl}/api/v1/workspaces/${fetchedWorkspaceId}/nodes${query}`, {
+  const encodedWorkspaceId = encodeURIComponent(fetchedWorkspaceId);
+  const response = await fetch(`${platformUrl}/api/v1/workspaces/${encodedWorkspaceId}/nodes${query}`, {
     headers: {
       'Stoplight-Elements-Version': appVersion,
       ...(platformAuthToken && { Authorization: `Bearer ${platformAuthToken}` }),

--- a/packages/elements-dev-portal/src/handlers/getTableOfContents.ts
+++ b/packages/elements-dev-portal/src/handlers/getTableOfContents.ts
@@ -12,8 +12,10 @@ export const getTableOfContents = async ({
   platformUrl?: string;
   platformAuthToken?: string;
 }): Promise<ProjectTableOfContents> => {
-  const branchQuery = branchSlug ? `?branch=${branchSlug}` : '';
-  const response = await fetch(`${platformUrl}/api/v1/projects/${projectId}/table-of-contents${branchQuery}`, {
+  const encodedProjectId = encodeURIComponent(projectId);
+  const encodedBranchSlug = branchSlug ? encodeURIComponent(branchSlug) : '';
+  const branchQuery = encodedBranchSlug ? `?branch=${encodedBranchSlug}` : '';
+  const response = await fetch(`${platformUrl}/api/v1/projects/${encodedProjectId}/table-of-contents${branchQuery}`, {
     headers: {
       'Stoplight-Elements-Version': appVersion,
       ...(platformAuthToken && { Authorization: `Bearer ${platformAuthToken}` }),

--- a/packages/elements-dev-portal/src/handlers/getWorkspace.ts
+++ b/packages/elements-dev-portal/src/handlers/getWorkspace.ts
@@ -10,7 +10,8 @@ export const getWorkspace = async ({
   platformUrl?: string;
   platformAuthToken?: string;
 }): Promise<Workspace> => {
-  const response = await fetch(`${platformUrl}/api/v1/projects/${projectIds[0]}`, {
+  const encodedProjectId = encodeURIComponent(projectIds[0]);
+  const response = await fetch(`${platformUrl}/api/v1/projects/${encodedProjectId}`, {
     headers: {
       'Stoplight-Elements-Version': appVersion,
       ...(platformAuthToken && { Authorization: `Bearer ${platformAuthToken}` }),


### PR DESCRIPTION
This fixes places where the platform URL components were only concatenated and not encoded. I separated out the encoded variables in order to maintain readability of the interpolated string