### PR TITLE
chore: bumping version after elements-core update

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^7.5.13",
+    "@stoplight/elements": "^7.5.14",
     "@stoplight/mosaic": "^1.15.4",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.5.13",
+  "version": "7.5.14",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.6.17",
+  "version": "1.6.18",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
-    "@stoplight/elements-core": "~7.5.13",
+    "@stoplight/elements-core": "~7.5.14",
     "@stoplight/markdown-viewer": "^5.4.2",
     "@stoplight/mosaic": "^1.16.2",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.5.13",
+  "version": "7.5.14",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@stoplight/elements-core": "~7.5.13",
+    "@stoplight/elements-core": "~7.5.14",
     "@stoplight/http-spec": "^4.3.1",
     "@stoplight/json": "^3.10.0",
     "@stoplight/mosaic": "^1.16.2",


### PR DESCRIPTION
# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)


Pushing a version bump for issue 10336 (PR that's already merged was 2093)
