### PR TITLE
fix(elements-dev-portal): link hover text

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     working_directory: /mnt/ramdisk/project
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.17
     resource_class: large
     environment:
       CYPRESS_CACHE_FOLDER: /mnt/ramdisk/.cache/Cypress

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -94,13 +94,13 @@ export const NodeContent = ({
 const NodeLinkContext = React.createContext<[Node, CustomLinkComponent] | undefined>(undefined);
 
 const externalRegex = new RegExp('^(?:[a-z]+:)?//', 'i');
-const LinkComponent: CustomComponentMapping['a'] = ({ children, href }) => {
+const LinkComponent: CustomComponentMapping['a'] = ({ children, href, title }) => {
   const ctx = React.useContext(NodeLinkContext);
 
   if (href && externalRegex.test(href)) {
     // Open external URL in a new tab
     return (
-      <a href={href} target="_blank" rel="noreferrer">
+      <a href={href} target="_blank" rel="noreferrer" title={title ? title : undefined}>
         {children}
       </a>
     );


### PR DESCRIPTION
# Elements Default PR Template
Before:
<img width="1512" alt="Screen Shot 2022-11-02 at 11 06 34 AM" src="https://user-images.githubusercontent.com/58235624/199570609-07b8c6bb-9aa5-4d2e-a05b-08f7971d4edc.png">
After:
<img width="1512" alt="Screen Shot 2022-11-02 at 11 07 19 AM" src="https://user-images.githubusercontent.com/58235624/199570869-33ab0874-84a7-4ca9-9076-9c8972e5eb7b.png">

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
