### PR TITLE
fix(elements-core): display response codes in full on any screen (#2260)

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
@@ -52,13 +52,15 @@ export const Responses = ({ responses: unsortedResponses, onStatusCodeChange, on
   return (
     <VStack spacing={8} as={Tabs} selectedId={activeResponseId} onChange={setActiveResponseId} appearance="pill">
       <SectionTitle title="Responses">
-        <TabList density="compact">
-          {responses.map(({ code }) => (
-            <Tab key={code} id={code} intent={codeToIntentVal(code)}>
-              {code}
-            </Tab>
-          ))}
-        </TabList>
+        <div className="sl-responses-tab-list">
+          <TabList density="compact">
+            {responses.map(({ code }) => (
+              <Tab key={code} id={code} intent={codeToIntentVal(code)}>
+                {code}
+              </Tab>
+            ))}
+          </TabList>
+        </div>
       </SectionTitle>
 
       <TabPanels p={0}>

--- a/packages/elements-core/src/core.css
+++ b/packages/elements-core/src/core.css
@@ -85,3 +85,10 @@
   font-size: 12px;
   line-height: 1.5em;
 }
+
+/* Responses */
+
+.sl-responses-tab-list > div {
+  flex-wrap: wrap;
+  gap: 4px;
+}


### PR DESCRIPTION
This PR makes all the response codes in a `TabList` visible so that the user can get a full information even on a small screen.