### PR TITLE
chore: release

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^7.6.1",
+    "@stoplight/elements": "^7.6.4",
     "@stoplight/mosaic": "^1.15.4",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.6.3",
+  "version": "7.6.4",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.6.3",
+    "@stoplight/elements-core": "~7.6.4",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.24.5",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.6.3",
+  "version": "7.6.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.6.3",
+    "@stoplight/elements-core": "~7.6.4",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.24.5",


### PR DESCRIPTION
# Elements Default PR Template

This PR releases elements after [bumping the version of mosaic](https://github.com/stoplightio/elements/pull/2214) so that we can then bump elements in platform-internal to resolve [8854](https://app.zenhub.com/workspaces/-team-burrito-dogs-61ddb473334b92001e5d6298/issues/stoplightio/platform-internal/8854)

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
