### PR TITLE
fix(elements): keep unresolvable hashes when hash router is used

### DIFF
--- a/packages/elements/src/components/API/APIWithSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithSidebarLayout.tsx
@@ -3,6 +3,7 @@ import {
   Logo,
   ParsedDocs,
   PoweredByLink,
+  RoutingProps,
   SidebarLayout,
   TableOfContents,
 } from '@stoplight/elements-core';
@@ -24,6 +25,7 @@ type SidebarLayoutProps = {
   exportProps?: ExportButtonProps;
   tryItCredentialsPolicy?: 'omit' | 'include' | 'same-origin';
   tryItCorsProxy?: string;
+  router?: RoutingProps['router'];
 };
 
 export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
@@ -36,6 +38,7 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
   exportProps,
   tryItCredentialsPolicy,
   tryItCorsProxy,
+  router,
 }) => {
   const container = React.useRef<HTMLDivElement>(null);
   const tree = React.useMemo(
@@ -45,7 +48,8 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
   const location = useLocation();
   const { pathname } = location;
   const isRootPath = !pathname || pathname === '/';
-  const node = isRootPath ? serviceNode : serviceNode.children.find(child => child.uri === pathname);
+  let node = isRootPath ? serviceNode : serviceNode.children.find(child => child.uri === pathname);
+  const isHashRouter = router === 'hash';
 
   const layoutOptions = React.useMemo(
     () => ({ hideTryIt: hideTryIt, hideExport: hideExport || node?.type !== NodeType.HttpService }),
@@ -56,7 +60,9 @@ export const APIWithSidebarLayout: React.FC<SidebarLayoutProps> = ({
     // Redirect to the first child if node doesn't exist
     const firstSlug = findFirstNodeSlug(tree);
 
-    if (firstSlug) {
+    if (isHashRouter) {
+      node = serviceNode;
+    } else if (firstSlug) {
       return <Redirect to={firstSlug} />;
     }
   }

--- a/packages/elements/src/containers/API.tsx
+++ b/packages/elements/src/containers/API.tsx
@@ -181,6 +181,7 @@ export const APIImpl: React.FC<APIProps> = props => {
           exportProps={exportProps}
           tryItCredentialsPolicy={tryItCredentialsPolicy}
           tryItCorsProxy={tryItCorsProxy}
+          router={props.router}
         />
       )}
     </InlineRefResolverProvider>


### PR DESCRIPTION
Fixes https://github.com/stoplightio/elements/issues/2205

When `HashRouter` is used, hashes are (obviously) used for navigation.
This poses an issue, as h2/h3/h4 headings may also contain anchors, which are supposed to navigate us to a particular fragment of the page.
Currently elements redirects you to root (`/`) if a given route has no node associated.
Due to the nature of `HashRouter`, both the heading anchors and the links adhere to the same mechanism, thus any link heading that's not associated with a subpage, will be redirected to `/`
Unfortunately, we cannot quite tell whether a user wants to navigate to a particular subpage or simply has an anchor, so what I ended up was: if we cannot associate any node with a particular hash, we redirect to `/` and keep the initial hash.
This way the navigation works correctly. That's presumably what 99% of hash router users would expect to happen.