### PR TITLE
fix(elements-dev-portal): some properties are optional for NodeContent

### DIFF
--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -14,10 +14,9 @@ import * as React from 'react';
 import { Node } from '../../types';
 
 // Props shared with elements-core Docs component
-type DocsBaseProps = Pick<DocsProps, 'tryItCorsProxy' | 'tryItCredentialsPolicy'>;
-type DocsLayoutProps = Pick<
-  Required<DocsProps>['layoutOptions'],
-  'compact' | 'hideTryIt' | 'hideTryItPanel' | 'hideExport'
+type DocsBaseProps = Partial<Pick<DocsProps, 'tryItCorsProxy' | 'tryItCredentialsPolicy'>>;
+type DocsLayoutProps = Partial<
+  Pick<Required<DocsProps>['layoutOptions'], 'compact' | 'hideTryIt' | 'hideTryItPanel' | 'hideExport'>
 >;
 
 export type NodeContentProps = {


### PR DESCRIPTION
After #2187, the docs properties that node content we're unexpectedly made required when they should still be optional

<img width="451" alt="image" src="https://user-images.githubusercontent.com/7423098/177399922-0cf59a30-fbee-471a-82e7-8f8bb0a5e8d9.png">
