### PR TITLE
Add CORS handling for web-components

### DIFF
--- a/packages/elements-core/src/hooks/useBundleRefsIntoDocument.ts
+++ b/packages/elements-core/src/hooks/useBundleRefsIntoDocument.ts
@@ -9,6 +9,7 @@ import * as React from 'react';
 
 interface Options {
   baseUrl?: string;
+  withCredentials?: boolean;
 }
 
 /**
@@ -18,6 +19,7 @@ export function useBundleRefsIntoDocument(document: unknown, options?: Options) 
   const [bundledData, setBundledData] = React.useState(document);
 
   const baseUrl = options?.baseUrl;
+  const withCredentials = options?.withCredentials;
 
   React.useEffect(() => {
     if (!isObject(document)) {
@@ -26,7 +28,7 @@ export function useBundleRefsIntoDocument(document: unknown, options?: Options) 
     }
 
     let isMounted = true;
-    doBundle(document, baseUrl)
+    doBundle(document, baseUrl, withCredentials)
       .then(res => {
         if (isMounted) {
           setBundledData({ ...res }); // this hmm....library mutates document so a shallow copy is required to force a rerender in all cases
@@ -45,13 +47,18 @@ export function useBundleRefsIntoDocument(document: unknown, options?: Options) 
     return () => {
       isMounted = false;
     };
-  }, [document, baseUrl]);
+  }, [document, baseUrl, withCredentials]);
 
   return bundledData;
 }
 
-const commonBundleOptions = { continueOnError: true };
-const doBundle = (data: object, baseUrl?: string) => {
+const doBundle = (data: object, baseUrl?: string, withCredentials?: boolean) => {
+  const commonBundleOptions: $RefParser.Options = {
+    continueOnError: true,
+    resolve: {
+      http: <$RefParser.HTTPResolverOptions>{ withCredentials },
+    },
+  };
   if (!baseUrl) {
     return $RefParser.bundle(data, commonBundleOptions);
   } else {

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.6.7';
+export const appVersion = '1.6.9';

--- a/packages/elements/src/containers/API.tsx
+++ b/packages/elements/src/containers/API.tsx
@@ -88,6 +88,13 @@ export interface CommonAPIProps extends RoutingProps {
    * @default false
    */
   tryItCorsProxy?: string;
+
+  /**
+   * Whether to include CORS credentials (cookies, authorization headers, TLS client certificates)
+   * in remote ref requests
+   * @default: false
+   */
+  withCredentials?: boolean;
 }
 
 const propsAreWithDocument = (props: APIProps): props is APIPropsWithDocument => {
@@ -105,6 +112,7 @@ export const APIImpl: React.FC<APIProps> = props => {
     hideExport,
     tryItCredentialsPolicy,
     tryItCorsProxy,
+    withCredentials,
   } = props;
   const apiDescriptionDocument = propsAreWithDocument(props) ? props.apiDescriptionDocument : undefined;
 
@@ -124,7 +132,7 @@ export const APIImpl: React.FC<APIProps> = props => {
 
   const document = apiDescriptionDocument || fetchedDocument || '';
   const parsedDocument = useParsedValue(document);
-  const bundledDocument = useBundleRefsIntoDocument(parsedDocument, { baseUrl: apiDescriptionUrl });
+  const bundledDocument = useBundleRefsIntoDocument(parsedDocument, { baseUrl: apiDescriptionUrl, withCredentials });
   const serviceNode = React.useMemo(() => transformOasToServiceNode(bundledDocument), [bundledDocument]);
   const exportProps = useExportDocumentProps({ originalDocument: document, bundledDocument });
 

--- a/packages/elements/src/web-components/components.ts
+++ b/packages/elements/src/web-components/components.ts
@@ -16,4 +16,5 @@ export const ApiElement = createElementClass(API, {
   logo: { type: 'string' },
   tryItCredentialsPolicy: { type: 'string' },
   tryItCorsProxy: { type: 'string' },
+  withCredentials: { type: 'boolean' },
 });


### PR DESCRIPTION
# Elements Default PR Template

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

I found myself using `elements` to create an online schema viewer that lives behind an authenticated proxy.  Things _mostly_ worked, except for parts of our schema that were remote `$ref` references in the primary schema document.  When `elements` attempted to resolve them in our environment, the browser console log exploded with CORS-related errors.

After a bunch of digging, it turned out that by default, `elements` was leaving [`@stoplight/json-schema-ref-parser`](https://github.com/stoplightio/json-schema-ref-parser/blob/master/lib/resolvers/http.js#L45-L51) use it's default HTTP resolver settings, which has has `credentials: 'omit'` in the options passed to `fetch()`.  This fails when CORS headers are required.

This PR doesn't change the default, but exposes a new option to the `elements-api` tag called `withCredentials` that is passed through to `@stoplight/json-schema-ref-parser`, allowing user control over whether CORS handling is enabled or not.

I'm not a front-end person by default, so apologies if the style of this PR is out of line, or if I've missed something fundamental.  These changes appear to be functioning as intendent in the environment where I have them deployed.