### PR TITLE
feat(elements-dev-portal): add compact option to NodeContent component

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.5.20",
+  "version": "7.6.0",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/Docs/Docs.tsx
+++ b/packages/elements-core/src/components/Docs/Docs.tsx
@@ -104,6 +104,14 @@ interface BaseDocsProps {
      * @default false
      */
     hideExport?: boolean;
+
+    /**
+     * Provide a number to trigger compact mode when the component is within that pixel width,
+     * or a boolean to enable or diable compact mode.
+     * @default false
+     * @example 600
+     */
+    compact?: number | boolean;
   };
 }
 

--- a/packages/elements-core/src/components/Docs/TwoColumnLayout.tsx
+++ b/packages/elements-core/src/components/Docs/TwoColumnLayout.tsx
@@ -8,19 +8,21 @@ export interface TwoColumnLayoutProps {
   className?: string;
 }
 
-export const TwoColumnLayout = ({ header, right, left, className }: TwoColumnLayoutProps) => (
-  <VStack w="full" className={className} spacing={8}>
-    {header}
-    <Flex>
-      <Box w={0} flex={1}>
-        {left}
-      </Box>
-
-      {right && (
-        <Box ml={16} pos="relative" w="2/5" style={{ maxWidth: 500 }}>
-          {right}
+export const TwoColumnLayout = React.forwardRef<HTMLDivElement, TwoColumnLayoutProps>(
+  ({ header, right, left, className }, ref) => (
+    <VStack ref={ref} w="full" className={className} spacing={8}>
+      {header}
+      <Flex>
+        <Box data-testid="two-column-left" w={0} flex={1}>
+          {left}
         </Box>
-      )}
-    </Flex>
-  </VStack>
+
+        {right && (
+          <Box data-testid="two-column-right" ml={16} pos="relative" w="2/5" style={{ maxWidth: 500 }}>
+            {right}
+          </Box>
+        )}
+      </Flex>
+    </VStack>
+  ),
 );

--- a/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
+++ b/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
@@ -1,4 +1,4 @@
-import { Panel, Select, Text } from '@stoplight/mosaic';
+import { CopyButton, Panel, Select, Text } from '@stoplight/mosaic';
 import { CodeViewer } from '@stoplight/mosaic-code-viewer';
 import { IHttpOperation, IMediaTypeContent } from '@stoplight/types';
 import React from 'react';
@@ -50,7 +50,9 @@ export const ResponseExamples = ({ httpOperation, responseMediaType, responseSta
 
   return (
     <Panel rounded isCollapsible={false}>
-      <Panel.Titlebar>{examplesSelect || <Text color="body">Response Example</Text>}</Panel.Titlebar>
+      <Panel.Titlebar rightComponent={<CopyButton size="sm" copyValue={responseExample || ''} />}>
+        {examplesSelect || <Text color="body">Response Example</Text>}
+      </Panel.Titlebar>
       <Panel.Content p={0}>
         {show || !exceedsSize(responseExample) ? (
           <CodeViewer

--- a/packages/elements-core/src/hooks/useIsCompact.ts
+++ b/packages/elements-core/src/hooks/useIsCompact.ts
@@ -21,7 +21,6 @@ const getBreakpoints = (compact?: number | boolean): Breakpoints | undefined => 
  */
 export function useIsCompact(layoutOptions: DocsProps['layoutOptions']) {
   const { ref, breakpoint } = useBreakpoints(getBreakpoints(layoutOptions?.compact));
-  console.log('breakpoint', breakpoint, layoutOptions?.compact);
 
   return { ref: ref as Ref<HTMLDivElement>, isCompact: breakpoint === 'compact' };
 }

--- a/packages/elements-core/src/hooks/useIsCompact.ts
+++ b/packages/elements-core/src/hooks/useIsCompact.ts
@@ -1,0 +1,27 @@
+import { Breakpoints, useBreakpoints } from '@stoplight/mosaic';
+import { Ref } from 'react';
+
+import { DocsProps } from '../components/Docs';
+
+const getBreakpoints = (compact?: number | boolean): Breakpoints | undefined => {
+  if (!compact) return undefined;
+
+  if (typeof compact === 'number') {
+    return [
+      ['compact', compact],
+      ['regular', Infinity],
+    ];
+  }
+
+  return [['compact', Infinity]];
+};
+
+/**
+ * Given layoutOptions, determines if the component is in compact mode
+ */
+export function useIsCompact(layoutOptions: DocsProps['layoutOptions']) {
+  const { ref, breakpoint } = useBreakpoints(getBreakpoints(layoutOptions?.compact));
+  console.log('breakpoint', breakpoint, layoutOptions?.compact);
+
+  return { ref: ref as Ref<HTMLDivElement>, isCompact: breakpoint === 'compact' };
+}

--- a/packages/elements-core/src/index.ts
+++ b/packages/elements-core/src/index.ts
@@ -1,4 +1,4 @@
-export { Docs, ParsedDocs } from './components/Docs';
+export { Docs, DocsProps, ParsedDocs } from './components/Docs';
 export { DeprecatedBadge } from './components/Docs/HttpOperation/Badges';
 export { ExportButton, ExportButtonProps } from './components/Docs/HttpService/ExportButton';
 export { SidebarLayout } from './components/Layout/SidebarLayout';

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.5.20",
+    "@stoplight/elements-core": "~7.6.0",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.24.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -5,6 +5,7 @@ import {
   MockingProvider,
   ReferenceResolver,
 } from '@stoplight/elements-core';
+import { DocsProps } from '@stoplight/elements-core/components/Docs';
 import { CustomComponentMapping } from '@stoplight/markdown-viewer';
 import { dirname, resolve } from '@stoplight/path';
 import { NodeType } from '@stoplight/types';
@@ -12,19 +13,16 @@ import * as React from 'react';
 
 import { Node } from '../../types';
 
+// Props shared with elements-core Docs component
+type DocsBaseProps = Pick<DocsProps, 'tryItCorsProxy' | 'tryItCredentialsPolicy'>;
+type DocsLayoutProps = Pick<
+  Required<DocsProps>['layoutOptions'],
+  'compact' | 'hideTryIt' | 'hideTryItPanel' | 'hideExport'
+>;
+
 export type NodeContentProps = {
   node: Node;
   Link: CustomLinkComponent;
-
-  /**
-   * Allows to hide TryIt component
-   */
-  hideTryIt?: boolean;
-
-  /**
-   * Allows to hide TryIt panel
-   */
-  hideTryItPanel?: boolean;
 
   /**
    * Allows to hide mocking button
@@ -32,42 +30,27 @@ export type NodeContentProps = {
   hideMocking?: boolean;
 
   /**
-   * Allows to hide export button
-   * @default false
-   */
-  hideExport?: boolean;
-
-  /**
-   * Fetch credentials policy for TryIt component
-   * For more information: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
-   * @default "omit"
-   */
-
-  tryItCredentialsPolicy?: 'omit' | 'include' | 'same-origin';
-
-  /**
-   * URL of a CORS proxy that will be used to send requests in TryIt.
-   * Provided url will be prepended to an URL of an actual request.
-   * @default false
-   */
-  tryItCorsProxy?: string;
-
-  /**
    * Support for custom reference resolver
    */
   refResolver?: ReferenceResolver;
-};
+} & DocsBaseProps &
+  DocsLayoutProps;
 
 export const NodeContent = ({
   node,
   Link,
+  hideMocking,
+  refResolver,
+
+  // Docs base props
+  tryItCorsProxy,
+  tryItCredentialsPolicy,
+
+  // Docs layout props
+  compact,
   hideTryIt,
   hideTryItPanel,
-  hideMocking,
   hideExport,
-  tryItCredentialsPolicy,
-  tryItCorsProxy,
-  refResolver,
 }: NodeContentProps) => {
   return (
     <NodeLinkContext.Provider value={[node, Link]}>
@@ -78,6 +61,7 @@ export const NodeContent = ({
             nodeData={node.data}
             nodeTitle={node.title}
             layoutOptions={{
+              compact,
               hideTryIt: hideTryIt,
               hideTryItPanel: hideTryItPanel,
               hideExport: hideExport || node.links.export_url === undefined,

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -1,11 +1,11 @@
 import {
   CustomLinkComponent,
   Docs,
+  DocsProps,
   MarkdownComponentsProvider,
   MockingProvider,
   ReferenceResolver,
 } from '@stoplight/elements-core';
-import { DocsProps } from '@stoplight/elements-core/components/Docs';
 import { CustomComponentMapping } from '@stoplight/markdown-viewer';
 import { dirname, resolve } from '@stoplight/path';
 import { NodeType } from '@stoplight/types';

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.7.4';
+export const appVersion = '1.8.0';

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.6.7';
+export const appVersion = '1.7.4';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.5.20",
+  "version": "7.6.0",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.5.20",
+    "@stoplight/elements-core": "~7.6.0",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.24.0",

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,16 +1,7 @@
 import '@testing-library/jest-dom';
 
+import { ResizeObserver } from '@juggle/resize-observer';
 import fetchMock from 'jest-fetch-mock';
-
-declare global {
-  interface Window {
-    ResizeObserver(entries: any[]): {
-      observe(el: HTMLElement): void;
-      unobserve(el: HTMLElement): void;
-      disconnect(): void;
-    };
-  }
-}
 
 const Enzyme = require('enzyme');
 const Adapter = require('enzyme-adapter-react-16');
@@ -20,6 +11,8 @@ Enzyme.configure({ adapter: new Adapter() });
 process.env.TZ = 'UTC';
 
 Element.prototype.scrollTo = () => {};
+
+window.ResizeObserver = ResizeObserver;
 
 window.IntersectionObserver = class implements IntersectionObserver {
   readonly root!: Element | null;


### PR DESCRIPTION
**elements-core**
- Adds a `layoutOptions.compact` prop to `Docs` to control when `Model` is in single vs two column layout
- Adds a copy button to `Model` examples

**elements-dev-portal**
- Adds a `compact` option to `NodeContent` to be passed down to the `Docs` component above


```ts
/**
 * Provide a number to trigger compact mode when the component is within that pixel width,
 * or a boolean to enable or diable compact mode.
 * @default false
 * @example 600
 */
compact?: number | boolean;
```

---

![2022-07-01 17 45 18](https://user-images.githubusercontent.com/7423098/176976057-1646e5e8-0dcd-4ad3-9145-9496f46c72b5.gif)
