### PR TITLE
fix(elements-core): model description overlaps examples

### DIFF
--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -71,7 +71,7 @@ const ModelComponent: React.FC<ModelProps> = ({
   const description = (
     <VStack spacing={10}>
       {data.description && data.type === 'object' && (
-        <Box pos="relative">
+        <Box pos="relative" overflowX="scroll">
           <MarkdownViewer role="textbox" markdown={data.description} />
           <NodeAnnotation change={descriptionChanged} />
         </Box>


### PR DESCRIPTION
# [Model] Description overlaps `Examples`

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)

In case the Model description is a pretty wide markdown table, it overlaps the Examples.

AR:
![image](https://user-images.githubusercontent.com/34237389/203272770-acbe1d9b-6415-4563-aa09-350156957217.png)
ER:
![image](https://user-images.githubusercontent.com/34237389/203272826-80dea38c-75df-408c-b6a8-2da4457d9a50.png)

