### PR TITLE
fix(StoplightProject): handle redirect to node slug

### DIFF
--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.6.16",
+  "version": "1.6.17",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -122,6 +122,9 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
     }
   } else if (!node) {
     elem = <NotFound />;
+  } else if (node?.slug && nodeSlug !== node.slug) {
+    // Handle redirect to node's slug
+    return <Redirect to={branchSlug ? `/branches/${branchSlug}/${node.slug}` : `/${node.slug}`} />;
   } else {
     elem = (
       <NodeContent


### PR DESCRIPTION
If a node's name is changed, we will automatically redirect to the new node slug.

- Fixes https://github.com/stoplightio/platform-internal/issues/10770