### PR TITLE
feat(elements/elements-core): added layout configuration option

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Badges.tsx
@@ -1,32 +1,42 @@
 import { faEye } from '@fortawesome/free-solid-svg-icons';
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { Badge, Tooltip } from '@stoplight/mosaic';
 import React from 'react';
 
 import { badgeDefaultBackgroundColor, badgeDefaultColor } from '../../../constants';
 
-export const DeprecatedBadge: React.FC = () => (
-  <Tooltip
-    renderTrigger={
-      <Badge intent="warning" icon={['fas', 'exclamation-circle']} data-testid="badge-deprecated">
-        Deprecated
-      </Badge>
-    }
-  >
-    This operation has been marked as deprecated, which means it could be removed at some point in the future.
-  </Tooltip>
-);
+export const DeprecatedBadge: React.FC = () => {
+  const layoutConfig = useLayoutConfig();
+  return (
+    <Tooltip
+      renderTrigger={
+        <Badge intent="warning" icon={['fas', 'exclamation-circle']} data-testid="badge-deprecated">
+          {layoutConfig?.badges?.deprecated ?? 'Deprecated'}
+        </Badge>
+      }
+    >
+      {layoutConfig?.badges?.deprecatedTip ??
+        'This operation has been marked as deprecated, which means it could be removed at some point in the future.'}
+    </Tooltip>
+  );
+};
 
