### PR TITLE
fix(elements-core): markdown ref resolving

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.7.19",
+  "version": "7.7.20",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/__fixtures__/articles/schema-with-refs.ts
+++ b/packages/elements-core/src/__fixtures__/articles/schema-with-refs.ts
@@ -1,0 +1,69 @@
+export const schemaWithRefs = `---
+title: Schema with refs
+---
+
+# Schema with refs (Swr)
+
+### Schema
+
+This is bundled schema with refs
+
+\`\`\`json jsonSchema
+{
+  "title": "DerefTest",
+  "type": "object",
+  "description": "Dereferencing test object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "inner": {
+      "description": "Inner object",
+      "title": "Inner",
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "referencedObject": {
+          "$ref": "#/properties/referencedObject",
+          "description": "Inner referenced object"
+        }
+      },
+      "required": [
+        "id",
+        "bookingRate"
+      ]
+    },
+    "referencedObject": {
+      "description": "Referenced object",
+      "title": "ReferencedObject",
+      "type": "object",
+      "required": [
+        "property1",
+        "property2",
+        "property3"
+      ],
+      "properties": {
+        "property1": {
+          "type": "integer",
+          "description": "Property 1"
+        },
+        "property2": {
+          "type": "string",
+          "description": "Property 2"
+        },
+        "property3": {
+          "type": "boolean",
+          "description": "Property 3"
+        }
+      }
+    }
+  },
+  "required": [
+    "id",
+    "inner",
+    "referencedObject"
+  ]
+}
+\`\`\``;

--- a/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/CustomComponents/CodeComponent.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import URI from 'urijs';
 
 import { NodeTypeColors, NodeTypeIconDefs } from '../../../constants';
-import { useSchemaInlineRefResolver } from '../../../context/InlineRefResolver';
+import { InlineRefResolverProvider, useInlineRefResolver, useSchemaInlineRefResolver } from '../../../context/InlineRefResolver';
 import { PersistenceContextProvider } from '../../../context/Persistence';
 import { useParsedValue } from '../../../hooks/useParsedValue';
 import { JSONSchema } from '../../../types';
@@ -58,6 +58,8 @@ export { DefaultSMDComponents };
 export const CodeComponent: CustomComponentMapping['code'] = props => {
   const { title, jsonSchema, http, resolved, children } = props;
 
+  const resolver = useInlineRefResolver();
+
   const value = resolved || String(Array.isArray(children) ? children[0] : children);
   const parsedValue = useParsedValue(value);
 
@@ -66,7 +68,11 @@ export const CodeComponent: CustomComponentMapping['code'] = props => {
       return null;
     }
 
-    return <SchemaAndDescription title={title} schema={parsedValue} />;
+    return (
+      <InlineRefResolverProvider document={parsedValue} resolver={resolver}>
+        <SchemaAndDescription title={title} schema={parsedValue} />
+      </InlineRefResolverProvider>
+    );
   }
 
   if (http) {

--- a/packages/elements-core/src/components/MarkdownViewer/MarkdownViewer.spec.tsx
+++ b/packages/elements-core/src/components/MarkdownViewer/MarkdownViewer.spec.tsx
@@ -4,6 +4,7 @@ import { NodeType } from '@stoplight/types';
 import { render, screen } from '@testing-library/react';
 import * as React from 'react';
 
+import { schemaWithRefs } from '../../__fixtures__/articles/schema-with-refs';
 import { withPersistenceBoundary } from '../../context/Persistence';
 import { IntegrationKind } from '../../types';
 import { MarkdownViewer } from '.';
@@ -148,6 +149,20 @@ describe('MarkdownViewer', () => {
       // no default
       expect(screen.getByText('limit')).toBeInTheDocument();
       expect(screen.getByLabelText('limit')).toHaveProperty('value', '');
+
+      unmount();
+    });
+
+    it('Should resolve refs in schema', () => {
+      const MarkdownViewerWithTryIt = withPersistenceBoundary(MarkdownViewer);
+
+      const { unmount } = render(
+        <MarkdownComponentsProvider value={{ code: CodeComponent }}>
+          <MarkdownViewerWithTryIt markdown={schemaWithRefs} />
+        </MarkdownComponentsProvider>,
+      );
+
+      expect(screen.getByText(/Inner referenced object/)).toBeInTheDocument();
 
       unmount();
     });

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.19",
+    "@stoplight/elements-core": "~7.7.20",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.7.19",
+  "version": "7.7.20",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.19",
+    "@stoplight/elements-core": "~7.7.20",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",


### PR DESCRIPTION
Fixes resolving refs in markdown files.

`Docs` component uses `InlineRefResolverProvider` referencing parsed document. That works fine with json/yaml files but in case of markdown it results in undefined document and resolver (since markdown file is not a plain object). We need to point to the schema document instead of whole markdown file. 

This PR adds internal `InlineRefResolverProvider` to `CodeComponent` to handle schemas within markdown files.



