### PR TITLE
fix(elements-core): display operation path correctly at all times

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -8,6 +8,7 @@ import * as React from 'react';
 import { HttpMethodColors } from '../../../constants';
 import { MockingContext } from '../../../containers/MockingProvider';
 import { useResolvedObject } from '../../../context/InlineRefResolver';
+import { useChosenServerUrl } from '../../../hooks/useChosenServerUrl';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { chosenServerAtom, TryItWithRequestSamples } from '../../TryIt';
 import { DocsComponentProps } from '..';
@@ -117,16 +118,21 @@ function MethodPath({ method, path }: MethodPathProps) {
 function MethodPathInner({ method, path, chosenServerUrl }: MethodPathProps & { chosenServerUrl: string }) {
   const isDark = useThemeIsDark();
   const fullUrl = `${chosenServerUrl}${path}`;
+  const { leading, trailing } = useChosenServerUrl(chosenServerUrl);
 
   const pathElem = (
-    <Flex overflowX="hidden">
-      {chosenServerUrl ? (
-        <Box dir="rtl" color="muted" fontSize="lg" textOverflow="truncate" overflowX="hidden">
-          {chosenServerUrl}
-        </Box>
-      ) : null}
+    <Flex overflowX="hidden" fontSize="lg" userSelect="all">
+      <Box dir="rtl" color="muted" textOverflow="truncate" overflowX="hidden">
+        {leading}
 
-      <Box fontSize="lg" fontWeight="semibold" flex={1}>
+        {trailing !== null && (
+          <Box as="span" dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
+            {trailing}
+          </Box>
+        )}
+      </Box>
+
+      <Box fontWeight="semibold" flex={1}>
         {path}
       </Box>
     </Flex>

--- a/packages/elements-core/src/hooks/__tests__/useChosenServerUrl.ts.spec.ts
+++ b/packages/elements-core/src/hooks/__tests__/useChosenServerUrl.ts.spec.ts
@@ -1,0 +1,23 @@
+import { useChosenServerUrl } from '../useChosenServerUrl';
+
+describe('useChosenServerUrl', () => {
+  it('given no trailing non-alphanumeric char, should return the leading and mark trailing as null', () => {
+    const chosenServerUrl = 'https://todos.stoplight.io/development';
+    const { leading, trailing } = useChosenServerUrl(chosenServerUrl);
+
+    expect(leading).toBe('https://todos.stoplight.io/development');
+    expect(trailing).toBeNull();
+  });
+
+  it('given trailing non-alphanumeric char, should return the leading and trailing parts of the chosen server url', () => {
+    expect(useChosenServerUrl('https://todos.stoplight.io/development-')).toStrictEqual({
+      leading: 'https://todos.stoplight.io/development',
+      trailing: '-',
+    });
+
+    expect(useChosenServerUrl('https://todos.stoplight.io/development--')).toStrictEqual({
+      leading: 'https://todos.stoplight.io/development',
+      trailing: '--',
+    });
+  });
+});

--- a/packages/elements-core/src/hooks/useChosenServerUrl.ts
+++ b/packages/elements-core/src/hooks/useChosenServerUrl.ts
@@ -1,0 +1,22 @@
+const ALPHANUMERIC = /[^A-Za-z0-9]+$/;
+
+type ChosenServerUrl = {
+  leading: string;
+  trailing: string | null;
+};
+
+export function useChosenServerUrl(chosenServerUrl: string): ChosenServerUrl {
+  const match = ALPHANUMERIC.exec(chosenServerUrl);
+
+  if (match === null) {
+    return {
+      leading: chosenServerUrl,
+      trailing: null,
+    };
+  }
+
+  return {
+    leading: chosenServerUrl.substring(0, match.index),
+    trailing: chosenServerUrl.substring(match.index),
+  };
+}


### PR DESCRIPTION
Aside from a fix, I also did it so that a single click selects the whole url.

https://user-images.githubusercontent.com/9273484/184356301-73afd1b5-c8ff-49d5-9691-04837e65b9d8.mp4