-export const InternalBadge: React.FC<{ isHttpService?: boolean }> = ({ isHttpService }) => (
-  <Tooltip
-    renderTrigger={
-      <Badge icon={faEye} data-testid="badge-internal" bg="danger">
-        Internal
-      </Badge>
-    }
-  >
-    {`This ${isHttpService ? 'operation' : 'model'} is marked as internal and won't be visible in public docs.`}
-  </Tooltip>
-);
+export const InternalBadge: React.FC<{ isHttpService?: boolean }> = ({ isHttpService }) => {
+  const layoutConfig = useLayoutConfig();
+  return (
+    <Tooltip
+      renderTrigger={
+        <Badge icon={faEye} data-testid="badge-internal" bg="danger">
+          {layoutConfig?.badges?.internal ?? 'Internal'}
+        </Badge>
+      }
+    >
+      {layoutConfig?.badges?.internalTip
+        ? layoutConfig.badges.internalTip(isHttpService)
+        : `This ${isHttpService ? 'operation' : 'model'} is marked as internal and won't be visible in public docs.`}
+    </Tooltip>
+  );
+};
 
 export const VersionBadge: React.FC<{ value: string; backgroundColor?: string }> = ({ value, backgroundColor }) => (
   <Badge

--- a/packages/elements-core/src/components/Docs/HttpOperation/Body.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Body.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
 import { Flex, Select, VStack } from '@stoplight/mosaic';
 import { IHttpOperationRequestBody } from '@stoplight/types';
@@ -26,6 +27,8 @@ export const Body = ({ body, onChange }: BodyProps) => {
   const refResolver = useInlineRefResolver();
   const [chosenContent, setChosenContent] = React.useState(0);
 
+  const layoutConfig = useLayoutConfig();
+
   React.useEffect(() => {
     onChange(chosenContent);
     // disabling because we don't want to react on `onChange` change
@@ -39,7 +42,7 @@ export const Body = ({ body, onChange }: BodyProps) => {
 
   return (
     <VStack spacing={6}>
-      <SectionSubtitle title="Body" id="request-body">
+      <SectionSubtitle title={layoutConfig?.responses?.bodyHeader ?? 'Body'} id="request-body">
         {contents.length > 0 && (
           <Flex flex={1} justify="end">
             <Select

--- a/packages/elements-core/src/components/Docs/HttpOperation/Request.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Request.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { VStack } from '@stoplight/mosaic';
 import { HttpSecurityScheme, IHttpOperation } from '@stoplight/types';
 import { useAtom } from 'jotai';
@@ -31,6 +32,7 @@ export const Request: React.FunctionComponent<IRequestProps> = ({
   },
   onChange,
 }) => {
+  const layoutConfig = useLayoutConfig();
   if (!request || typeof request !== 'object') return null;
 
   const bodyIsEmpty = isBodyEmpty(body);
@@ -43,11 +45,12 @@ export const Request: React.FunctionComponent<IRequestProps> = ({
       cookieParams.length ||
       !bodyIsEmpty,
   );
+
   if (!hasRequestData) return null;
 
   return (
     <VStack spacing={8}>
-      <SectionTitle title="Request" />
+      <SectionTitle title={layoutConfig?.request?.header ?? 'Request'} />
 
       {securitySchemes.length > 0 && (
         <VStack spacing={3}>
@@ -59,28 +62,28 @@ export const Request: React.FunctionComponent<IRequestProps> = ({
 
       {pathParams.length > 0 && (
         <VStack spacing={5}>
-          <SectionSubtitle title="Path Parameters" />
+          <SectionSubtitle title={layoutConfig?.request?.pathParameters ?? 'Path Parameters'} />
           <Parameters parameterType="path" parameters={pathParams} />
         </VStack>
       )}
 
       {queryParams.length > 0 && (
         <VStack spacing={5}>
-          <SectionSubtitle title="Query Parameters" />
+          <SectionSubtitle title={layoutConfig?.request?.queryParameters ?? 'Query Parameters'} />
           <Parameters parameterType="query" parameters={queryParams} />
         </VStack>
       )}
 
       {headerParams.length > 0 && (
         <VStack spacing={5}>
-          <SectionSubtitle title="Headers" id="request-headers" />
+          <SectionSubtitle title={layoutConfig?.request?.headerParameters ?? 'Headers'} id="request-headers" />
           <Parameters parameterType="header" parameters={headerParams} />
         </VStack>
       )}
 
       {cookieParams.length > 0 && (
         <VStack spacing={5}>
-          <SectionSubtitle title="Cookies" id="request-cookies" />
+          <SectionSubtitle title={layoutConfig?.request?.cookiesParameters ?? 'Cookies'} id="request-cookies" />
           <Parameters parameterType="cookie" parameters={cookieParams} />
         </VStack>
       )}
@@ -95,10 +98,11 @@ const schemeExpandedState = atomWithStorage<Record<string, boolean>>('HttpOperat
 
 const SecurityPanel: React.FC<{ scheme: HttpSecurityScheme; includeKey: boolean }> = ({ scheme, includeKey }) => {
   const [expandedState, setExpanded] = useAtom(schemeExpandedState);
+  const layoutConfig = useLayoutConfig();
 
   return (
     <SubSectionPanel
-      title={`Security: ${getReadableSecurityName(scheme, includeKey)}`}
+      title={`${layoutConfig?.securitySchemes?.title ?? 'Security'}: ${getReadableSecurityName(scheme, includeKey)}`}
       defaultIsOpen={!!expandedState[scheme.key]}
       onChange={isOpen => setExpanded({ ...expandedState, [scheme.key]: isOpen })}
     >

--- a/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
 import { Flex, IntentVals, Select, Tab, TabList, TabPanel, TabPanels, Tabs, VStack } from '@stoplight/mosaic';
 import { IHttpOperationResponse } from '@stoplight/types';
@@ -28,6 +29,7 @@ export const Responses = ({ responses: unsortedResponses, onStatusCodeChange, on
   );
 
   const [activeResponseId, setActiveResponseId] = React.useState(responses[0]?.code ?? '');
+  const layoutConfig = useLayoutConfig();
 
   React.useEffect(() => {
     onStatusCodeChange(activeResponseId);
@@ -38,7 +40,7 @@ export const Responses = ({ responses: unsortedResponses, onStatusCodeChange, on
 
   return (
     <VStack spacing={8} as={Tabs} selectedId={activeResponseId} onChange={setActiveResponseId} appearance="pill">
-      <SectionTitle title="Responses">
+      <SectionTitle title={layoutConfig?.responses?.header ?? 'Responses'}>
         <TabList density="compact">
           {responses.map(({ code }) => (
             <Tab key={code} id={code} intent={codeToIntentVal(code)}>
@@ -68,6 +70,8 @@ const Response = ({ response, onMediaTypeChange }: ResponseProps) => {
   const responseContent = contents[chosenContent];
   const schema = responseContent?.schema;
 
+  const layoutConfig = useLayoutConfig();
+
   React.useEffect(() => {
     responseContent && onMediaTypeChange(responseContent.mediaType);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -86,7 +90,7 @@ const Response = ({ response, onMediaTypeChange }: ResponseProps) => {
 
       {contents.length > 0 && (
         <>
-          <SectionSubtitle title="Body" id="response-body">
+          <SectionSubtitle title={layoutConfig?.responses?.bodyHeader ?? 'Body'} id="response-body">
             <Flex flex={1} justify="end">
               <Select
                 aria-label="Response Body Content Type"

--- a/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { Panel } from '@stoplight/mosaic';
 import { IHttpService } from '@stoplight/types';
 import React from 'react';
@@ -11,21 +12,29 @@ interface AdditionalInfoProps {
 }
 
 export const AdditionalInfo: React.FC<AdditionalInfoProps> = ({ termsOfService, contact, license }) => {
+  const layoutConfig = useLayoutConfig();
   const contactLink =
     contact?.name && contact?.url
-      ? `[Contact ${contact.name}](${contact.url})`
+      ? `[${layoutConfig?.additionalInfo?.contact ?? 'Contact'} ${contact.name}](${contact.url})`
       : contact?.email
-      ? `[Contact ${contact.name || contact.email}](mailto:${contact.email})`
+      ? `[${layoutConfig?.additionalInfo?.contact ?? 'Contact'} ${contact.name || contact.email}](mailto:${
+          contact.email
+        })`
       : '';
 
   //use spdx to look up url for license identifier if available
   const licenseUrl = license?.url || `https://spdx.org/licenses/${license?.identifier}.html`;
-  const licenseLink = license?.name && licenseUrl ? `[${license.name} License](${licenseUrl})` : '';
-  const tosLink = termsOfService ? `[Terms of Service](${termsOfService})` : '';
+  const licenseLink =
+    license?.name && licenseUrl
+      ? `[${license.name} ${layoutConfig?.additionalInfo?.license ?? 'License'}](${licenseUrl})`
+      : '';
+  const tosLink = termsOfService
+    ? `[${layoutConfig?.additionalInfo?.termsOfService ?? 'Terms of Service'}](${termsOfService})`
+    : '';
   return contactLink || licenseLink || tosLink ? (
     <Panel rounded isCollapsible={false}>
       <Panel.Titlebar bg="canvas-300">
-        <span role="heading">Additional Information</span>
+        <span role="heading">{layoutConfig?.additionalInfo?.title ?? 'Additional Information'}</span>
       </Panel.Titlebar>
       <Panel.Content p={0}>
         <Panel.Content>

--- a/packages/elements-core/src/components/Docs/HttpService/SecuritySchemes.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/SecuritySchemes.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { Box, Panel, PanelProps } from '@stoplight/mosaic';
 import { HttpSecurityScheme } from '@stoplight/types';
 import { sortBy } from 'lodash';
@@ -18,11 +19,12 @@ export const SecuritySchemes: React.FC<SecuritySchemesProps> = ({
   defaultScheme,
   defaultCollapsed = false,
 }) => {
+  const layoutConfig = useLayoutConfig();
   return (
     <Panel rounded isCollapsible={defaultCollapsed}>
       <Panel.Titlebar bg="canvas-300">
         <Box as="span" role="heading">
-          Security
+          {layoutConfig?.securitySchemes?.title ?? 'Security'}
         </Box>
       </Panel.Titlebar>
       <Panel.Content p={0}>

--- a/packages/elements-core/src/components/Docs/HttpService/ServerInfo.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/ServerInfo.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { Box, Icon, InvertTheme, Panel, Text, Tooltip, useClipboard, VStack } from '@stoplight/mosaic';
 import * as React from 'react';
 
@@ -16,6 +17,7 @@ export const ServerInfo: React.FC<ServerInfoProps> = ({ servers, mockUrl }) => {
   const $mockUrl = showMocking ? mockUrl || mocking.mockUrl : undefined;
 
   const serversToDisplay = getServersToDisplay(servers, $mockUrl);
+  const layoutConfig = useLayoutConfig();
 
   if (!showMocking && serversToDisplay.length === 0) {
     return null;
@@ -24,7 +26,7 @@ export const ServerInfo: React.FC<ServerInfoProps> = ({ servers, mockUrl }) => {
   return (
     <InvertTheme>
       <Panel rounded isCollapsible={false} className="BaseURLContent" w="full">
-        <Panel.Titlebar whitespace="nowrap">API Base URL</Panel.Titlebar>
+        <Panel.Titlebar whitespace="nowrap">{layoutConfig?.serverInfo?.title ?? 'API Base URL'}</Panel.Titlebar>
         <Box overflowX="auto">
           <Panel.Content w="full" className="sl-flex sl-flex-col">
             <VStack spacing={1} divider>

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
 import { CopyButton, Flex, Heading, HStack, Panel, Select, Text, VStack } from '@stoplight/mosaic';
 import { CodeViewer } from '@stoplight/mosaic-code-viewer';
@@ -85,6 +86,8 @@ const ModelExamples = React.memo(({ data, isCollapsible = false }: { data: JSONS
 
   const selectedExample = examples[chosenExampleIndex]?.data;
 
+  const layoutConfig = useLayoutConfig();
+
   const handleLoadMorePress = React.useCallback(() => {
     setLoading(true);
     setTimeout(() => setShow(true), 50);
@@ -106,7 +109,7 @@ const ModelExamples = React.memo(({ data, isCollapsible = false }: { data: JSONS
       <Panel.Titlebar rightComponent={selectedExample ? <CopyButton size="sm" copyValue={selectedExample} /> : null}>
         {examplesSelect || (
           <Text color="body" role="heading">
-            Example
+            {layoutConfig?.modelExamples?.title ?? 'Example'}
           </Text>
         )}
       </Panel.Titlebar>

--- a/packages/elements-core/src/components/RequestSamples/RequestSamples.tsx
+++ b/packages/elements-core/src/components/RequestSamples/RequestSamples.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { Box, Button, CopyButton, Menu, MenuItems, Panel } from '@stoplight/mosaic';
 import { CodeViewer } from '@stoplight/mosaic-code-viewer';
 import { Request } from 'har-format';
@@ -70,6 +71,8 @@ export const RequestSamples = React.memo<RequestSamplesProps>(({ request, embedd
     return items;
   }, [selectedLanguage, selectedLibrary, setSelectedLanguage, setSelectedLibrary]);
 
+  const layoutConfig = useLayoutConfig();
+
   return (
     <Panel rounded={embeddedInMd ? undefined : true} isCollapsible={embeddedInMd}>
       <Panel.Titlebar rightComponent={<CopyButton size="sm" copyValue={requestSample || ''} />}>
@@ -80,7 +83,8 @@ export const RequestSamples = React.memo<RequestSamplesProps>(({ request, embedd
             items={menuItems}
             renderTrigger={({ isOpen }) => (
               <Button size="sm" iconRight="chevron-down" appearance="minimal" active={isOpen}>
-                Request Sample: {selectedLanguage} {selectedLibrary ? ` / ${selectedLibrary}` : ''}
+                {`${layoutConfig?.requestSamples?.title ?? 'Request Sample'}: `}
+                {selectedLanguage} {selectedLibrary ? ` / ${selectedLibrary}` : ''}
               </Button>
             )}
           />

--- a/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
+++ b/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { CopyButton, Panel, Select, Text } from '@stoplight/mosaic';
 import { CodeViewer } from '@stoplight/mosaic-code-viewer';
 import { IHttpOperation, IMediaTypeContent } from '@stoplight/types';
@@ -16,6 +17,8 @@ export const ResponseExamples = ({ httpOperation, responseMediaType, responseSta
   const [chosenExampleIndex, setChosenExampleIndex] = React.useState(0);
   const [show, setShow] = React.useState<boolean>(false);
   const [loading, setLoading] = React.useState<boolean>(false);
+
+  const layoutConfig = useLayoutConfig();
 
   const response = httpOperation.responses.find(response => response.code === responseStatusCode);
   const responseContents = response?.contents?.find(content => content.mediaType === responseMediaType);
@@ -51,7 +54,7 @@ export const ResponseExamples = ({ httpOperation, responseMediaType, responseSta
   return (
     <Panel rounded isCollapsible={false}>
       <Panel.Titlebar rightComponent={<CopyButton size="sm" copyValue={responseExample || ''} />}>
-        {examplesSelect || <Text color="body">Response Example</Text>}
+        {examplesSelect || <Text color="body">{layoutConfig?.responseExamples?.title ?? 'Response Example'}</Text>}
       </Panel.Titlebar>
       <Panel.Content p={0}>
         {show || !exceedsSize(responseExample) ? (

--- a/packages/elements-core/src/components/TryIt/Auth/Auth.tsx
+++ b/packages/elements-core/src/components/TryIt/Auth/Auth.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { Button, Menu, MenuItems, Panel } from '@stoplight/mosaic';
 import { HttpSecurityScheme } from '@stoplight/types';
 import { flatten } from 'lodash';
@@ -24,6 +25,8 @@ export const TryItAuth: React.FC<TryItAuthProps> = ({ operationSecurityScheme: o
   const securityScheme = value ? value.scheme : filteredSecurityItems[0];
 
   const menuName = securityScheme ? getReadableSecurityName(securityScheme) : 'Security Scheme';
+
+  const layoutConfig = useLayoutConfig();
 
   const handleChange = (authValue?: string) => {
     onChange(securityScheme && { scheme: securityScheme, authValue: authValue });
@@ -73,7 +76,7 @@ export const TryItAuth: React.FC<TryItAuthProps> = ({ operationSecurityScheme: o
           )
         }
       >
-        Auth
+        {layoutConfig?.tryIt?.authTitle ?? 'Auth'}
       </Panel.Titlebar>
       {
         <SecuritySchemeComponent

--- a/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
+++ b/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { safeStringify } from '@stoplight/json';
 import { Panel } from '@stoplight/mosaic';
 import { IMediaTypeContent } from '@stoplight/types';
@@ -28,6 +29,8 @@ export const FormDataBody: React.FC<FormDataBodyProps> = ({
   const parameters = schema?.properties;
   const required = schema?.required;
 
+  const layoutConfig = useLayoutConfig();
+
   React.useEffect(() => {
     if (parameters === undefined) {
       console.warn(`Invalid schema in form data spec: ${safeStringify(schema)}`);
@@ -40,7 +43,7 @@ export const FormDataBody: React.FC<FormDataBodyProps> = ({
 
   return (
     <Panel defaultIsOpen>
-      <Panel.Titlebar>Body</Panel.Titlebar>
+      <Panel.Titlebar>{layoutConfig?.tryIt?.formDataBodyTitle ?? 'Body'}</Panel.Titlebar>
       <Panel.Content className="sl-overflow-y-auto ParameterGrid OperationParametersContent">
         {mapSchemaPropertiesToParameters(parameters, required).map(parameter => {
           const supportsFileUpload = parameterSupportsFileUpload(parameter);

--- a/packages/elements-core/src/components/TryIt/Body/RequestBody.tsx
+++ b/packages/elements-core/src/components/TryIt/Body/RequestBody.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { safeStringify } from '@stoplight/json';
 import { Button, Menu, MenuItems, Panel } from '@stoplight/mosaic';
 import { CodeEditor } from '@stoplight/mosaic-code-editor';
@@ -11,6 +12,7 @@ interface RequestBodyProps {
 }
 
 export const RequestBody: React.FC<RequestBodyProps> = ({ examples, requestBody, onChange }) => {
+  const layoutConfig = useLayoutConfig();
   return (
     <Panel defaultIsOpen>
       <Panel.Titlebar
@@ -18,7 +20,7 @@ export const RequestBody: React.FC<RequestBodyProps> = ({ examples, requestBody,
           examples.length > 1 && <ExampleMenu examples={examples} requestBody={requestBody} onChange={onChange} />
         }
       >
-        Body
+        {layoutConfig?.request?.bodyHeader ?? 'Body'}
       </Panel.Titlebar>
       <Panel.Content className="TextRequestBody">
         <CodeEditor

--- a/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { Panel } from '@stoplight/mosaic';
 import * as React from 'react';
 
@@ -17,9 +18,10 @@ export const OperationParameters: React.FC<OperationParametersProps> = ({
   onChangeValue,
   validate,
 }) => {
+  const layoutConfig = useLayoutConfig();
   return (
     <Panel defaultIsOpen>
-      <Panel.Titlebar>Parameters</Panel.Titlebar>
+      <Panel.Titlebar>{layoutConfig?.operationParameters?.title ?? 'Parameters'}</Panel.Titlebar>
       <Panel.Content className="sl-overflow-y-auto ParameterGrid OperationParametersContent">
         {parameters.map(parameter => (
           <ParameterEditor

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -1,3 +1,4 @@
+import { useLayoutConfig } from '@stoplight/elements-core';
 import { Box, Button, HStack, Icon, Panel, useThemeIsDark } from '@stoplight/mosaic';
 import { IHttpOperation } from '@stoplight/types';
 import { Request as HarRequest } from 'har-format';
@@ -220,6 +221,8 @@ export const TryIt: React.FC<TryItProps> = ({
   const isOnlySendButton =
     !httpOperation.security?.length && !allParameters.length && !formDataState.isFormDataBody && !mediaTypeContent;
 
+  const layoutConfig = useLayoutConfig();
+
   const tryItPanelContents = (
     <>
       {httpOperation.security?.length ? (
@@ -258,7 +261,7 @@ export const TryIt: React.FC<TryItProps> = ({
       <Panel.Content className="SendButtonHolder" mt={4} pt={!isOnlySendButton && !embeddedInMd ? 0 : undefined}>
         <HStack alignItems="center" spacing={2}>
           <Button appearance="primary" loading={loading} disabled={loading} onPress={handleSendRequest} size="sm">
-            Send API Request
+            {layoutConfig?.tryIt?.sendApiRequest ?? 'Send API Request'}
           </Button>
 
           {servers.length > 1 && <ServersDropdown servers={servers} />}

--- a/packages/elements-core/src/context/LayoutConfigContext.tsx
+++ b/packages/elements-core/src/context/LayoutConfigContext.tsx
@@ -1,0 +1,67 @@
+import React, { useContext } from 'react';
+
+import { LayoutConfig } from '../types';
+import { defaultLayoutConfig } from './defaultLayoutConfig';
+import { defaultLayoutConfig as defaultLayoutConfigPTBR } from './defaultLayoutConfig_PT-BR';
+
+export type LayoutConfigLanguage = 'EN' | 'PT-BR';
+
+type LayoutConfigProviderProps = {
+  config: LayoutConfig;
+  setConfig: (config: LayoutConfig | LayoutConfigLanguage) => void;
+};
+
+const LayoutConfigContext = React.createContext<LayoutConfigProviderProps>({
+  config: defaultLayoutConfig,
+  setConfig: () => {},
+});
+LayoutConfigContext.displayName = 'LayoutConfigContext';
+
+export const LayoutConfigProvider: React.FC = ({ children }) => {
+  const [layoutConfig, setLayoutConfig] = React.useState<LayoutConfig>(defaultLayoutConfig);
+
+  const setLayoutConfigHandler = React.useCallback((newConfig: LayoutConfig | LayoutConfigLanguage) => {
+    if (typeof newConfig === 'string') {
+      if (newConfig === 'EN') {
+        setLayoutConfig(defaultLayoutConfig);
+      }
+      if (newConfig === 'PT-BR') {
+        setLayoutConfig(defaultLayoutConfigPTBR);
+      }
+    } else {
+      setLayoutConfig((previousConfig: LayoutConfig) => {
+        return Object.keys(previousConfig).reduce((obj, key) => {
+          if (newConfig.hasOwnProperty(key)) {
+            obj[key] = { ...previousConfig[key], ...newConfig[key] };
+          } else {
+            obj[key] = previousConfig[key];
+          }
+          return obj;
+        }, {});
+      });
+    }
+  }, []);
+
+  const contextValue: LayoutConfigProviderProps = {
+    config: layoutConfig,
+    setConfig: setLayoutConfigHandler,
+  };
+
+  return <LayoutConfigContext.Provider value={contextValue}>{children}</LayoutConfigContext.Provider>;
+};
+
+export const useLayoutConfigStarter = (userConfig?: LayoutConfig | LayoutConfigLanguage | undefined) => {
+  const { config, setConfig } = useContext(LayoutConfigContext);
+
+  React.useEffect(() => {
+    if (!userConfig) return;
+    setConfig(userConfig);
+  }, [userConfig, setConfig]);
+
+  return config;
+};
+
+export const useLayoutConfig = () => {
+  const { config } = useContext(LayoutConfigContext);
+  return config;
+};

--- a/packages/elements-core/src/context/defaultLayoutConfig.tsx
+++ b/packages/elements-core/src/context/defaultLayoutConfig.tsx
@@ -1,0 +1,65 @@
+import { LayoutConfig } from '../types';
+
+export const defaultLayoutConfig: LayoutConfig = {
+  api: {
+    descriptionUrlErrorTitle: 'Document could not be loaded',
+    descriptionUrlError:
+      'The API description document could not be fetched. This could indicate connectivity problems, or issues with the server hosting the spec.',
+    descriptionFileErrorTitle: 'Failed to parse OpenAPI file',
+    descriptionFileError: 'Please make sure your OpenAPI file is valid and try again',
+  },
+  apiTree: {
+    overview: 'Overview',
+    endpoints: 'Endpoints',
+    schemas: 'Schemas',
+  },
+  serverInfo: {
+    title: 'API Base URL',
+  },
+  securitySchemes: {
+    title: 'Security',
+  },
+  additionalInfo: {
+    title: 'Additional Information',
+    contact: 'Contact',
+    license: 'License',
+    termsOfService: 'Terms of Service',
+  },
+  operationParameters: {
+    title: 'Parameters',
+  },
+  tryIt: {
+    sendApiRequest: 'Send API Request',
+    authTitle: 'Auth',
+    formDataBodyTitle: 'Body',
+  },
+  requestSamples: {
+    title: 'Request Sample',
+  },
+  responseExamples: {
+    title: 'Response Example',
+  },
+  request: {
+    header: 'Request',
+    queryParameters: 'Query Parameters',
+    cookiesParameters: 'Cookies',
+    headerParameters: 'Headers',
+    pathParameters: 'Path Parameters',
+    bodyHeader: 'Body',
+  },
+  responses: {
+    header: 'Responses',
+    bodyHeader: 'Body',
+  },
+  badges: {
+    deprecated: 'Deprecated',
+    deprecatedTip:
+      'This operation has been marked as deprecated, which means it could be removed at some point in the future.',
+    internal: 'Internal',
+    internalTip: isHttpService =>
+      `This ${isHttpService ? 'operation' : 'model'} is marked as internal and won't be visible in public docs.`,
+  },
+  modelExamples: {
+    title: 'Example',
+  },
+};

--- a/packages/elements-core/src/context/defaultLayoutConfig_PT-BR.tsx
+++ b/packages/elements-core/src/context/defaultLayoutConfig_PT-BR.tsx
@@ -1,0 +1,64 @@
+import { LayoutConfig } from '../types';
+
+export const defaultLayoutConfig: LayoutConfig = {
+  api: {
+    descriptionUrlErrorTitle: 'Documento não pôde ser carregado',
+    descriptionUrlError:
+      'O documento de descrição do API não pôde ser obtido. Isto poderia indicar problemas de conectividade, ou problemas com o servidor que aloja o arquivo.',
+  },
+  apiTree: {
+    overview: 'Sobre',
+    endpoints: 'Rotas',
+    schemas: 'Esquemas',
+  },
+  serverInfo: {
+    title: 'URL Base do API',
+  },
+  securitySchemes: {
+    title: 'Segurança',
+  },
+  additionalInfo: {
+    title: 'Informações Adicionais',
+    contact: 'Contato',
+    license: 'Licença',
+    termsOfService: 'Termos de Serviço',
+  },
+  operationParameters: {
+    title: 'Parâmetros',
+  },
+  tryIt: {
+    sendApiRequest: 'Enviar solicitação ao API',
+    authTitle: 'Autenticação',
+    formDataBodyTitle: 'Corpo',
+  },
+  requestSamples: {
+    title: 'Exemplo de Solicitação',
+  },
+  responseExamples: {
+    title: 'Exemplos de Resposta',
+  },
+  request: {
+    header: 'Solicitação',
+    queryParameters: 'Parâmetros de Consulta',
+    cookiesParameters: 'Cookies',
+    headerParameters: 'Headers',
+    pathParameters: 'Parâmetros da Rota',
+    bodyHeader: 'Corpo',
+  },
+  responses: {
+    header: 'Respostas',
+    bodyHeader: 'Corpo',
+  },
+  badges: {
+    deprecated: 'Depreciada',
+    deprecatedTip:
+      'Esta operação foi marcada como depreciada, o que significa que poderá ser removida em algum momento no futuro.',
+    internalTip: isHttpService =>
+      ` ${
+        isHttpService ? 'Esta operação' : 'Este modelo'
+      } é marcado como interno e não será visível em documentos públicos.`,
+  },
+  modelExamples: {
+    title: 'Exemplo',
+  },
+};

--- a/packages/elements-core/src/hoc/withLayoutConfigProvider.tsx
+++ b/packages/elements-core/src/hoc/withLayoutConfigProvider.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { LayoutConfigProvider } from '../context/LayoutConfigContext';
+import { getDisplayName } from './utils';
+
+export function withLayoutConfigProvider<P>(WrappedComponent: React.ComponentType<P>): React.FC<P> {
+  const WithLayoutConfigProvider = (props: P) => {
+    return (
+      <LayoutConfigProvider>
+        <WrappedComponent {...props} />
+      </LayoutConfigProvider>
+    );
+  };
+
+  WithLayoutConfigProvider.displayName = `withLayoutConfigProvider(${getDisplayName(WrappedComponent)})`;
+
+  return WithLayoutConfigProvider;
+}

--- a/packages/elements-core/src/index.ts
+++ b/packages/elements-core/src/index.ts
@@ -23,7 +23,9 @@ export { TryIt, TryItProps, TryItWithRequestSamples, TryItWithRequestSamplesProp
 export { HttpMethodColors, NodeTypeColors, NodeTypeIconDefs, NodeTypePrettyName } from './constants';
 export { MockingProvider } from './containers/MockingProvider';
 export { InlineRefResolverProvider } from './context/InlineRefResolver';
+export { LayoutConfigLanguage, useLayoutConfig, useLayoutConfigStarter } from './context/LayoutConfigContext';
 export { PersistenceContextProvider, withPersistenceBoundary } from './context/Persistence';
+export { withLayoutConfigProvider } from './hoc/withLayoutConfigProvider';
 export { withMosaicProvider } from './hoc/withMosaicProvider';
 export { withQueryClientProvider } from './hoc/withQueryClientProvider';
 export { withRouter } from './hoc/withRouter';
@@ -32,7 +34,16 @@ export { useParsedData } from './hooks/useParsedData';
 export { useParsedValue } from './hooks/useParsedValue';
 export { useRouter } from './hooks/useRouter';
 export { Styled, withStyles } from './styled';
-export { Divider, Group, ITableOfContentsTree, Item, ParsedNode, RoutingProps, TableOfContentItem } from './types';
+export {
+  Divider,
+  Group,
+  ITableOfContentsTree,
+  Item,
+  LayoutConfig,
+  ParsedNode,
+  RoutingProps,
+  TableOfContentItem,
+} from './types';
 export { isHttpOperation, isHttpService } from './utils/guards';
 export { ReferenceResolver } from './utils/ref-resolving/ReferenceResolver';
 export { createResolvedObject } from './utils/ref-resolving/resolvedObject';

--- a/packages/elements-core/src/types.ts
+++ b/packages/elements-core/src/types.ts
@@ -157,3 +157,244 @@ export type ParamField = {
   description: string;
   example: string;
 };
+
+type ApiLayoutConfig = {
+  /**
+   * Title of error message thrown when fetch of openAPI description URL fails.
+   *  @default "Document could not be loaded"
+   */
+  descriptionUrlErrorTitle?: string;
+  /**
+   * Error message thrown when fetch of openAPI description URL fails.
+   * @default "The API description document could not be fetched. This could indicate connectivity problems, or issues with the server hosting the spec."
+   */
+  descriptionUrlError?: string;
+  /**
+   * Title of error message thrown when fails to open openAPI file.
+   * @default "Failed to parse OpenAPI file"
+   */
+  descriptionFileErrorTitle?: string;
+  /**
+   * Error message thrown when fails to open openAPI file.
+   * @default "Please make sure your OpenAPI file is valid and try again"
+   */
+  descriptionFileError?: string;
+};
+
+type ApiTreeLayoutConfig = {
+  /**
+   * NavBar config.
+   * API tree alias for overview route (main page).
+   * @default "Overview"
+   */
+  overview?: string;
+  /**
+   * NavBar config.
+   * API tree alias for endpoints group title.
+   * @default "Endpoints"
+   */
+  endpoints?: string;
+  /**
+   * NavBar config.
+   * API tree alias for schemas group title.
+   * @default "Schemas"
+   */
+  schemas?: string;
+};
+
+type ServerInfoLayoutConfig = {
+  /**
+   * ServerInfo component configuration.
+   * Container title.
+   * @default "API Base URL"
+   */
+  title?: string;
+};
+
+type SecuritySchemesLayoutConfig = {
+  /**
+   * SecuritySchemes component configuration.
+   * Container title.
+   * @default "Security"
+   */
+  title?: string;
+};
+
+type AdditionalInfoLayoutConfig = {
+  /**
+   * AdditionalInfo component configuration.
+   * Container title.
+   * @default "Additional Information"
+   */
+  title?: string;
+  /**
+   * AdditionalInfo component configuration.
+   * Alias for contact.
+   * @default "Security"
+   */
+  contact?: string;
+  /**
+   * AdditionalInfo component configuration.
+   * Alias for license.
+   * @default "license"
+   */
+  license?: string;
+  /**
+   * AdditionalInfo component configuration.
+   * Alias for terms of service.
+   * @default "license"
+   */
+  termsOfService?: string;
+};
+
+type OperationParametersLayoutConfig = {
+  /**
+   * OperationParameters component configuration.
+   * Container title.
+   * @default "Parameters"
+   */
+  title?: string;
+};
+
+type TryItLayoutConfig = {
+  /**
+   * TryIt component configuration.
+   * Send API Request button text.
+   * @default "Send API Request"
+   */
+  sendApiRequest?: string;
+  /**
+   * TryItAuth component configuration.
+   * Auth component title.
+   * @default "Send API Request"
+   */
+  authTitle?: string;
+  /**
+   * TryItAuth FormDataBody component configuration.
+   * Body component title.
+   * @default "Body"
+   */
+  formDataBodyTitle?: string;
+};
+
+type RequestSamplesLayoutConfig = {
+  /**
+   * RequestSamples component configuration.
+   * Container title.
+   * @default "Request Sample"
+   */
+  title?: string;
+};
+
+type ResponseExamplesLayoutConfig = {
+  /**
+   * ResponseExamples component configuration.
+   * Container title.
+   * @default "Response Example"
+   */
+  title?: string;
+};
+
+type RequestLayoutConfig = {
+  /**
+   * Endpoints request section configuration.
+   * Header.
+   * @default "Request"
+   */
+  header?: string;
+  /**
+   * Endpoints request section configuration.
+   * Path Parameters subtitle.
+   * @default "Path Parameters"
+   */
+  pathParameters?: string;
+  /**
+   * Endpoints request section configuration.
+   * Header Parameters subtitle.
+   * @default "Header"
+   */
+  headerParameters?: string;
+  /**
+   * Endpoints request section configuration.
+   * Cookies Parameters subtitle.
+   * @default "Cookies"
+   */
+  cookiesParameters?: string;
+  /**
+   * Endpoints request section configuration.
+   * Query Parameters subtitle.
+   * @default "Query Parameters"
+   */
+  queryParameters?: string;
+  /**
+   * Endpoints responses section configuration.
+   * Body Header.
+   * @default "Body"
+   */
+  bodyHeader?: string;
+};
+
+type ResponsesLayoutConfig = {
+  /**
+   * Endpoints responses section configuration.
+   * Header.
+   * @default "Responses"
+   */
+  header?: string;
+  /**
+   * Endpoints responses section configuration.
+   * Body Header.
+   * @default "Body"
+   */
+  bodyHeader?: string;
+};
+
+type BadgesLayoutConfig = {
+  /**
+   * Badges components configuration.
+   * Deprecated badge title.
+   * @default "Deprecated"
+   */
+  deprecated?: string;
+  /**
+   * Badges components configuration.
+   * Deprecated badge tooltip text.
+   */
+  deprecatedTip?: string;
+  /**
+   * Badges components configuration.
+   * Internal badge title.
+   * @default "Internal"
+   */
+  internal?: string;
+  /**
+   * Badges components configuration.
+   * Deprecated badge tooltip text.
+   */
+  internalTip?: (isHttpService?: boolean) => string;
+};
+
+type ModelExamplesLayoutConfig = {
+  /**
+   * ModelExamples components configuration.
+   * Tilte of component.
+   * @default "Example"
+   */
+  title?: string;
+};
+
+export type LayoutConfig = {
+  api?: ApiLayoutConfig;
+  apiTree?: ApiTreeLayoutConfig;
+  serverInfo?: ServerInfoLayoutConfig;
+  securitySchemes?: SecuritySchemesLayoutConfig;
+  additionalInfo?: AdditionalInfoLayoutConfig;
+  operationParameters?: OperationParametersLayoutConfig;
+  tryIt?: TryItLayoutConfig;
+  requestSamples?: RequestSamplesLayoutConfig;
+  responseExamples?: ResponseExamplesLayoutConfig;
+  request?: RequestLayoutConfig;
+  responses?: ResponsesLayoutConfig;
+  badges?: BadgesLayoutConfig;
+  modelExamples?: ModelExamplesLayoutConfig;
+};

--- a/packages/elements/src/components/API/APIWithSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithSidebarLayout.tsx
@@ -5,6 +5,7 @@ import {
   PoweredByLink,
   SidebarLayout,
   TableOfContents,
+  useLayoutConfig,
 } from '@stoplight/elements-core';
 import { Flex, Heading } from '@stoplight/mosaic';
 import { NodeType } from '@stoplight/types';
@@ -37,10 +38,11 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
   tryItCredentialsPolicy,
   tryItCorsProxy,
 }) => {
+  const layoutConfig = useLayoutConfig();
   const container = React.useRef<HTMLDivElement>(null);
   const tree = React.useMemo(
-    () => computeAPITree(serviceNode, { hideSchemas, hideInternal }),
-    [serviceNode, hideSchemas, hideInternal],
+    () => computeAPITree(serviceNode, { hideSchemas, hideInternal }, layoutConfig),
+    [serviceNode, hideSchemas, hideInternal, layoutConfig],
   );
   const location = useLocation();
   const { pathname } = location;

--- a/packages/elements/src/components/API/utils.ts
+++ b/packages/elements/src/components/API/utils.ts
@@ -1,4 +1,5 @@
 import { isHttpOperation, isHttpService, TableOfContentsItem } from '@stoplight/elements-core';
+import { LayoutConfig } from '@stoplight/elements-core/types';
 import { NodeType } from '@stoplight/types';
 import { defaults } from 'lodash';
 
@@ -63,14 +64,18 @@ const defaultComputerAPITreeConfig = {
   hideInternal: false,
 };
 
-export const computeAPITree = (serviceNode: ServiceNode, config: ComputeAPITreeConfig = {}) => {
+export const computeAPITree = (
+  serviceNode: ServiceNode,
+  config: ComputeAPITreeConfig = {},
+  layoutConfig?: LayoutConfig,
+) => {
   const mergedConfig = defaults(config, defaultComputerAPITreeConfig);
   const tree: TableOfContentsItem[] = [];
 
   tree.push({
     id: '/',
     slug: '/',
-    title: 'Overview',
+    title: layoutConfig?.apiTree?.overview ?? 'Overview',
     type: 'overview',
     meta: '',
   });
@@ -78,7 +83,7 @@ export const computeAPITree = (serviceNode: ServiceNode, config: ComputeAPITreeC
   const operationNodes = serviceNode.children.filter(node => node.type === NodeType.HttpOperation);
   if (operationNodes.length) {
     tree.push({
-      title: 'Endpoints',
+      title: layoutConfig?.apiTree?.endpoints ?? 'Endpoints',
     });
 
     const { groups, ungrouped } = computeTagGroups(serviceNode);
@@ -126,7 +131,7 @@ export const computeAPITree = (serviceNode: ServiceNode, config: ComputeAPITreeC
 
   if (!mergedConfig.hideSchemas && schemaNodes.length) {
     tree.push({
-      title: 'Schemas',
+      title: layoutConfig?.apiTree?.schemas ?? 'Schemas',
     });
 
     schemaNodes.forEach(node => {


### PR DESCRIPTION
This PR adds the prop `layoutConfig` to the <API> component, which adds support for configuring layout texts. Thus making it possible to change the language of the layout. Added Portuguese-BR layout option.


### Example using `layoutConfig` object:

    layoutConfig = {
        api: {
            descriptionUrlErrorTitle: "Doc could not be loaded"
        },
        serverInfo: {
            title: "API Base URL",
        },
    }

    <API apiDescriptionUrl={url} layoutConfig={layoutConfig}  />


### Example using language support (*only english and portuguese-BR*):

    <API apiDescriptionUrl={url} layoutConfig="EN"  />

    or

    <API apiDescriptionUrl={url} layoutConfig="PT-BR"  />

### `layoutConfig` keys:
#### api:
| name  | description | default |
|---|---|---|
|  descriptionUrlErrorTitle | Title of error message thrown when fetch of openAPI description URL fail.s | Document could not be loaded.|
|  descriptionUrlError| Error message thrown when fetch of openAPI description URL fails. | The API description document could not be fetched. This could indicate connectivity problems, or issues with the server hosting the spec.|
| descriptionFileErrorTitle | Title of error message thrown when fails to open openAPI file. | Failed to parse OpenAPI file. |
| descriptionFileError | Error message thrown when fails to open openAPI file. | Please make sure your OpenAPI file is valid and try again. |

#### apiTree:
| name  | description | default |
|---|---|---|
| overview | NavBar config. API tree alias for overview route (main page). | Overview |
| endpoints | NavBar config. API tree alias for endpoints group title. | Endpoints |
| schemas | NavBar config. API tree alias for schemas group title. | Schemas |

#### serverInfo:
| name  | description | default |
|---|---|---|
|title|ServerInfo component configuration. Container title.| API Base URL |

#### securitySchemes:
| name  | description | default |
|---|---|---|
|title|SecuritySchemes component configuration. Container title.|Security|

#### additionalInfo:
| name  | description | default |
|---|---|---|
|title| AdditionalInfo component configuration. Alias for contact. |  Additional Information|
|contact| AdditionalInfo component configuration. Alias for contact. | Contact | 
|license|AdditionalInfo component configuration. Alias for license.|license|
|termsOfService|AdditionalInfo component configuration. Alias for terms of service.| Terms of Service|

#### operationParameters:
| name  | description | default |
|---|---|---|
|title|OperationParameters component configuration. Container title. | Parameters|

#### tryIt:
| name  | description | default |
|---|---|---|
|sendApiRequest|TryIt component configuration. Send API Request button text.|Send API Request|
|authTitle|TryItAuth component configuration. Auth component title.|Auth|
|formDataBodyTitle|TryItAuth FormDataBody component configuration. Body component title.|Body|

#### requestSamples:
| name  | description | default |
|---|---|---|
|title|RequestSamples component configuration. Container title. | Request Sample|

#### responseExamples:
| name  | description | default |
|---|---|---|
|title|ResponseExamples component configuration. Container title.|Response Example|

#### request:
| name  | description | default |
|---|---|---|
|header|Endpoints request section configuration. Header.|Request|
|pathParameters|Endpoints request section configuration. Path Parameters subtitle.|Path Parameters|
|headerParameters|Endpoints request section configuration. Header Parameters subtitle.|Header|
|cookiesParameters|Endpoints request section configuration. Cookies Parameters subtitle.|Cookies|
|queryParameters|Endpoints request section configuration. Query Parameters subtitle.|Query Parameters|
|bodyHeader|Endpoints responses section configuration. Body Header.|Body|

#### response:
| name  | description | default |
|---|---|---|
|header|Endpoints responses section configuration. Header.|Responses|
|bodyHeader|Endpoints responses section configuration. Body Header.|Body|

#### badges:
| name  | description | default |
|---|---|---|
|deprecated|Badges components configuration. Deprecated badge title.|Deprecated|
|deprecatedTip|Badges components configuration. Deprecated badge tooltip text.||
|internal|Badges components configuration. Internal badge title.|Internal|
|internalTip|Badges components configuration. Deprecated badge tooltip text.||

#### modelExamples:
| name  | description | default |
|---|---|---|
|title|ModelExamples components configuration. Tilte of component.|Example|

# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
