### PR TITLE
feat(elements-dev-portal): embedded search component

### DIFF
--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -1,4 +1,5 @@
-import { Input, useModalState } from '@stoplight/mosaic';
+import { faSearch, faSpinner } from '@fortawesome/free-solid-svg-icons';
+import { Box, Icon, Input, useModalState } from '@stoplight/mosaic';
 import { Story } from '@storybook/react';
 import * as React from 'react';
 
@@ -39,7 +40,7 @@ const SearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWrapperPro
 
   return (
     <>
-      {!isEmbedded && <Input placeholder="Search..." onClick={open} />}
+      <Input placeholder="Search..." onClick={open} />
       <Search
         isLoading={isFetching}
         search={search}
@@ -54,6 +55,61 @@ const SearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWrapperPro
   );
 };
 
+const EmbeddedSearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWrapperProps) => {
+  const { isOpen, close } = useModalState();
+  const [search, setSearch] = React.useState('');
+  const { data, isFetching } = useGetNodes({
+    search,
+    projectIds,
+    workspaceId,
+  });
+
+  const { data: workspace } = useGetWorkspace({
+    projectIds,
+  });
+
+  const handleClose = () => {
+    close();
+    setSearch('');
+  };
+
+  const handleClick = (searchResult: NodeSearchResult) => {
+    console.log('Search clicked', searchResult);
+    window.open(
+      `https://${workspace?.workspace.slug}.stoplight.io/docs/${searchResult.project_slug}${searchResult.uri}`,
+      '_blank',
+    );
+
+    handleClose();
+  };
+
+  return (
+    <>
+      <Input
+        appearance="minimal"
+        borderB
+        icon={<Box as={Icon} ml={1} icon={isFetching ? faSpinner : faSearch} spin={isFetching} />}
+        autoFocus
+        placeholder="Search..."
+        value={search}
+        onChange={e => {
+          setSearch(e.currentTarget.value);
+        }}
+        type="search"
+      />
+      <Search
+        isLoading={isFetching}
+        search={search}
+        searchResults={data}
+        onSearch={setSearch}
+        isOpen={isOpen}
+        onClose={handleClose}
+        onClick={handleClick}
+        isEmbedded={true}
+      />
+    </>
+  );
+};
 export default {
   title: 'Public/Search',
   component: SearchWrapper,
@@ -70,11 +126,8 @@ export default {
 };
 
 export const Playground: Story<SearchWrapperProps> = args => <SearchWrapper {...args} />;
+export const EmbeddedSearch: Story<SearchWrapperProps> = args => <EmbeddedSearchWrapper {...args} />;
 
 Playground.storyName = 'Studio Demo';
 
-export const EmbeddedSearch = Playground.bind({});
-EmbeddedSearch.args = {
-  isEmbedded: true,
-};
 EmbeddedSearch.storyName = 'Embedded Search';

--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -7,9 +7,9 @@ import { useGetWorkspace } from '../../hooks/useGetWorkspace';
 import { NodeSearchResult } from '../../types';
 import { Search } from './';
 
-type SearchWrapperProps = { projectIds: string[]; workspaceId: string };
+type SearchWrapperProps = { projectIds: string[]; workspaceId: string; isEmbedded?: boolean };
 // Wrapper to show how to use the node content hook
-const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
+const SearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWrapperProps) => {
   const { isOpen, open, close } = useModalState();
   const [search, setSearch] = React.useState('');
   const { data, isFetching } = useGetNodes({
@@ -39,7 +39,7 @@ const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
 
   return (
     <>
-      <Input placeholder="Search..." onClick={open} />
+      {!isEmbedded && <Input placeholder="Search..." onClick={open} />}
       <Search
         isLoading={isFetching}
         search={search}
@@ -48,6 +48,7 @@ const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
         isOpen={isOpen}
         onClose={handleClose}
         onClick={handleClick}
+        isEmbedded={isEmbedded}
       />
     </>
   );
@@ -71,3 +72,9 @@ export default {
 export const Playground: Story<SearchWrapperProps> = args => <SearchWrapper {...args} />;
 
 Playground.storyName = 'Studio Demo';
+
+export const EmbeddedSearch = Playground.bind({});
+EmbeddedSearch.args = {
+  isEmbedded: true,
+};
+EmbeddedSearch.storyName = 'Embedded Search';

--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { useGetNodes } from '../../hooks/useGetNodes';
 import { useGetWorkspace } from '../../hooks/useGetWorkspace';
 import { NodeSearchResult } from '../../types';
-import { Search } from './';
+import { Search, SearchResults } from './';
 
 type SearchWrapperProps = { projectIds: string[]; workspaceId: string; isEmbedded?: boolean };
 // Wrapper to show how to use the node content hook
@@ -49,14 +49,12 @@ const SearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWrapperPro
         isOpen={isOpen}
         onClose={handleClose}
         onClick={handleClick}
-        isEmbedded={isEmbedded}
       />
     </>
   );
 };
 
 const EmbeddedSearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWrapperProps) => {
-  const { isOpen, close } = useModalState();
   const [search, setSearch] = React.useState('');
   const { data, isFetching } = useGetNodes({
     search,
@@ -68,19 +66,12 @@ const EmbeddedSearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWr
     projectIds,
   });
 
-  const handleClose = () => {
-    close();
-    setSearch('');
-  };
-
   const handleClick = (searchResult: NodeSearchResult) => {
     console.log('Search clicked', searchResult);
     window.open(
       `https://${workspace?.workspace.slug}.stoplight.io/docs/${searchResult.project_slug}${searchResult.uri}`,
       '_blank',
     );
-
-    handleClose();
   };
 
   return (
@@ -97,16 +88,9 @@ const EmbeddedSearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWr
         }}
         type="search"
       />
-      <Search
-        isLoading={isFetching}
-        search={search}
-        searchResults={data}
-        onSearch={setSearch}
-        isOpen={isOpen}
-        onClose={handleClose}
-        onClick={handleClick}
-        isEmbedded={true}
-      />
+      <Box p={5}>
+        <SearchResults searchResults={data} onClick={handleClick} isEmbedded={true} />
+      </Box>
     </>
   );
 };

