### PR TITLE
fix(elements): double asterisks in path results in error

### DIFF
--- a/packages/elements/src/utils/oas/index.ts
+++ b/packages/elements/src/utils/oas/index.ts
@@ -133,8 +133,11 @@ function computeChildNodes(
 
 function findMapMatch(key: string | number, map: ISourceNodeMap[]): ISourceNodeMap | void {
   if (typeof key === 'number') return;
+
+  const escapedKey = key.replace(/\*\*/g, '\\*\\*');
+
   for (const entry of map) {
-    if (!!entry.match?.match(key) || (entry.notMatch !== void 0 && !entry.notMatch.match(key))) {
+    if (!!entry.match?.match(escapedKey) || (entry.notMatch !== void 0 && !entry.notMatch.match(escapedKey))) {
       return entry;
     }
   }


### PR DESCRIPTION
# Double Asterisks (**) in openapi `path` results in error

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)

Example:
1) open https://stoplight-elements.netlify.app/?path=/story/public-api--open-api-3-schema
2) add `**` to any path (e.g. `'/todos/{id}` -> `'/todos/{id}/**'`)

ER: Such path does not break the view. Displayed correctly
AR: Unexpected error while parsing regexp.
![image](https://github.com/stoplightio/elements/assets/34237389/bc136562-da68-46e5-be80-8b286ef8f6f1)

Fixed behavior can be tested on netlify CI server