### PR TITLE
fix: handle keys which have uncommon url paths, such as `/entries/{id}/data)`

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements/src/utils/oas/__tests__/oas.spec.ts
+++ b/packages/elements/src/utils/oas/__tests__/oas.spec.ts
@@ -269,4 +269,63 @@ describe('computeOasNodes', () => {
       ],
     });
   });
+
+  it('should not throw error for non-common url paths', () => {
+    expect(
+      transformOasToServiceNode({
+        'x-stoplight': { id: 'def' },
+        openapi: '3.0.0',
+        info: {
+          title: 'oas3',
+          version: '1.0.0',
+        },
+        paths: {
+          '/todos/{id}/flow)': {
+            get: {
+              operationId: 'get-todos',
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      type: 'http_service',
+      uri: '/',
+      name: 'oas3',
+      tags: [],
+      data: {
+        id: 'def',
+        version: '1.0.0',
+        name: 'oas3',
+      },
+      children: [
+        {
+          type: 'http_operation',
+          uri: '/operations/get-todos',
+          data: {
+            id: '7b7e36ffa6501',
+            iid: 'get-todos',
+            method: 'get',
+            path: '/todos/{id}/flow)',
+            responses: [],
+            servers: [],
+            request: {
+              body: {
+                id: '9b96158a8647a',
+                contents: [],
+              },
+              headers: [],
+              query: [],
+              cookie: [],
+              path: [],
+            },
+            tags: [],
+            security: [],
+            extensions: {},
+          },
+          tags: [],
+          name: 'get-todos',
+        },
+      ],
+    });
+  });
 });

--- a/packages/elements/src/utils/oas/index.ts
+++ b/packages/elements/src/utils/oas/index.ts
@@ -134,7 +134,9 @@ function computeChildNodes(
 function findMapMatch(key: string | number, map: ISourceNodeMap[]): ISourceNodeMap | void {
   if (typeof key === 'number') return;
   for (const entry of map) {
-    if (!!entry.match?.match(key) || (entry.notMatch !== void 0 && !entry.notMatch.match(key))) {
+    const escapedKey = key.replace(/([()[{*+.$^\\|?])/g, '\\$1');
+
+    if (!!entry.match?.match(escapedKey) || (entry.notMatch !== void 0 && !entry.notMatch.match(escapedKey))) {
       return entry;
     }
   }

--- a/packages/elements/src/utils/oas/index.ts
+++ b/packages/elements/src/utils/oas/index.ts
@@ -134,7 +134,7 @@ function computeChildNodes(
 function findMapMatch(key: string | number, map: ISourceNodeMap[]): ISourceNodeMap | void {
   if (typeof key === 'number') return;
   for (const entry of map) {
-    const escapedKey = key.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')
+    const escapedKey = key.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
 
     if (!!entry.match?.match(escapedKey) || (entry.notMatch !== void 0 && !entry.notMatch.match(escapedKey))) {
       return entry;

--- a/packages/elements/src/utils/oas/index.ts
+++ b/packages/elements/src/utils/oas/index.ts
@@ -134,7 +134,7 @@ function computeChildNodes(
 function findMapMatch(key: string | number, map: ISourceNodeMap[]): ISourceNodeMap | void {
   if (typeof key === 'number') return;
   for (const entry of map) {
-    const escapedKey = key.replace(/([()[{*+.$^\\|?])/g, '\\$1');
+    const escapedKey = key.replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')
 
     if (!!entry.match?.match(escapedKey) || (entry.notMatch !== void 0 && !entry.notMatch.match(escapedKey))) {
       return entry;


### PR DESCRIPTION
Fixes the issue when a OpenAPI specification file has a url such as `/entries/{id}/data)` the `findMapMatch`-function
throws a `invalid regular expresison` error.

# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
