### PR TITLE
chore: ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           command: weekly_lockfile_maintenance.sh
   release:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.17
     steps:
       - checkout
       - run:


### PR DESCRIPTION
# Elements Default PR Template
circle ci failed on release and threw the same error as it previously threw in the build process.  docker image was deprecated in build but not in release.  This pr deprecates it in release as well to get ci to pass.
In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
