### PR TITLE
Update docs to pin create-react-app to 4.0.3 when using elements templates

### DIFF
--- a/docs/getting-started/dev-portal/react.md
+++ b/docs/getting-started/dev-portal/react.md
@@ -6,8 +6,10 @@ Learn how to quickly get started with Elements Dev Portal in a React project.
 
 We've created a [Create React App template](https://github.com/stoplightio/cra-template-elements-dev-portal), which allows you to create a brand new Elements Dev Portal website in React without any additional setup.
 
+> Note: [The Create React App template only works with version 4 of create-react-app because of Webpack 5 polyfill issues.](https://github.com/facebook/create-react-app/issues/11756)
+
 ```bash
-npx create-react-app my-dir --template @stoplight/elements-dev-portal
+npx create-react-app@4.0.3 my-dir --template @stoplight/elements-dev-portal
 ```
 
 Then run `cd my-dir` and `yarn start` and you will see a basic Elements Dev Portal website in the browser.

--- a/docs/getting-started/elements/react.md
+++ b/docs/getting-started/elements/react.md
@@ -6,8 +6,10 @@ Learn how to quickly get started with Elements in a React project.
 
 We've created a [Create React App template](https://github.com/stoplightio/cra-template-elements), which allows you to create a brand new Elements website in React without any additional setup.
 
+> Note: [The Create React App template only works with version 4 of create-react-app because of Webpack 5 polyfill issues.](https://github.com/facebook/create-react-app/issues/11756)
+
 ```bash
-npx create-react-app my-dir --template @stoplight/elements
+npx create-react-app@4.0.3 my-dir --template @stoplight/elements
 ```
 
 Then run `cd my-dir` and `yarn start` and you will see a basic Elements website in the browser.


### PR DESCRIPTION
Partially addresses https://github.com/stoplightio/elements/issues/2058.

We're still looking into alternatives to CRA such as:
- [Create Next App with `-e`](https://nextjs.org/docs/api-reference/create-next-app#options)
- [npm init using](https://ar.al/2021/04/01/npm-init-using/)
- [Vite/degit](https://vitejs.dev/guide/#community-templates)
- etc.

There is also https://github.com/stoplightio/dev-portal/tree/plugin but DnC didn't create it and it would need more documentation in place before suggesting it to new users.

I have [a PoC](https://github.com/stoplightio/elements-template) to test some of these other options but it's broken and needs more work.

For now this documentation update will at least not immediately give errors for new users of `elements`.