### PR TITLE
fix: responseType slow regex check

### DIFF
--- a/packages/elements-core/src/components/TryIt/Response/Response.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/Response/Response.spec.tsx
@@ -116,6 +116,7 @@ describe('Response', () => {
   it.each([
     ['application/json', 'json'],
     [`application/json; charset='utf-8'`, 'json'],
+    ['application/example.com.kontakt+json;version=10;charset=UTF-8', 'json'],
     ['application/foo-json', 'json'],
     ['application/xml', 'xml'],
     ['application/html', 'xml'],
@@ -130,7 +131,13 @@ describe('Response', () => {
     ['image/png', 'image'],
     ['image/svg', 'image'],
   ])('correctly maps %s mime type', (contentType, type) => {
+    const timerStart = Date.now();
     const responseType = getResponseType(contentType);
+    const timerEnd = Date.now();
+
     expect(responseType).toEqual(type);
+
+    // checking if regex is not too slow (https://github.com/stoplightio/platform-internal/issues/9446)
+    expect(timerEnd - timerStart).toBeLessThan(5000);
   });
 });

--- a/packages/elements-core/src/components/TryIt/Response/Response.tsx
+++ b/packages/elements-core/src/components/TryIt/Response/Response.tsx
@@ -31,9 +31,9 @@ const bodyFormatMap: Record<ContentType, BodyFormat[]> = {
 };
 
 const regex: Record<ContentType, RegExp> = {
-  image: /image\/(.+)*(jpeg|gif|png|svg)/,
-  json: /application\/(.+)*json/,
-  xml: /(text|application)\/(.+)*(xml|html)/,
+  image: /image\/(.?)*(jpeg|gif|png|svg)/,
+  json: /application\/(.?)*json/,
+  xml: /(text|application)\/(.?)*(xml|html)/,
   text: /text\/.*/,
 };
 


### PR DESCRIPTION
For: https://github.com/stoplightio/platform-internal/issues/9446

It can be reproduced by using this [spec](https://stoplight.io/api/v1/projects/kontakt-api-docs/dev-ctr-device-api/nodes/spec10.json) (with api key in issue) but I've also added a speed test for that function