### PR TITLE
feat(elements-dev-portal): support new node links for export

### DIFF
--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -70,7 +70,10 @@ export const NodeContent = ({
               compact,
               hideTryIt: hideTryIt,
               hideTryItPanel: hideTryItPanel,
-              hideExport: hideExport || node.links.export_url === undefined,
+              hideExport:
+                hideExport ||
+                (node.links.export_url ?? node.links.export_original_file_url ?? node.links.export_bundled_file_url) ===
+                  undefined,
             }}
             useNodeForRefResolving
             refResolver={refResolver}
@@ -80,10 +83,10 @@ export const NodeContent = ({
                 ? {
                     original: onExportRequest
                       ? { onPress: () => onExportRequest('original') }
-                      : { href: node.links.export_url },
+                      : { href: node.links.export_original_file_url ?? node.links.export_url },
                     bundled: onExportRequest
                       ? { onPress: () => onExportRequest('bundled') }
-                      : { href: getBundledUrl(node.links.export_url) },
+                      : { href: node.links.export_bundled_file_url ?? getBundledUrl(node.links.export_url) },
                   }
                 : undefined
             }

--- a/packages/elements-dev-portal/src/types.ts
+++ b/packages/elements-dev-portal/src/types.ts
@@ -19,7 +19,18 @@ export type Node = NodeSummary & {
   data: any;
   links: {
     mock_url?: string;
+    /**
+     * @deprecated use export_original_file_url instead
+     */
     export_url?: string;
+    /**
+     * The URL to export the original file. This is not a bundled output, meaning references are left in place.
+     */
+    export_original_file_url?: string;
+    /**
+     * The URL to export a bundled form of the file. Bundling means references are copied into the output file.
+     */
+    export_bundled_file_url?: string;
   };
   outbound_edges: NodeEdge[];
   inbound_edges: NodeEdge[];


### PR DESCRIPTION
adds support for more specific export urls in dev portal.
