### PR TITLE
chore: release elements-dev-portal

### DIFF
--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [


### PR DESCRIPTION
This mostly makes sure we the new packages uses the latest elements.
The current one points at ~7.7.5 and is potentially 5 releases behind