### PR TITLE
fix: don't add "undefined" to the end of links

### DIFF
--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -119,7 +119,7 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
     );
 
     if (edge) {
-      return <Link to={`${edge.slug}${hash && `#${hash}`}`}>{children}</Link>;
+      return <Link to={`${edge.slug}${hash ? `#${hash}` : ''}`}>{children}</Link>;
     }
   }
 


### PR DESCRIPTION
@jgreen44 pointed me to the line. I'm like, 95% confident this will fix #1969.

Update: I have tested it by yalcing dev portal into platform-internal and confirm it does the trick.