### PR TITLE
fix: do not use custom link heading if no router

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^7.7.0",
+    "@stoplight/elements": "^7.7.1",
     "@stoplight/mosaic": "^1.33.0",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/LinkHeading.tsx
+++ b/packages/elements-core/src/components/LinkHeading.tsx
@@ -1,14 +1,21 @@
-import { LinkHeading as MosaicLinkedHeading, LinkHeadingProps } from '@stoplight/mosaic';
+import { LinkHeading as MosaicLinkHeading, LinkHeadingProps } from '@stoplight/mosaic';
 import * as React from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { RouterTypeContext } from '../context/RouterType';
+import { RouterTypeContext, useRouterType } from '../context/RouterType';
 
-export const LinkHeading = React.memo<LinkHeadingProps>(function LinkHeading({ id: _id, ...props }) {
+export const LinkHeading = React.memo<LinkHeadingProps>(function LinkHeading(props) {
+  const isUsingRouter = !!useRouterType();
+  const Comp = isUsingRouter ? CustomLinkHeading : MosaicLinkHeading;
+
+  return <Comp {...props} />;
+});
+
+const CustomLinkHeading = React.memo<LinkHeadingProps>(function LinkHeading({ id: _id, ...props }) {
   const { pathname } = useLocation();
   const routerKind = React.useContext(RouterTypeContext);
   const route = pathname.split('#')[0];
   const id = routerKind === 'hash' ? `${route}#${_id}` : _id;
 
-  return <MosaicLinkedHeading id={id} {...props} />;
+  return <MosaicLinkHeading id={id} {...props} />;
 });

--- a/packages/elements-core/src/context/RouterType.tsx
+++ b/packages/elements-core/src/context/RouterType.tsx
@@ -2,4 +2,8 @@ import * as React from 'react';
 
 import type { RouterType } from '../types';
 
-export const RouterTypeContext = React.createContext<RouterType>('history');
+export const RouterTypeContext = React.createContext<RouterType | null>(null);
+
+export const useRouterType = () => {
+  return React.useContext(RouterTypeContext);
+};

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.0",
+    "@stoplight/elements-core": "~7.7.1",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.7.0",
+  "version": "7.7.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.0",
+    "@stoplight/elements-core": "~7.7.1",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",


### PR DESCRIPTION
Follow up to https://github.com/stoplightio/elements/pull/2237

We can't use `useLocation` if we're not in the context of the react router provider. Verified fixed the issue over in platform, and the tests from the above PR still pass.