### PR TITLE
feat: responsive http operation

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^7.7.5",
+    "@stoplight/elements": "^7.9.2",
     "@stoplight/mosaic": "^1.33.0",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^7.9.2",
+    "@stoplight/elements": "^7.10.0",
     "@stoplight/mosaic": "^1.33.0",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.9.0",
+  "version": "7.9.1",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.9.1",
+  "version": "7.10.0",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.stories.ts
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.stories.ts
@@ -6,4 +6,4 @@ const { meta, createHoistedStory } = createStoriesForDocsComponent(HttpOperation
 
 export default meta;
 
-export const Story = createHoistedStory({ data: httpOperation });
+export const Story = createHoistedStory({ data: httpOperation, layoutOptions: { compact: 600 } });

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -10,6 +10,7 @@ import { MockingContext } from '../../../containers/MockingProvider';
 import { useResolvedObject } from '../../../context/InlineRefResolver';
 import { useOptionsCtx } from '../../../context/Options';
 import { useChosenServerUrl } from '../../../hooks/useChosenServerUrl';
+import { useIsCompact } from '../../../hooks/useIsCompact';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { chosenServerAtom, TryItWithRequestSamples } from '../../TryIt';
 import { DocsComponentProps } from '..';
@@ -24,6 +25,7 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
   ({ className, data: unresolvedData, layoutOptions, tryItCredentialsPolicy, tryItCorsProxy }) => {
     const { nodeHasChanged } = useOptionsCtx();
     const data = useResolvedObject(unresolvedData) as IHttpOperation;
+    const { ref: layoutRef, isCompact } = useIsCompact(layoutOptions);
 
     const mocking = React.useContext(MockingContext);
     const isDeprecated = !!data.deprecated;
@@ -49,6 +51,19 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
       />
     );
 
+    const tryItPanel = !layoutOptions?.hideTryItPanel && (
+      <TryItWithRequestSamples
+        httpOperation={data}
+        responseMediaType={responseMediaType}
+        responseStatusCode={responseStatusCode}
+        requestBodyIndex={requestBodyIndex}
+        hideTryIt={layoutOptions?.hideTryIt}
+        tryItCredentialsPolicy={tryItCredentialsPolicy}
+        mockUrl={mocking.hideMocking ? undefined : mocking.mockUrl}
+        corsProxy={tryItCorsProxy}
+      />
+    );
+
     const descriptionChanged = nodeHasChanged?.({ nodeId: data.id, attr: 'description' });
     const description = (
       <VStack spacing={10}>
@@ -66,30 +81,21 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
             responses={data.responses}
             onMediaTypeChange={setResponseMediaType}
             onStatusCodeChange={setResponseStatusCode}
+            isCompact={isCompact}
           />
         )}
-      </VStack>
-    );
 
-    const tryItPanel = !layoutOptions?.hideTryItPanel && (
-      <TryItWithRequestSamples
-        httpOperation={data}
-        responseMediaType={responseMediaType}
-        responseStatusCode={responseStatusCode}
-        requestBodyIndex={requestBodyIndex}
-        hideTryIt={layoutOptions?.hideTryIt}
-        tryItCredentialsPolicy={tryItCredentialsPolicy}
-        mockUrl={mocking.hideMocking ? undefined : mocking.mockUrl}
-        corsProxy={tryItCorsProxy}
-      />
+        {isCompact && tryItPanel}
+      </VStack>
     );
 
     return (
       <TwoColumnLayout
+        ref={layoutRef}
         className={cn('HttpOperation', className)}
         header={header}
         left={description}
-        right={tryItPanel}
+        right={!isCompact && tryItPanel}
       />
     );
   },

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.9.0",
+    "@stoplight/elements-core": "~7.9.1",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.9.1",
+    "@stoplight/elements-core": "~7.10.0",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.9.1",
+  "version": "7.9.2",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.9.0",
+    "@stoplight/elements-core": "~7.9.1",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.9.2",
+  "version": "7.10.0",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.9.1",
+    "@stoplight/elements-core": "~7.10.0",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",


### PR DESCRIPTION
Adding responsiveness to Docs `HttpOperation`:
- Adds `compact` property and usage of `useIsCompact` hook to `HttpOperation`
- Moves `TryIt` panel to left column for compact layout
- Adds modal instead of tab responses for compact layout

https://github.com/stoplightio/elements/assets/14196079/cf20cac7-07b0-4158-9213-9a56c4737cea

