### PR TITLE
Fix: missing dependency in package.json for static html example

### DIFF
--- a/examples/static-html/package.json
+++ b/examples/static-html/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "@stoplight/elements-dev-portal": "^1.0.0"
   }
 }


### PR DESCRIPTION
Adds a missing dependency in Package.json in static html example