### PR TITLE
feat/add credential policy params to try it

### DIFF
--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -144,6 +144,7 @@ export const TryIt: React.FC<TryItProps> = ({
         ...(isMockingEnabled && { mockData: getMockData(mockUrl, httpOperation, mockingOptions) }),
         chosenServer,
         corsProxy,
+        credentials: tryItCredentialsPolicy
       }).then(request => {
         if (isMounted) {
           if (onRequestChange) {
@@ -171,6 +172,7 @@ export const TryIt: React.FC<TryItProps> = ({
     mockingOptions,
     chosenServer,
     corsProxy,
+    tryItCredentialsPolicy,
     embeddedInMd,
   ]);
 

--- a/packages/elements-core/src/components/TryIt/build-request.ts
+++ b/packages/elements-core/src/components/TryIt/build-request.ts
@@ -240,6 +240,7 @@ export async function buildHarRequest({
   mockData,
   chosenServer,
   corsProxy,
+  credentials
 }: BuildRequestInput): Promise<HarRequest> {
   const serverUrl = getServerUrl({ httpOperation, mockData, chosenServer, corsProxy });
 
@@ -297,7 +298,7 @@ export async function buildHarRequest({
     method: httpOperation.method.toUpperCase(),
     url: urlObject.href,
     httpVersion: 'HTTP/1.1',
-    cookies: [],
+    cookies: [credentials],
     headers: headerParamsWithAuth,
     queryString: queryParamsWithAuth,
     postData: postData,
@@ -326,3 +327,4 @@ export function getAcceptedMimeTypes(httpOperation: IHttpOperation): string[] {
     ),
   );
 }
+`


### PR DESCRIPTION
Passing in the credential policy parameter to the `har` request to expose and make available the request policies for cookies:

- `omit` (already default)
- `include`
- `same-site`

[More information on credentials policies](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials)