### PR TITLE
fix: increase tick count for json schema sampler

### DIFF
--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
@@ -16,7 +16,7 @@ export type GenerateExampleFromMediaTypeContentOptions = Sampler.Options;
 export const useGenerateExampleFromMediaTypeContent = (
   mediaTypeContent: IMediaTypeContent | undefined,
   chosenExampleIndex?: number,
-  { skipReadOnly, skipWriteOnly, skipNonRequired }: GenerateExampleFromMediaTypeContentOptions = {},
+  { skipReadOnly, skipWriteOnly, skipNonRequired, ticks }: GenerateExampleFromMediaTypeContentOptions = {},
 ) => {
   const document = useDocument();
   return React.useMemo(
@@ -25,8 +25,9 @@ export const useGenerateExampleFromMediaTypeContent = (
         skipNonRequired,
         skipWriteOnly,
         skipReadOnly,
+        ticks: ticks || 6000,
       }),
-    [mediaTypeContent, document, chosenExampleIndex, skipNonRequired, skipReadOnly, skipWriteOnly],
+    [mediaTypeContent, document, chosenExampleIndex, skipNonRequired, skipWriteOnly, skipReadOnly, ticks],
   );
 };
 
@@ -82,6 +83,7 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7): Example[] =
   try {
     const generated = Sampler.sample(schema, {
       maxSampleDepth: 4,
+      ticks: 6000,
     });
 
     return generated !== null


### PR DESCRIPTION
#2238 

Fix for 2238, large example schemas throwing "Exceeds schema size error massage". Fix should allow for larger sized response and example schemas. 

The fix was to increase the tick count for the json schema sampler. By default the tick count is set to 1000. For elements I am now passing in a count of 6000. For context the schema the kicked off this issue has around 30,000 lines and requires around 4500 ticks. 

Impacts. Ticks are used as a count ceiling for performance and dose not increase execution time. Added by https://github.com/stoplightio/json-schema-sampler/pull/22 . It appears ticks might not be a great indicator of time/performance. For context the sampler execution timer is exponential but only averages around 8ms for the large schema mentioned above. I think we need a followup ticket to rethink/rework this mechanism in the json schema sampler (https://github.com/stoplightio/json-schema-sampler/issues/33)


I'm using SB here with the schema provided by the client to test.

https://user-images.githubusercontent.com/2607104/201147121-d83e1f88-da14-4970-ada9-cd4109c22a2b.mov



- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
