### PR TITLE
fix: bump json-schema-viewer to show array[$ref] descriptions

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.7.20",
+  "version": "7.7.21",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",
@@ -61,7 +61,7 @@
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.3",
-    "@stoplight/json-schema-viewer": "^4.10.1",
+    "@stoplight/json-schema-viewer": "^4.10.2",
     "@stoplight/markdown-viewer": "^5.6.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/mosaic-code-editor": "^1.33.0",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.20",
+    "@stoplight/elements-core": "~7.7.21",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.7.20",
+  "version": "7.7.21",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.7.20",
+    "@stoplight/elements-core": "~7.7.21",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3518,10 +3518,10 @@
     "@types/json-schema" "^7.0.7"
     json-pointer "^0.6.1"
 
-"@stoplight/json-schema-tree@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-tree/-/json-schema-tree-2.2.4.tgz#60e41ffc454a60225a45450bfac711ec31bd7766"
-  integrity sha512-UW+ubBHgh1QIGvhA3tFlDLBwWyq4vAxlln/rDwPcaSFjP9PKlJu7d19RT6WJyg247FwbSqsTTqS7n4Y7aLz63A==
+"@stoplight/json-schema-tree@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-tree/-/json-schema-tree-2.2.5.tgz#a3f78f3d475b74338f6d2da7ec6733a96cb9819f"
+  integrity sha512-H2d5EHbWJwbu4h7Eh3R4He4SGlfA5ScucpMqylVTgPwQImvikIyrI+v6oqzpl9fFZ6SkidfTcUs3z1+IKwxWdA==
   dependencies:
     "@stoplight/json" "^3.12.0"
     "@stoplight/json-schema-merge-allof" "^0.7.8"
@@ -3529,13 +3529,13 @@
     "@types/json-schema" "^7.0.7"
     magic-error "0.0.1"
 
-"@stoplight/json-schema-viewer@^4.10.1":
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.10.1.tgz#8f199a1902a8eb10aa0b5107ef8b4d3863c9ee73"
-  integrity sha512-jyQdeME80Y1Q3Ap/XL8YdpCHvqYso0FgWpFCULcg1KFO7Ga9o+Scs4ifl1mefgqPL2Vs65kteM8A+Uln3f2Alw==
+"@stoplight/json-schema-viewer@^4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.10.2.tgz#c0f18a7f628f569e47d1c51ea969dfc9d5f24f8e"
+  integrity sha512-SOyBtERCT+3P2GymMa1SjSn26q8oR0wInVt50QJEylhtJY0kZ5ZjtTv4frSFqZWTLdREu8Pg5uTI+YEneb4fIA==
   dependencies:
     "@stoplight/json" "^3.20.1"
-    "@stoplight/json-schema-tree" "^2.2.4"
+    "@stoplight/json-schema-tree" "^2.2.5"
     "@stoplight/react-error-boundary" "^2.0.0"
     "@types/json-schema" "^7.0.7"
     classnames "^2.2.6"


### PR DESCRIPTION
# Elements Default PR Template

Addresses [#12516](https://app.zenhub.com/workspaces/-team-enchilotters-62ab7d6627416c001df37493/issues/gh/stoplightio/platform-internal/12516)

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)


#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
