### PR TITLE
fix(core): gracefully handle invalid URLs in server objects

### DIFF
--- a/packages/elements-core/src/utils/guards.ts
+++ b/packages/elements-core/src/utils/guards.ts
@@ -25,10 +25,10 @@ export function isHttpOperation(maybeHttpOperation: unknown): maybeHttpOperation
   return isStoplightNode(maybeHttpOperation) && 'method' in maybeHttpOperation && 'path' in maybeHttpOperation;
 }
 
-export function isProperUrl(url: string) {
-  const properUrl = new RegExp(
-    /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/,
-  );
+const properUrl = new RegExp(
+  /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/,
+);
 
-  return url.match(properUrl);
+export function isProperUrl(url: string) {
+  return properUrl.test(url);
 }

--- a/packages/elements-core/src/utils/http-spec/__tests__/IServer.spec.ts
+++ b/packages/elements-core/src/utils/http-spec/__tests__/IServer.spec.ts
@@ -1,0 +1,30 @@
+import type { IServer } from '@stoplight/types';
+
+import { getServersToDisplay, getServerUrlWithDefaultValues } from '../IServer';
+
+describe('IServer', () => {
+  describe('getServerUrlWithDefaultValues()', () => {
+    it('should handle invalid server URLs', () => {
+      const server: IServer = {
+        url: 'https://[env].stoplight.io/v1',
+      };
+
+      expect(getServerUrlWithDefaultValues(server)).toBeNull();
+    });
+  });
+
+  describe('getServersToDisplay', () => {
+    it('should filter out server objects containing invalid URLs', () => {
+      const servers: IServer[] = [
+        {
+          url: 'https://[env].stoplight.io/v1',
+        },
+        {
+          url: 'https://stoplight.io/v1',
+        },
+      ];
+
+      expect(getServersToDisplay(servers)).toStrictEqual([{ description: 'Server 2', url: 'https://stoplight.io/v1' }]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/stoplightio/platform-internal/issues/9800

According to [RFC3986#3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2), which OAS spec adheres to, `[` and `]` are not valid chars to use as a host.

I'm uncertain how to handle https://github.com/stoplightio/elements/blob/9f9ae13782edde922f4299a3db817a545095aa55/packages/elements-core/src/components/TryIt/build-request.ts#L44L45 from the UX standpoint.
If the URL is invalid, we'll end up using the current origin of the active frame elements is embedded in, which might be a potentially jarring experience. 
Either way, since this is likely uncommon to happen, we may be good to leave it as is.
