### PR TITLE
chore: refResolver param in Docs and NodeContent

### DIFF
--- a/packages/elements-core/src/components/Docs/Docs.tsx
+++ b/packages/elements-core/src/components/Docs/Docs.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { InlineRefResolverProvider } from '../../context/InlineRefResolver';
 import { useParsedData } from '../../hooks/useParsedData';
 import { ParsedNode } from '../../types';
+import { ReferenceResolver } from '../../utils/ref-resolving/ReferenceResolver';
 import { Article } from './Article';
 import { HttpOperation } from './HttpOperation';
 import { HttpService } from './HttpService';
@@ -110,6 +111,7 @@ export interface DocsProps extends BaseDocsProps {
   nodeType: NodeType;
   nodeData: unknown;
   useNodeForRefResolving?: boolean;
+  refResolver?: ReferenceResolver;
 }
 
 export interface DocsComponentProps<T = unknown> extends BaseDocsProps {
@@ -119,22 +121,28 @@ export interface DocsComponentProps<T = unknown> extends BaseDocsProps {
   data: T;
 }
 
-export const Docs = React.memo<DocsProps>(({ nodeType, nodeData, useNodeForRefResolving = false, ...commonProps }) => {
-  const parsedNode = useParsedData(nodeType, nodeData);
+export const Docs = React.memo<DocsProps>(
+  ({ nodeType, nodeData, useNodeForRefResolving = false, refResolver, ...commonProps }) => {
+    const parsedNode = useParsedData(nodeType, nodeData);
 
-  if (!parsedNode) {
-    // TODO: maybe report failure
-    return null;
-  }
+    if (!parsedNode) {
+      // TODO: maybe report failure
+      return null;
+    }
 
-  const parsedDocs = <ParsedDocs node={parsedNode} {...commonProps} />;
+    const parsedDocs = <ParsedDocs node={parsedNode} {...commonProps} />;
 
-  if (useNodeForRefResolving) {
-    return <InlineRefResolverProvider document={parsedNode.data}>{parsedDocs}</InlineRefResolverProvider>;
-  }
+    if (useNodeForRefResolving) {
+      return (
+        <InlineRefResolverProvider document={parsedNode.data} resolver={refResolver}>
+          {parsedDocs}
+        </InlineRefResolverProvider>
+      );
+    }
 
-  return parsedDocs;
-});
+    return parsedDocs;
+  },
+);
 
 export interface ParsedDocsProps extends BaseDocsProps {
   node: ParsedNode;

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -1,4 +1,10 @@
-import { CustomLinkComponent, Docs, MarkdownComponentsProvider, MockingProvider } from '@stoplight/elements-core';
+import {
+  CustomLinkComponent,
+  Docs,
+  MarkdownComponentsProvider,
+  MockingProvider,
+  ReferenceResolver,
+} from '@stoplight/elements-core';
 import { CustomComponentMapping } from '@stoplight/markdown-viewer';
 import { dirname, resolve } from '@stoplight/path';
 import { NodeType } from '@stoplight/types';
@@ -45,6 +51,11 @@ export type NodeContentProps = {
    * @default false
    */
   tryItCorsProxy?: string;
+
+  /**
+   * Support for custom reference resolver
+   */
+  refResolver?: ReferenceResolver;
 };
 
 export const NodeContent = ({
@@ -56,6 +67,7 @@ export const NodeContent = ({
   hideExport,
   tryItCredentialsPolicy,
   tryItCorsProxy,
+  refResolver,
 }: NodeContentProps) => {
   return (
     <NodeLinkContext.Provider value={[node, Link]}>
@@ -71,6 +83,7 @@ export const NodeContent = ({
               hideExport: hideExport || node.links.export_url === undefined,
             }}
             useNodeForRefResolving
+            refResolver={refResolver}
             tryItCorsProxy={tryItCorsProxy}
             exportProps={
               [NodeType.HttpService, NodeType.Model].includes(node.type as NodeType)


### PR DESCRIPTION
For [stoplightio/platform-internal/8677](https://github.com/stoplightio/platform-internal/issues/8677)
Connected PR: https://github.com/stoplightio/platform-internal/pull/9882

Adds ability to pass a custom `refResolver` function in `NodeContent` and `Docs`