### PR TITLE
fix: multipart form-data request samples

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^7.6.4",
+    "@stoplight/elements": "^7.6.5",
     "@stoplight/mosaic": "^1.15.4",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -70,7 +70,7 @@
     "@stoplight/types": "^13.0.0",
     "@stoplight/yaml": "^4.2.3",
     "classnames": "^2.2.6",
-    "httpsnippet": "^1.24.0",
+    "httpsnippet": "^2.0.0",
     "jotai": "1.3.9",
     "json-schema": "^0.4.0",
     "lodash": "^4.17.19",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.6.4",
+  "version": "7.6.5",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/RequestSamples/__tests__/RequestSamples.test.tsx
+++ b/packages/elements-core/src/components/RequestSamples/__tests__/RequestSamples.test.tsx
@@ -23,8 +23,18 @@ const sampleRequest = {
   ],
   queryString: [],
   cookies: [],
+  postData: {
+    mimeType: 'multipart/form-data',
+    params: [
+      {
+        name: 'file',
+        fileName: 'example.jpeg',
+        contentType: 'image.jpeg',
+      },
+    ],
+  },
   headersSize: 678,
-  bodySize: 0,
+  bodySize: -1,
 };
 
 describe('RequestSend', () => {
@@ -84,6 +94,16 @@ describe('RequestSend', () => {
 
     expect(langSelector).toHaveTextContent(/obj-c/i);
     expect(container).toHaveTextContent('#import <Foundation/Foundation.h>');
+  });
+
+  it('adds multipart form data to js/fetch request', async () => {
+    const { container } = render(<RequestSamples request={sampleRequest} />);
+    const langSelector = getLanguageSelectorButton();
+    await chooseLanguage('JavaScript', 'Fetch');
+
+    expect(langSelector).toHaveTextContent(/javascript/i);
+    expect(langSelector).toHaveTextContent(/fetch/i);
+    expect(container).toHaveTextContent('options.body = form;');
   });
 });
 

--- a/packages/elements-core/src/components/TryIt/build-request.ts
+++ b/packages/elements-core/src/components/TryIt/build-request.ts
@@ -1,7 +1,6 @@
 import { Dictionary, IHttpOperation, IMediaTypeContent } from '@stoplight/types';
 import { Request as HarRequest } from 'har-format';
 
-import { fileToBase64 } from '../../utils/fileToBase64';
 import { getServerUrlWithDefaultValues, IServer } from '../../utils/http-spec/IServer';
 import {
   filterOutAuthorizationParams,
@@ -201,26 +200,19 @@ export async function buildHarRequest({
   if (shouldIncludeBody && typeof bodyInput === 'object') {
     postData = {
       mimeType,
-      params: await Promise.all(
-        Object.entries(bodyInput).map(async ([name, value]) => {
-          if (value instanceof File) {
-            let base64Value = undefined;
-            try {
-              base64Value = await fileToBase64(value);
-            } catch {}
-            return {
-              name,
-              ...(base64Value && { value: base64Value }),
-              fileName: value.name,
-              contentType: value.type,
-            };
-          }
+      params: Object.entries(bodyInput).map(([name, value]) => {
+        if (value instanceof File) {
           return {
             name,
-            value,
+            fileName: value.name,
+            contentType: value.type,
           };
-        }),
-      ),
+        }
+        return {
+          name,
+          value,
+        };
+      }),
     };
   }
 

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.6.4",
+    "@stoplight/elements-core": "~7.6.5",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.24.5",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.6.4",
+  "version": "7.6.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.6.4",
+    "@stoplight/elements-core": "~7.6.5",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.24.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12178,10 +12178,10 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-httpsnippet@^1.24.0:
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/httpsnippet/-/httpsnippet-1.25.0.tgz#c7efaef9e3b980c6ba03652a45efcb0b8480a1d0"
-  integrity sha512-jobE6S923cLuf5BPG6Jf+oLBRkPzv2RPp0dwOHcWwj/t9FwV/t9hyZ46kpT3Q5DHn9iFNmGhrcmmFUBqyjoTQg==
+httpsnippet@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/httpsnippet/-/httpsnippet-2.0.0.tgz#695bc2e662535b37a993d25f40b3496b5ae82350"
+  integrity sha512-Hb2ttfB5OhasYxwChZ8QKpYX3v4plNvwMaMulUIC7M3RHRDf1Op6EMp47LfaU2sgQgfvo5spWK4xRAirMEisrg==
   dependencies:
     chalk "^1.1.1"
     commander "^2.9.0"
@@ -12191,7 +12191,6 @@ httpsnippet@^1.24.0:
     fs-readfile-promise "^2.0.1"
     fs-writefile-promise "^1.0.3"
     har-validator "^5.0.0"
-    pinkie-promise "^2.0.0"
     stringify-object "^3.3.0"
 
 human-signals@^1.1.1:


### PR DESCRIPTION
Fixes missing data property for javascript/fetch request sample for multipart/form-data requests with attached file.

Generated code snippet didn't include form data in fetch options. It was fixed in the newest version of `httpsnippet`. 

Before:
<img width="583" alt="Screenshot 2022-08-24 at 15 22 44" src="https://user-images.githubusercontent.com/14196079/186429615-faab1052-c709-4111-97bc-25214d051746.png">

After:
<img width="576" alt="Screenshot 2022-08-24 at 15 20 28" src="https://user-images.githubusercontent.com/14196079/186429640-50b21a34-4426-482e-9d1e-ec4630df0d5a.png">

