### PR TITLE
fix(embedded-jsv): use resolved value if one exists in the markdown tree

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -49,7 +49,7 @@
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.2",
     "@stoplight/json-schema-viewer": "^4.5.0",
-    "@stoplight/markdown-viewer": "^5.4.1",
+    "@stoplight/markdown-viewer": "^5.4.2",
     "@stoplight/mosaic": "^1.15.2",
     "@stoplight/mosaic-code-editor": "^1.15.2",
     "@stoplight/mosaic-code-viewer": "^1.15.2",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.5.10",
+  "version": "7.5.11",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
@@ -56,9 +56,9 @@ const SchemaAndDescription = ({ title: titleProp, schema }: ISchemaAndDescriptio
 export { DefaultSMDComponents };
 
 export const CodeComponent: CustomComponentMapping['code'] = props => {
-  const { title, jsonSchema, http, children } = props;
+  const { title, jsonSchema, http, resolved, children } = props;
 
-  const value = String(Array.isArray(children) ? children[0] : children);
+  const value = resolved || String(Array.isArray(children) ? children[0] : children);
   const parsedValue = useParsedValue(value);
 
   if (jsonSchema) {

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
-    "@stoplight/elements-core": "~7.5.10",
+    "@stoplight/elements-core": "~7.5.11",
     "@stoplight/markdown-viewer": "^5.4.2",
     "@stoplight/mosaic": "^1.15.2",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
     "@stoplight/elements-core": "~7.5.10",
-    "@stoplight/markdown-viewer": "^5.4.1",
+    "@stoplight/markdown-viewer": "^5.4.2",
     "@stoplight/mosaic": "^1.15.2",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^12.0.0",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.5.10",
+  "version": "7.5.11",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@stoplight/elements-core": "~7.5.10",
+    "@stoplight/elements-core": "~7.5.11",
     "@stoplight/http-spec": "^4.3.1",
     "@stoplight/json": "^3.10.0",
     "@stoplight/mosaic": "^1.15.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3643,10 +3643,10 @@
   dependencies:
     wolfy87-eventemitter "~5.2.8"
 
-"@stoplight/markdown-viewer@^5.4.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-5.4.1.tgz#72c2846e5e89b477f14ccc8c7e27e88641e3a699"
-  integrity sha512-s0NwEDHjWDz4BNlX2qbqEN+pQkmXVj5hmSvd2nbs39SJp8nNyC4w2Qwgj6ElRYRveja+XuOybY0Z+tQw4U/dmA==
+"@stoplight/markdown-viewer@^5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/markdown-viewer/-/markdown-viewer-5.4.2.tgz#e814324ccea827cbb06d4eebfce23e37e5bca426"
+  integrity sha512-1lkx7ibRqqiA+DDjcPEZ8pS61idFAieACZR2r2Ar3tdki6jvM1O+REYI4ggJJKRDh0/KVX4l/C8GF8StTkAl3A==
   dependencies:
     "@fortawesome/free-solid-svg-icons" "^5.15.4"
     "@rehooks/component-size" "^1.0.3"


### PR DESCRIPTION
~Needs https://github.com/stoplightio/markdown-viewer/pull/114~
Needed by https://github.com/stoplightio/platform-internal/pull/9586

Use the `resolved` property if it exists on the MDAST tree.

This allows us to display the resolved schema when embedded in markdown (see image)

![image](https://user-images.githubusercontent.com/7423098/151465979-559cc821-22f2-4a70-81ae-459b737c88ff.png)
