### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,3 @@
 # the repo. Unless a later match takes precedence,
 # @lottamus will be requested for
 # review when someone opens a pull request.
-*       @mnaumanali94 @stoplightio/pierogi-platoon


### PR DESCRIPTION
Removing the Nauman/Pierogi requirement so that other Stoplight teams can approve PRs for elements.