### PR TITLE
feat: response tabs horizontal scrolling

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^7.7.3",
+    "@stoplight/elements": "^7.7.5",
     "@stoplight/mosaic": "^1.33.0",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.7.4",
+  "version": "7.7.5",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/Docs/Sections.tsx
+++ b/packages/elements-core/src/components/Docs/Sections.tsx
@@ -12,11 +12,11 @@ export interface ISectionTitle {
 
 export const SectionTitle: React.FC<ISectionTitle> = ({ title, id, size = 2, children }) => {
   return (
-    <Flex flexWrap>
+    <Flex w="full">
       <Box py={1} pr={6} as={LinkHeading} size={size} aria-label={title} id={id || slugify(title)}>
         {title}
       </Box>
-      <Box alignSelf={'center'} py={1}>
+      <Box alignSelf={'center'} py={1} flexGrow style={{ minWidth: 0 }}>
         {children}
       </Box>
     </Flex>

--- a/packages/elements-core/src/core.css
+++ b/packages/elements-core/src/core.css
@@ -85,3 +85,8 @@
   font-size: 12px;
   line-height: 1.5em;
 }
+
+.sl-elements .HttpOperation div[role=tablist] {
+  /* Enables horizontal scrolling for response tabs */
+  overflow-x: auto;
+}

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.4",
+    "@stoplight/elements-core": "~7.7.5",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.7.4",
+  "version": "7.7.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.4",
+    "@stoplight/elements-core": "~7.7.5",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/10150

Adds horizontal scrolling for http operation responses.

I'm not adding `x-overflow` property directly to mosaic because:
- it has some side effects with wrapping whitespaces 
- mosaic is supposed to handle overflowing tabs by switching them to select component (though it may require good bit of work)
- elements response tabs is the only case when we need that


https://user-images.githubusercontent.com/14196079/200484922-62e122e6-a5af-4b6c-9380-4e4ce280b941.mov

