### PR TITLE
fix(elements-core): allow trailing slash use for endpoints

### DIFF
--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -79,6 +79,7 @@ export const TryIt: React.FC<TryItProps> = ({
   tryItCredentialsPolicy,
   corsProxy,
 }) => {
+  TryIt.displayName = 'TryIt';
   const isDark = useThemeIsDark();
 
   const [response, setResponse] = React.useState<ResponseState | ErrorState | undefined>();

--- a/packages/elements-core/src/components/TryIt/build-request.ts
+++ b/packages/elements-core/src/components/TryIt/build-request.ts
@@ -78,7 +78,9 @@ export async function buildFetchRequest({
   const [queryParamsWithAuth, headersWithAuth] = runAuthRequestEhancements(auth, queryParams, rawHeaders);
 
   const expandedPath = uriExpand(httpOperation.path, parameterValues);
-  const url = new URL(URI(serverUrl).segment(expandedPath).toString());
+
+  // url is concatenated this way to avoid /user and /user/ endpoint edge cases
+  const url = new URL(serverUrl + '/' + expandedPath);
   url.search = new URLSearchParams(queryParamsWithAuth.map(nameAndValueObjectToPair)).toString();
 
   const body = typeof bodyInput === 'object' ? await createRequestBody(mediaTypeContent, bodyInput) : bodyInput;

--- a/packages/elements-core/src/components/TryIt/build-request.ts
+++ b/packages/elements-core/src/components/TryIt/build-request.ts
@@ -1,6 +1,5 @@
 import { Dictionary, IHttpOperation, IMediaTypeContent, IServer } from '@stoplight/types';
 import { Request as HarRequest } from 'har-format';
-import URI from 'urijs';
 
 import { getServerUrlWithDefaultValues } from '../../utils/http-spec/IServer';
 import {
@@ -192,6 +191,7 @@ export async function buildHarRequest({
 
   const [queryParamsWithAuth, headerParamsWithAuth] = runAuthRequestEhancements(auth, queryParams, headerParams);
   const extendedPath = uriExpand(httpOperation.path, parameterValues);
+  const combinedUrl = serverUrl + extendedPath;
 
   let postData: HarRequest['postData'] = undefined;
   if (shouldIncludeBody && typeof bodyInput === 'string') {
@@ -218,7 +218,7 @@ export async function buildHarRequest({
 
   return {
     method: httpOperation.method.toUpperCase(),
-    url: URI(serverUrl).segment(extendedPath).toString(),
+    url: combinedUrl,
     httpVersion: 'HTTP/1.1',
     cookies: [],
     headers: [{ name: 'Content-Type', value: mimeType }, ...headerParamsWithAuth],

--- a/packages/elements-core/src/components/TryIt/build-request.ts
+++ b/packages/elements-core/src/components/TryIt/build-request.ts
@@ -78,9 +78,9 @@ export async function buildFetchRequest({
 
   const expandedPath = uriExpand(httpOperation.path, parameterValues);
 
-  // url is concatenated this way to avoid /user and /user/ endpoint edge cases
-  const url = new URL(serverUrl + '/' + expandedPath);
-  url.search = new URLSearchParams(queryParamsWithAuth.map(nameAndValueObjectToPair)).toString();
+  // urlObject is concatenated this way to avoid /user and /user/ endpoint edge cases
+  const urlObject = new URL(serverUrl + expandedPath);
+  urlObject.search = new URLSearchParams(queryParamsWithAuth.map(nameAndValueObjectToPair)).toString();
 
   const body = typeof bodyInput === 'object' ? await createRequestBody(mediaTypeContent, bodyInput) : bodyInput;
 
@@ -94,7 +94,7 @@ export async function buildFetchRequest({
   };
 
   return [
-    url.toString(),
+    urlObject.href,
     {
       credentials,
       method: httpOperation.method.toUpperCase(),
@@ -190,8 +190,8 @@ export async function buildHarRequest({
   }
 
   const [queryParamsWithAuth, headerParamsWithAuth] = runAuthRequestEhancements(auth, queryParams, headerParams);
-  const extendedPath = uriExpand(httpOperation.path, parameterValues);
-  const combinedUrl = serverUrl + extendedPath;
+  const expandedPath = uriExpand(httpOperation.path, parameterValues);
+  const urlObject = new URL(serverUrl + expandedPath);
 
   let postData: HarRequest['postData'] = undefined;
   if (shouldIncludeBody && typeof bodyInput === 'string') {
@@ -218,7 +218,7 @@ export async function buildHarRequest({
 
   return {
     method: httpOperation.method.toUpperCase(),
-    url: combinedUrl,
+    url: urlObject.href,
     httpVersion: 'HTTP/1.1',
     cookies: [],
     headers: [{ name: 'Content-Type', value: mimeType }, ...headerParamsWithAuth],


### PR DESCRIPTION
Addresses: [#9966](https://github.com/stoplightio/platform-internal/issues/9966)

**Summary**

Endpoints that had trailing slashes (ex. /user/) were returning a response of 422 (sometimes). This was because the trailing slash was being stripped out, ultimately pointing to either a non-existent path, or in an edge-case, to the wrong path (ex. /user). This edge-case was returning a response of 200. Allowing the use of a trailing slash now points to two paths if necessary (/user and /user/).

**Steps to Test**

1. Create API project in local or prod with both use-cases:
a. With endpoint /user
b. With endpoint /user/
2. Run storybook in elements-dev-portal
3. Copy nodeSlug, projectId from newly created API project (step 1)
4. Paste values into Storybook and use https://stoplight.io (if step 1 is prod) or https://stoplight-local.com (if step 1 is local) for platformUrl
5. Select endpoint /user
6. In the TryIt component, select Mock Server, click Send API Request (res should equal 200)
7. Select endpoint /user/
8. In the TryIt component, select Mock Server, click Send API Request (res should equal 200)
NOTE: Step 8 is the edge-case. The 200 response is because it's requesting from /user, not /user/

9. Delete endpoint /user
10. Select endpoint /user/
11. In the TryIt component, select Mock Server, click Send API Request (res should equal 200)
NOTE: Response used to return 422