--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -8,9 +8,9 @@ import { useGetWorkspace } from '../../hooks/useGetWorkspace';
 import { NodeSearchResult } from '../../types';
 import { Search, SearchResults } from './';
 
-type SearchWrapperProps = { projectIds: string[]; workspaceId: string; isEmbedded?: boolean };
+type SearchWrapperProps = { projectIds: string[]; workspaceId: string };
 // Wrapper to show how to use the node content hook
-const SearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWrapperProps) => {
+const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
   const { isOpen, open, close } = useModalState();
   const [search, setSearch] = React.useState('');
   const { data, isFetching } = useGetNodes({
@@ -54,7 +54,7 @@ const SearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWrapperPro
   );
 };
 
-const EmbeddedSearchWrapper = ({ projectIds, workspaceId, isEmbedded }: SearchWrapperProps) => {
+const EmbeddedSearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
   const [search, setSearch] = React.useState('');
   const { data, isFetching } = useGetNodes({
     search,

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -85,38 +85,18 @@ const SearchImpl = ({
           isOpen={!!isOpen}
           onClose={onClose}
         >
-          <SearchResults
-            searchResults={searchResults}
-            onSelectionChange={onSelectionChange}
-            isEmbedded={false}
-          ></SearchResults>
+          <SearchResults searchResults={searchResults} onSelectionChange={onSelectionChange} isEmbedded={false} />
         </Modal>
       ) : (
-        <Box>
-          <Input
-            appearance="minimal"
-            borderB
-            icon={<Box as={Icon} ml={1} icon={isLoading ? faSpinner : faSearch} spin={isLoading} />}
-            autoFocus
-            placeholder="Search..."
-            value={search}
-            onChange={onChange}
-            onKeyDown={onKeyDown}
-          />
-          <Box p={5}>
-            <SearchResults
-              searchResults={searchResults}
-              onSelectionChange={onSelectionChange}
-              isEmbedded={true}
-            ></SearchResults>
-          </Box>
+        <Box p={5}>
+          <SearchResults searchResults={searchResults} onSelectionChange={onSelectionChange} isEmbedded={true} />
         </Box>
       )}
     </>
   );
 };
 
-const SearchResults = ({ searchResults, onSelectionChange, isEmbedded }: SearchResultsProps) => {
+export const SearchResults = ({ searchResults, onSelectionChange, isEmbedded }: SearchResultsProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
 
   return (

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -21,25 +21,15 @@ export type SearchProps = {
   onClick: (result: NodeSearchResult) => void;
   isOpen?: boolean;
   onClose: ModalProps['onClose'];
-  isEmbedded?: boolean;
 };
 
 export type SearchResultsProps = {
   searchResults?: NodeSearchResult[];
   isEmbedded?: boolean;
-  onSelectionChange: (keys: any) => void;
+  onClick: (result: NodeSearchResult) => void;
 };
 
-const SearchImpl = ({
-  isLoading,
-  search,
-  searchResults,
-  isOpen,
-  onClose,
-  onClick,
-  onSearch,
-  isEmbedded,
-}: SearchProps) => {
+const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick, onSearch }: SearchProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
 
   const onChange = React.useCallback(e => onSearch(e.currentTarget.value), [onSearch]);
@@ -52,6 +42,31 @@ const SearchImpl = ({
     }
   }, []);
 
+  return (
+    <Modal
+      renderHeader={() => (
+        <Input
+          appearance="minimal"
+          borderB
+          size="lg"
+          icon={<Box as={Icon} ml={1} icon={isLoading ? faSpinner : faSearch} spin={isLoading} />}
+          autoFocus
+          placeholder="Search..."
+          value={search}
+          onChange={onChange}
+          onKeyDown={onKeyDown}
+        />
+      )}
+      isOpen={!!isOpen}
+      onClose={onClose}
+    >
+      <SearchResults searchResults={searchResults} onClick={onClick} isEmbedded={false} />
+    </Modal>
+  );
+};
+
+export const SearchResults = ({ searchResults, onClick, isEmbedded }: SearchResultsProps) => {
+  const listBoxRef = React.useRef<HTMLDivElement>(null);
   const onSelectionChange = React.useCallback(
     keys => {
       const selectedId = keys.values().next().value;
@@ -64,40 +79,6 @@ const SearchImpl = ({
     },
     [searchResults, onClick],
   );
-
-  return (
-    <>
-      {!isEmbedded ? (
-        <Modal
-          renderHeader={() => (
-            <Input
-              appearance="minimal"
-              borderB
-              size="lg"
-              icon={<Box as={Icon} ml={1} icon={isLoading ? faSpinner : faSearch} spin={isLoading} />}
-              autoFocus
-              placeholder="Search..."
-              value={search}
-              onChange={onChange}
-              onKeyDown={onKeyDown}
-            />
-          )}
-          isOpen={!!isOpen}
-          onClose={onClose}
-        >
-          <SearchResults searchResults={searchResults} onSelectionChange={onSelectionChange} isEmbedded={false} />
-        </Modal>
-      ) : (
-        <Box p={5}>
-          <SearchResults searchResults={searchResults} onSelectionChange={onSelectionChange} isEmbedded={true} />
-        </Box>
-      )}
-    </>
-  );
-};
-
-export const SearchResults = ({ searchResults, onSelectionChange, isEmbedded }: SearchResultsProps) => {
-  const listBoxRef = React.useRef<HTMLDivElement>(null);
 
   return (
     <>

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -60,12 +60,12 @@ const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick
       isOpen={!!isOpen}
       onClose={onClose}
     >
-      <SearchResults searchResults={searchResults} onClick={onClick} isEmbedded={false} />
+      <SearchResultsList searchResults={searchResults} onClick={onClick} />
     </Modal>
   );
 };
 
-export const SearchResults = ({ searchResults, onClick, isEmbedded }: SearchResultsProps) => {
+export const SearchResultsList = ({ searchResults, onClick, isEmbedded }: SearchResultsProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
   const onSelectionChange = React.useCallback(
     keys => {
@@ -139,6 +139,13 @@ export const SearchResults = ({ searchResults, onClick, isEmbedded }: SearchResu
     </>
   );
 };
+
+export const SearchResults = flow(
+  withStyles,
+  withPersistenceBoundary,
+  withMosaicProvider,
+  withQueryClientProvider,
+)(SearchResultsList);
 
 export const Search = flow(
   withStyles,

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -23,7 +23,7 @@ export type SearchProps = {
   onClose: ModalProps['onClose'];
 };
 
-export type SearchResultsProps = {
+export type SearchResultsListProps = {
   searchResults?: NodeSearchResult[];
   isEmbedded?: boolean;
   onClick: (result: NodeSearchResult) => void;
@@ -65,7 +65,7 @@ const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick
   );
 };
 
-export const SearchResultsList = ({ searchResults, onClick, isEmbedded }: SearchResultsProps) => {
+export const SearchResultsList = ({ searchResults, onClick, isEmbedded }: SearchResultsListProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
   const onSelectionChange = React.useCallback(
     keys => {

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -23,6 +23,11 @@ export type SearchProps = {
   onClose: ModalProps['onClose'];
 };
 
+export type SearchResultsProps = {
+  searchResults?: NodeSearchResult[];
+  onSelectionChange: (keys: any) => void;
+};
+
 const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick, onSearch }: SearchProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
 
@@ -67,6 +72,16 @@ const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick
       isOpen={!!isOpen}
       onClose={onClose}
     >
+      <SearchResults searchResults={searchResults} onSelectionChange={onSelectionChange}></SearchResults>
+    </Modal>
+  );
+};
+
+const SearchResults = ({ searchResults, onSelectionChange }: SearchResultsProps) => {
+  const listBoxRef = React.useRef<HTMLDivElement>(null);
+
+  return (
+    <Box>
       {searchResults && searchResults.length > 0 ? (
         <ListBox
           ref={listBoxRef}
@@ -121,7 +136,7 @@ const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick
           No search results
         </Flex>
       )}
-    </Modal>
+    </Box>
   );
 };
 

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -26,6 +26,7 @@ export type SearchProps = {
 export type SearchResultsListProps = {
   searchResults?: NodeSearchResult[];
   isEmbedded?: boolean;
+  showDivider?: boolean;
   onClick: (result: NodeSearchResult) => void;
 };
 
@@ -65,7 +66,12 @@ const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick
   );
 };
 
-export const SearchResultsList = ({ searchResults, onClick, isEmbedded }: SearchResultsListProps) => {
+export const SearchResultsList = ({
+  searchResults,
+  onClick,
+  isEmbedded,
+  showDivider = true,
+}: SearchResultsListProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
   const onSelectionChange = React.useCallback(
     keys => {
@@ -96,7 +102,7 @@ export const SearchResultsList = ({ searchResults, onClick, isEmbedded }: Search
           {(searchResult: NodeSearchResult) => {
             return (
               <ListBoxItem key={`${searchResult.id}-${searchResult.project_id}`} textValue={searchResult.title}>
-                <Box p={3} borderB>
+                <Box p={3} borderB={!showDivider ? undefined : true}>
                   <Flex align="center">
                     <Box
                       as={Icon}

--- a/packages/elements-dev-portal/src/components/Search/Search.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.tsx
@@ -21,14 +21,25 @@ export type SearchProps = {
   onClick: (result: NodeSearchResult) => void;
   isOpen?: boolean;
   onClose: ModalProps['onClose'];
+  isEmbedded?: boolean;
 };
 
 export type SearchResultsProps = {
   searchResults?: NodeSearchResult[];
+  isEmbedded?: boolean;
   onSelectionChange: (keys: any) => void;
 };
 
-const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick, onSearch }: SearchProps) => {
+const SearchImpl = ({
+  isLoading,
+  search,
+  searchResults,
+  isOpen,
+  onClose,
+  onClick,
+  onSearch,
+  isEmbedded,
+}: SearchProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
 
   const onChange = React.useCallback(e => onSearch(e.currentTarget.value), [onSearch]);
@@ -55,39 +66,67 @@ const SearchImpl = ({ isLoading, search, searchResults, isOpen, onClose, onClick
   );
 
   return (
-    <Modal
-      renderHeader={() => (
-        <Input
-          appearance="minimal"
-          borderB
-          size="lg"
-          icon={<Box as={Icon} ml={1} icon={isLoading ? faSpinner : faSearch} spin={isLoading} />}
-          autoFocus
-          placeholder="Search..."
-          value={search}
-          onChange={onChange}
-          onKeyDown={onKeyDown}
-        />
+    <>
+      {!isEmbedded ? (
+        <Modal
+          renderHeader={() => (
+            <Input
+              appearance="minimal"
+              borderB
+              size="lg"
+              icon={<Box as={Icon} ml={1} icon={isLoading ? faSpinner : faSearch} spin={isLoading} />}
+              autoFocus
+              placeholder="Search..."
+              value={search}
+              onChange={onChange}
+              onKeyDown={onKeyDown}
+            />
+          )}
+          isOpen={!!isOpen}
+          onClose={onClose}
+        >
+          <SearchResults
+            searchResults={searchResults}
+            onSelectionChange={onSelectionChange}
+            isEmbedded={false}
+          ></SearchResults>
+        </Modal>
+      ) : (
+        <Box>
+          <Input
+            appearance="minimal"
+            borderB
+            icon={<Box as={Icon} ml={1} icon={isLoading ? faSpinner : faSearch} spin={isLoading} />}
+            autoFocus
+            placeholder="Search..."
+            value={search}
+            onChange={onChange}
+            onKeyDown={onKeyDown}
+          />
+          <Box p={5}>
+            <SearchResults
+              searchResults={searchResults}
+              onSelectionChange={onSelectionChange}
+              isEmbedded={true}
+            ></SearchResults>
+          </Box>
+        </Box>
       )}
-      isOpen={!!isOpen}
-      onClose={onClose}
-    >
-      <SearchResults searchResults={searchResults} onSelectionChange={onSelectionChange}></SearchResults>
-    </Modal>
+    </>
   );
 };
 
-const SearchResults = ({ searchResults, onSelectionChange }: SearchResultsProps) => {
+const SearchResults = ({ searchResults, onSelectionChange, isEmbedded }: SearchResultsProps) => {
   const listBoxRef = React.useRef<HTMLDivElement>(null);
 
   return (
-    <Box>
+    <>
       {searchResults && searchResults.length > 0 ? (
         <ListBox
           ref={listBoxRef}
           aria-label="Search"
           overflowY="auto"
-          h={80}
+          h={isEmbedded ? undefined : 80}
           m={-5}
           items={searchResults}
           selectionMode="single"
@@ -136,7 +175,7 @@ const SearchResults = ({ searchResults, onSelectionChange }: SearchResultsProps)
           No search results
         </Flex>
       )}
-    </Box>
+    </>
   );
 };
 

--- a/packages/elements-dev-portal/src/index.ts
+++ b/packages/elements-dev-portal/src/index.ts
@@ -5,7 +5,7 @@ export { DevPortalProvider } from './components/DevPortalProvider';
 export type { NodeContentProps } from './components/NodeContent';
 export { NodeContent } from './components/NodeContent';
 export type { SearchProps } from './components/Search';
-export { Search } from './components/Search';
+export { Search, SearchResults } from './components/Search';
 export type { TableOfContentsProps } from './components/TableOfContents';
 export { TableOfContents } from './components/TableOfContents';
 export { devPortalCacheKeys } from './consts';

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.12.0';
+export const appVersion = '1.13.0';


### PR DESCRIPTION
# Elements Default PR Template

https://github.com/stoplightio/elements/assets/58235624/394bb2d9-b2f8-45bd-9349-e07a2810df06

This is an example of the `SearchResults` component embedded into the search sidebar in ninja.  

I basically extracted the search results into its own component so that it can be shown anywhere (doesn't have to be in a modal).  

This is how it looks in storybook: 

https://github.com/stoplightio/elements/assets/58235624/63eea696-01aa-415e-88b2-566009178736


In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
