### PR TITLE
fix: schema property examples are no longer incorrectly arrays

### DIFF
--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
@@ -1,8 +1,9 @@
+import { JSONSchema7Definition } from 'json-schema';
 import { httpOperation } from '../../../__fixtures__/operations/put-todos';
-import { initialParameterValues } from './parameter-utils';
+import { initialParameterValues, mapSchemaPropertiesToParameters } from './parameter-utils';
 
 describe('Parameter Utils', () => {
-  describe(initialParameterValues.name, () => {
+  describe('initialParameterValues.name', () => {
     it('should fill initial parameters', () => {
       const allParameters = [
         ...(httpOperation.request?.path ?? []),
@@ -18,6 +19,65 @@ describe('Parameter Utils', () => {
         'account-id': 'account-id-default',
         'message-id': 'example value',
       });
+    });
+  });
+
+  describe('mapSchemaPropertiesToParameters.name', () => {
+    it('should convert schema properties to parameters', () => {
+      const properties: { [key: string]: JSONSchema7Definition } = {
+        withExamples: { type: 'string', examples: ['blah'] },
+        withEmptyExamples: { type: 'string', examples: [] },
+        withNoExamples: { type: 'string' },
+        requiredWithExamples: { type: 'string', examples: ['blah'] },
+        requiredWithEmptyExamples: { type: 'string', examples: [] },
+        requiredWithNoExamples: { type: 'string' },
+        requiredBoolean: true,
+        boolean: false,
+      };
+      const required = [
+        'requiredWithExamples',
+        'requiredWithEmptyExamples',
+        'requiredWithNoExamples',
+        'requiredBoolean',
+      ];
+      expect(mapSchemaPropertiesToParameters(properties, required)).toEqual([
+        {
+          name: 'withExamples',
+          schema: { type: 'string', examples: ['blah'] },
+          examples: [{ key: 'example', value: 'blah' }],
+        },
+        {
+          name: 'withEmptyExamples',
+          schema: { type: 'string', examples: [] },
+        },
+        {
+          name: 'withNoExamples',
+          schema: { type: 'string' },
+        },
+        {
+          name: 'requiredWithExamples',
+          schema: { type: 'string', examples: ['blah'] },
+          examples: [{ key: 'example', value: 'blah' }],
+          required: true,
+        },
+        {
+          name: 'requiredWithEmptyExamples',
+          schema: { type: 'string', examples: [] },
+          required: true,
+        },
+        {
+          name: 'requiredWithNoExamples',
+          schema: { type: 'string' },
+          required: true,
+        },
+        {
+          name: 'requiredBoolean',
+          required: true,
+        },
+        {
+          name: 'boolean',
+        },
+      ]);
     });
   });
 });

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
@@ -1,4 +1,5 @@
 import { JSONSchema7Definition } from 'json-schema';
+
 import { httpOperation } from '../../../__fixtures__/operations/put-todos';
 import { initialParameterValues, mapSchemaPropertiesToParameters } from './parameter-utils';
 

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -109,7 +109,10 @@ export function mapSchemaPropertiesToParameters(
   return Object.entries(properties).map(([name, schema]) => ({
     name,
     schema: typeof schema !== 'boolean' ? schema : undefined,
-    examples: typeof schema !== 'boolean' && schema.examples ? [{ key: 'example', value: schema.examples }] : undefined,
+    examples:
+      typeof schema !== 'boolean' && schema.examples && schema.examples[0]
+        ? [{ key: 'example', value: schema.examples[0] }]
+        : undefined,
     ...(required?.includes(name) && { required: true }),
   }));
 }


### PR DESCRIPTION
# Elements Default PR Template
Fix for https://github.com/stoplightio/platform-internal/issues/15773

With it yalc'd into platform-internal using the provided spec in the ticket:
![image](https://user-images.githubusercontent.com/33431856/228973029-2229fa78-b887-4999-ba66-e5de2c8b59f8.png)

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
