### PR TITLE
chore: update markdown-viewer versions and bump elements versions

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^7.5.17",
+    "@stoplight/elements": "^7.5.18",
     "@stoplight/mosaic": "^1.15.4",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.5.17",
+  "version": "7.5.18",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",
@@ -57,7 +57,7 @@
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.2",
     "@stoplight/json-schema-viewer": "^4.5.0",
-    "@stoplight/markdown-viewer": "^5.4.6",
+    "@stoplight/markdown-viewer": "^5.4.7",
     "@stoplight/mosaic": "^1.19.1",
     "@stoplight/mosaic-code-editor": "^1.19.1",
     "@stoplight/mosaic-code-viewer": "^1.19.1",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.10.2",
-    "@stoplight/elements-core": "~7.5.17",
-    "@stoplight/markdown-viewer": "^5.4.6",
+    "@stoplight/elements-core": "~7.5.18",
+    "@stoplight/markdown-viewer": "^5.4.7",
     "@stoplight/mosaic": "^1.16.2",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^13.0.0",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.5.17",
+  "version": "7.5.18",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
-    "@stoplight/elements-core": "~7.5.17",
+    "@stoplight/elements-core": "~7.5.18",
     "@stoplight/http-spec": "^5.1.0",
     "@stoplight/json": "^3.18.0",
     "@stoplight/mosaic": "^1.16.2",


### PR DESCRIPTION
Fix to table borders in markdown-viewer; need to update to point to the new package and bump elements versions to create new package.
