### PR TITLE
fix(dev-portal): support links to http operations

### DIFF
--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -128,7 +128,6 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
     const [resolvedUriWithoutAnchor, hash] = resolvedUri.split('#');
     const decodedUrl = decodeURIComponent(href);
     const decodedResolvedUriWithoutAnchor = decodeURIComponent(resolvedUriWithoutAnchor);
-
     const edge = node.outbound_edges.find(
       edge => edge.uri === decodedUrl || edge.uri === decodedResolvedUriWithoutAnchor,
     );
@@ -158,8 +157,7 @@ function getBundledUrl(url: string | undefined) {
 // pointer = /paths/~1v2~1contact~1last_change/post#heading-anchor
 export const getNodeUriParts = (uri: string): { fileUri: string; pointer: string } => {
   const parts = uri.split(/(\.yaml|\.yml|\.json|\.md)/);
-  const fileUri = parts[0] || '' + parts[1] || '';
-  const pointer = parts[2] ? `${parts[2]}` : '';
+  const fileUri = `${parts[0] || ''}${parts[1] || ''}`;
 
-  return { fileUri, pointer };
+  return { fileUri, pointer: parts[2] || '' };
 };

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -123,14 +123,11 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
   if (href && ctx) {
     const [node, Link] = ctx;
     // Resolve relative file URI with
-    const { fileUri } = getNodeUriParts(node.uri);
-    const resolvedUri = resolve(dirname(fileUri), href);
-    const [resolvedUriWithoutAnchor, hash] = resolvedUri.split('#');
+    const { fileUri, pointer } = getNodeUriParts(node.uri);
+    const hash = pointer[0] === '#' ? pointer.slice(1) : null;
     const decodedUrl = decodeURIComponent(href);
-    const decodedResolvedUriWithoutAnchor = decodeURIComponent(resolvedUriWithoutAnchor);
-    const edge = node.outbound_edges.find(
-      edge => edge.uri === decodedUrl || edge.uri === decodedResolvedUriWithoutAnchor,
-    );
+    const decodedFileUri = decodeURIComponent(fileUri);
+    const edge = node.outbound_edges.find(edge => edge.uri === decodedUrl || edge.uri === decodedFileUri);
 
     if (edge) {
       return <Link to={`${edge.slug}${hash ? `#${hash}` : ''}`}>{children}</Link>;

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -124,7 +124,17 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
     const [node, Link] = ctx;
     // Resolve relative file URI with
     const { fileUri } = getNodeUriParts(node.uri);
-    const resolvedUri = resolve(dirname(fileUri), href);
+    const { fileUri: hrefFileUri } = getNodeUriParts(href);
+
+    let resolvedUri;
+    if (hrefFileUri) {
+      // if the href is targeting another file, resolve it against the dir path of current file
+      resolvedUri = resolve(dirname(fileUri), href);
+    } else {
+      // If the href does not include a file, resolve it relative to the current file
+      resolvedUri = resolve(fileUri, href);
+    }
+
     const [resolvedUriWithoutAnchor, hash] = resolvedUri.split('#');
     const decodedUrl = decodeURIComponent(href);
     const decodedResolvedUriWithoutAnchor = decodeURIComponent(resolvedUriWithoutAnchor);
@@ -157,6 +167,10 @@ function getBundledUrl(url: string | undefined) {
 // pointer = /paths/~1v2~1contact~1last_change/post#heading-anchor
 export const getNodeUriParts = (uri: string): { fileUri: string; pointer: string } => {
   const parts = uri.split(/(\.yaml|\.yml|\.json|\.md)/);
+  if (parts.length === 1) {
+    return { fileUri: '', pointer: parts[0] || '' };
+  }
+
   const fileUri = `${parts[0] || ''}${parts[1] || ''}`;
 
   return { fileUri, pointer: parts[2] || '' };

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -128,7 +128,7 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
     const [resolvedUriWithoutAnchor, hash] = resolvedUri.split('#');
     const decodedUrl = decodeURIComponent(href);
     const decodedResolvedUriWithoutAnchor = decodeURIComponent(resolvedUriWithoutAnchor);
-    console.log({ fileUri, resolvedUri, resolvedUriWithoutAnchor, decodedUrl });
+
     const edge = node.outbound_edges.find(
       edge => edge.uri === decodedUrl || edge.uri === decodedResolvedUriWithoutAnchor,
     );

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -123,11 +123,14 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
   if (href && ctx) {
     const [node, Link] = ctx;
     // Resolve relative file URI with
-    const { fileUri, pointer } = getNodeUriParts(node.uri);
-    const hash = pointer[0] === '#' ? pointer.slice(1) : null;
+    const { fileUri } = getNodeUriParts(node.uri);
+    const resolvedUri = resolve(dirname(fileUri), href);
+    const [resolvedUriWithoutAnchor, hash] = resolvedUri.split('#');
     const decodedUrl = decodeURIComponent(href);
-    const decodedFileUri = decodeURIComponent(fileUri);
-    const edge = node.outbound_edges.find(edge => edge.uri === decodedUrl || edge.uri === decodedFileUri);
+    const decodedResolvedUriWithoutAnchor = decodeURIComponent(resolvedUriWithoutAnchor);
+    const edge = node.outbound_edges.find(
+      edge => edge.uri === decodedUrl || edge.uri === decodedResolvedUriWithoutAnchor,
+    );
 
     if (edge) {
       return <Link to={`${edge.slug}${hash ? `#${hash}` : ''}`}>{children}</Link>;


### PR DESCRIPTION
This change allows one to link into an operation or schema that is defined in an openapi specification, along the lines of `[My link to a specific http operation](/reference/openapi.json/paths/~1v2~1contact~1last_change/post)`.