### PR TITLE
feat(elements-core): add callback when node docs is not going to render

### DIFF
--- a/packages/elements-core/src/components/Docs/Docs.tsx
+++ b/packages/elements-core/src/components/Docs/Docs.tsx
@@ -13,6 +13,8 @@ import { HttpService } from './HttpService';
 import { ExportButtonProps } from './HttpService/ExportButton';
 import { Model } from './Model';
 
+type NodeUnsupportedFn = (err: 'dataEmpty' | 'invalidType' | Error) => void;
+
 interface BaseDocsProps {
   /**
    * CSS class to add to the root container.
@@ -116,6 +118,14 @@ interface BaseDocsProps {
   };
 
   nodeHasChanged?: NodeHasChangedFn<React.ReactNode>;
+
+  /**
+   * Allows consumers to know when the node is not supported.
+   *
+   * @type {NodeUnsupportedFn}
+   * @default undefined
+   */
+  nodeUnsupported?: NodeUnsupportedFn;
 }
 
 export interface DocsProps extends BaseDocsProps {
@@ -137,7 +147,7 @@ export const Docs = React.memo<DocsProps>(
     const parsedNode = useParsedData(nodeType, nodeData);
 
     if (!parsedNode) {
-      // TODO: maybe report failure
+      commonProps.nodeUnsupported?.('dataEmpty');
       return null;
     }
 
@@ -159,7 +169,7 @@ export interface ParsedDocsProps extends BaseDocsProps {
   node: ParsedNode;
 }
 
-export const ParsedDocs = ({ node, ...commonProps }: ParsedDocsProps) => {
+export const ParsedDocs = ({ node, nodeUnsupported, ...commonProps }: ParsedDocsProps) => {
   switch (node.type) {
     case 'article':
       return <Article data={node.data} {...commonProps} />;
@@ -170,6 +180,7 @@ export const ParsedDocs = ({ node, ...commonProps }: ParsedDocsProps) => {
     case 'model':
       return <Model data={node.data} {...commonProps} />;
     default:
+      nodeUnsupported?.('invalidType');
       return null;
   }
 };

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -14,7 +14,10 @@ import * as React from 'react';
 import { Node } from '../../types';
 
 // Props shared with elements-core Docs component
-type DocsBaseProps = Pick<DocsProps, 'tryItCorsProxy' | 'tryItCredentialsPolicy' | 'nodeHasChanged'>;
+type DocsBaseProps = Pick<
+  DocsProps,
+  'tryItCorsProxy' | 'tryItCredentialsPolicy' | 'nodeHasChanged' | 'nodeUnsupported'
+>;
 type DocsLayoutProps = Pick<
   Required<DocsProps>['layoutOptions'],
   'compact' | 'hideTryIt' | 'hideTryItPanel' | 'hideExport'
@@ -48,6 +51,7 @@ export const NodeContent = ({
   tryItCorsProxy,
   tryItCredentialsPolicy,
   nodeHasChanged,
+  nodeUnsupported,
 
   // Docs layout props
   compact,
@@ -92,6 +96,7 @@ export const NodeContent = ({
             }
             tryItCredentialsPolicy={tryItCredentialsPolicy}
             nodeHasChanged={nodeHasChanged}
+            nodeUnsupported={nodeUnsupported}
           />
         </MockingProvider>
       </MarkdownComponentsProvider>


### PR DESCRIPTION
adds `nodeUnsupported` as a callback to indicate that the `Docs` component is not going to render anything for the node