### PR TITLE
fix: try it large responses

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^7.7.2",
+    "@stoplight/elements": "^7.7.3",
     "@stoplight/mosaic": "^1.33.0",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.7.2",
+  "version": "7.7.3",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -206,7 +206,7 @@ export const TryIt: React.FC<TryItProps> = ({
         const bodyText = type !== 'image' ? await response.text() : undefined;
         const blob = type === 'image' ? await response.blob() : undefined;
 
-        setResponse(undefined);
+        setResponse(undefined); // setting undefined to handle rendering large responses
         setResponse({
           status: response.status,
           bodyText,

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -193,21 +193,21 @@ export const TryIt: React.FC<TryItProps> = ({
         credentials: tryItCredentialsPolicy,
         corsProxy,
       });
-      let response1: Response | undefined;
+      let response: Response | undefined;
       try {
-        setResponse(response);
-        response1 = await fetch(...request);
+        setResponse(undefined);
+        response = await fetch(...request);
       } catch (e: any) {
         setResponse({ error: new NetworkError(e.message) });
       }
-      if (response1) {
-        const contentType = response1.headers.get('Content-Type');
+      if (response) {
+        const contentType = response.headers.get('Content-Type');
         const type = contentType ? getResponseType(contentType) : undefined;
 
         setResponse({
-          status: response1.status,
-          bodyText: type !== 'image' ? await response1.text() : undefined,
-          blob: type === 'image' ? await response1.blob() : undefined,
+          status: response.status,
+          bodyText: type !== 'image' ? await response.text() : undefined,
+          blob: type === 'image' ? await response.blob() : undefined,
           contentType,
         });
       }

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -193,20 +193,21 @@ export const TryIt: React.FC<TryItProps> = ({
         credentials: tryItCredentialsPolicy,
         corsProxy,
       });
-      let response: Response | undefined;
+      let response1: Response | undefined;
       try {
-        response = await fetch(...request);
+        setResponse(response);
+        response1 = await fetch(...request);
       } catch (e: any) {
         setResponse({ error: new NetworkError(e.message) });
       }
-      if (response) {
-        const contentType = response.headers.get('Content-Type');
+      if (response1) {
+        const contentType = response1.headers.get('Content-Type');
         const type = contentType ? getResponseType(contentType) : undefined;
 
         setResponse({
-          status: response.status,
-          bodyText: type !== 'image' ? await response.text() : undefined,
-          blob: type === 'image' ? await response.blob() : undefined,
+          status: response1.status,
+          bodyText: type !== 'image' ? await response1.text() : undefined,
+          blob: type === 'image' ? await response1.blob() : undefined,
           contentType,
         });
       }

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -195,7 +195,6 @@ export const TryIt: React.FC<TryItProps> = ({
       });
       let response: Response | undefined;
       try {
-        setResponse(undefined);
         response = await fetch(...request);
       } catch (e: any) {
         setResponse({ error: new NetworkError(e.message) });
@@ -204,10 +203,14 @@ export const TryIt: React.FC<TryItProps> = ({
         const contentType = response.headers.get('Content-Type');
         const type = contentType ? getResponseType(contentType) : undefined;
 
+        const bodyText = type !== 'image' ? await response.text() : undefined;
+        const blob = type === 'image' ? await response.blob() : undefined;
+
+        setResponse(undefined);
         setResponse({
           status: response.status,
-          bodyText: type !== 'image' ? await response.text() : undefined,
-          blob: type === 'image' ? await response.blob() : undefined,
+          bodyText,
+          blob,
           contentType,
         });
       }

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.2",
+    "@stoplight/elements-core": "~7.7.3",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.8.3';
+export const appVersion = '1.9.2';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.7.2",
+  "version": "7.7.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.2",
+    "@stoplight/elements-core": "~7.7.3",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/11697
Continuation of https://github.com/stoplightio/elements/pull/2061

Large TryIt responses are causing a bug that prevents response component to rerender correctly making old response content persist (despite the `response` state set with new data). 

I wasn't able to find the reason for that, even going deep into mosaic CodeViewer component - new props are passed and can be accessed correctly.

Solution to that issue (not the greatest one) is resetting the `response` state ~~after invoking request~~ before setting actual response, which causes the CodeViewer to unmount and render again once new response is set. ~~That causes slight change in the ui making old response disappear on invoking new request. That's something that could be considered as either feature or bug.~~

**Before**

https://user-images.githubusercontent.com/14196079/197600613-66609301-7188-4686-9ecd-68c57aed8ab6.mov

**After**

https://user-images.githubusercontent.com/14196079/197600687-37d0ad87-45ae-4843-b772-cfc4552bdc94.mov
