### PR TITLE
Feat: Project ToC Responsive Style Adjustments

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.11.0",
+  "version": "7.12.0",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/MosaicTableOfContents/constants.ts
+++ b/packages/elements-core/src/components/MosaicTableOfContents/constants.ts
@@ -1,9 +1,15 @@
-import { faCloud, faCube } from '@fortawesome/free-solid-svg-icons';
+import { faBullseye, faCloud, faCube, faCubes } from '@fortawesome/free-solid-svg-icons';
 import { IIconProps } from '@stoplight/mosaic';
 
 // Icons appear left of the node title
 export const NODE_TYPE_TITLE_ICON: { [nodeType: string]: IIconProps['icon'] } = {
   http_service: faCloud,
+  http_operation: faBullseye,
+  model: faCube,
+};
+
+export const NODE_TITLE_ICON: { [nodeTitle: string]: IIconProps['icon'] } = {
+  Schemas: faCubes,
 };
 
 // Icons appear in the right meta
@@ -13,6 +19,12 @@ export const NODE_TYPE_META_ICON: { [nodeType: string]: IIconProps['icon'] } = {
 
 export const NODE_TYPE_ICON_COLOR = {
   model: 'warning',
+  http_service: '#D812EA',
+  http_operation: '#9747FF',
+};
+
+export const NODE_TITLE_ICON_COLOR = {
+  Schemas: 'warning',
 };
 
 export const NODE_META_COLOR = {

--- a/packages/elements-core/src/components/MosaicTableOfContents/types.ts
+++ b/packages/elements-core/src/components/MosaicTableOfContents/types.ts
@@ -4,6 +4,7 @@ export type TableOfContentsProps = {
   Link: CustomLinkComponent;
   maxDepthOpenByDefault?: number;
   externalScrollbar?: boolean;
+  isInResponsiveMode?: boolean;
   onLinkClick?(): void;
 };
 

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.11.0",
+    "@stoplight/elements-core": "~7.12.0",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -93,7 +93,7 @@ const EmbeddedSearchWrapper = ({ projectIds, workspaceId, isInResponsiveMode }: 
           type="search"
         />
       </Box>
-      <Box p={5}>
+      <Box>
         {isInResponsiveMode && !search && tableOfContents ? (
           <TableOfContents
             isInResponsiveMode={isInResponsiveMode}
@@ -116,7 +116,9 @@ const EmbeddedSearchWrapper = ({ projectIds, workspaceId, isInResponsiveMode }: 
         )}
         {/* show search results first if not in responsive mode */}
         {!isInResponsiveMode || (isInResponsiveMode && search) ? (
-          <SearchResults searchResults={data} onClick={handleClick} isEmbedded={true} />
+          <Box p={5}>
+            <SearchResults searchResults={data} onClick={handleClick} isEmbedded={true} />
+          </Box>
         ) : null}
       </Box>
     </>

--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -79,19 +79,21 @@ const EmbeddedSearchWrapper = ({ projectIds, workspaceId, isInResponsiveMode }: 
 
   return (
     <>
-      <Box pos="sticky" pinY bg="canvas" w="full">
-        <Input
-          appearance="minimal"
-          border
-          icon={<Box as={Icon} ml={1} icon={isFetching ? faSpinner : faSearch} spin={isFetching} />}
-          autoFocus
-          placeholder="Search..."
-          value={search}
-          onChange={e => {
-            setSearch(e.currentTarget.value);
-          }}
-          type="search"
-        />
+      <Box bg="canvas" pos="sticky" style={{ top: 0 }}>
+        <Box bg="canvas" w="full" pt={3}>
+          <Input
+            appearance="minimal"
+            border
+            icon={<Box as={Icon} ml={1} icon={isFetching ? faSpinner : faSearch} spin={isFetching} />}
+            autoFocus
+            placeholder="Search..."
+            value={search}
+            onChange={e => {
+              setSearch(e.currentTarget.value);
+            }}
+            type="search"
+          />
+        </Box>
       </Box>
       <Box>
         {isInResponsiveMode && !search && tableOfContents ? (

--- a/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
+++ b/packages/elements-dev-portal/src/components/Search/Search.stories.tsx
@@ -4,11 +4,13 @@ import { Story } from '@storybook/react';
 import * as React from 'react';
 
 import { useGetNodes } from '../../hooks/useGetNodes';
+import { useGetTableOfContents } from '../../hooks/useGetTableOfContents';
 import { useGetWorkspace } from '../../hooks/useGetWorkspace';
 import { NodeSearchResult } from '../../types';
+import { TableOfContents } from '../TableOfContents';
 import { Search, SearchResults } from './';
 
-type SearchWrapperProps = { projectIds: string[]; workspaceId: string };
+type SearchWrapperProps = { projectIds: string[]; workspaceId: string; isInResponsiveMode?: boolean };
 // Wrapper to show how to use the node content hook
 const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
   const { isOpen, open, close } = useModalState();
@@ -54,7 +56,7 @@ const SearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
   );
 };
 
-const EmbeddedSearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) => {
+const EmbeddedSearchWrapper = ({ projectIds, workspaceId, isInResponsiveMode }: SearchWrapperProps) => {
   const [search, setSearch] = React.useState('');
   const { data, isFetching } = useGetNodes({
     search,
@@ -65,6 +67,7 @@ const EmbeddedSearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) 
   const { data: workspace } = useGetWorkspace({
     projectIds,
   });
+  const { data: tableOfContents } = useGetTableOfContents({ projectId: projectIds[0], branchSlug: '' });
 
   const handleClick = (searchResult: NodeSearchResult) => {
     console.log('Search clicked', searchResult);
@@ -76,20 +79,45 @@ const EmbeddedSearchWrapper = ({ projectIds, workspaceId }: SearchWrapperProps) 
 
   return (
     <>
-      <Input
-        appearance="minimal"
-        borderB
-        icon={<Box as={Icon} ml={1} icon={isFetching ? faSpinner : faSearch} spin={isFetching} />}
-        autoFocus
-        placeholder="Search..."
-        value={search}
-        onChange={e => {
-          setSearch(e.currentTarget.value);
-        }}
-        type="search"
-      />
+      <Box pos="sticky" pinY bg="canvas" w="full">
+        <Input
+          appearance="minimal"
+          border
+          icon={<Box as={Icon} ml={1} icon={isFetching ? faSpinner : faSearch} spin={isFetching} />}
+          autoFocus
+          placeholder="Search..."
+          value={search}
+          onChange={e => {
+            setSearch(e.currentTarget.value);
+          }}
+          type="search"
+        />
+      </Box>
       <Box p={5}>
-        <SearchResults searchResults={data} onClick={handleClick} isEmbedded={true} />
+        {isInResponsiveMode && !search && tableOfContents ? (
+          <TableOfContents
+            isInResponsiveMode={isInResponsiveMode}
+            tableOfContents={tableOfContents}
+            activeId="b3A6MTE0"
+            Link={({ children, ...props }) => {
+              return (
+                <a
+                  onClick={() => {
+                    console.log('Link clicked!', props);
+                  }}
+                >
+                  {children}
+                </a>
+              );
+            }}
+          />
+        ) : (
+          !search && isInResponsiveMode && <>Loading...</>
+        )}
+        {/* show search results first if not in responsive mode */}
+        {!isInResponsiveMode || (isInResponsiveMode && search) ? (
+          <SearchResults searchResults={data} onClick={handleClick} isEmbedded={true} />
+        ) : null}
       </Box>
     </>
   );
@@ -101,11 +129,13 @@ export default {
     workspaceId: { table: { category: 'Input' } },
     projectIds: { table: { category: 'Input' } },
     platformUrl: { table: { category: 'Input' } },
+    isInResponsiveMode: { table: { category: 'Input' } },
   },
   args: {
     projectIds: ['cHJqOjYwNjYx'],
     workspaceId: 'd2s6NDE1NTU',
     platformUrl: 'https://stoplight.io',
+    isInResponsiveMode: false,
   },
 };
 

--- a/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.stories.tsx
+++ b/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.stories.tsx
@@ -5,11 +5,20 @@ import { useGetTableOfContents } from '../../hooks/useGetTableOfContents';
 import { TableOfContents } from './';
 
 // Wrapper to show how to use the node content hook
-const TableOfContentsWrapper = ({ projectId, branchSlug }: { projectId: string; branchSlug?: string }) => {
+const TableOfContentsWrapper = ({
+  projectId,
+  branchSlug,
+  isInResponsiveMode,
+}: {
+  projectId: string;
+  branchSlug?: string;
+  isInResponsiveMode?: boolean;
+}) => {
   const { data } = useGetTableOfContents({ projectId, branchSlug });
 
   return data ? (
     <TableOfContents
+      isInResponsiveMode={isInResponsiveMode}
       activeId="b3A6MTE0"
       tableOfContents={data}
       Link={({ children, ...props }) => {
@@ -39,16 +48,21 @@ export default {
     projectId: { table: { category: 'Input' } },
     branchSlug: { table: { category: 'Input' } },
     platformUrl: { table: { category: 'Input' } },
+    isInResponsiveMode: { table: { category: 'Input' } },
   },
   args: {
     projectId: 'cHJqOjYwNjYx',
     branchSlug: '',
     platformUrl: 'https://stoplight.io',
+    isInResponsiveMode: false,
   },
 };
 
-export const Playground: Story<{ nodeSlug: string; projectId: string; branchSlug?: string }> = args => (
-  <TableOfContentsWrapper {...args} />
-);
+export const Playground: Story<{
+  nodeSlug: string;
+  projectId: string;
+  branchSlug?: string;
+  isInResponsiveMode?: boolean;
+}> = args => <TableOfContentsWrapper {...args} />;
 
 Playground.storyName = 'Studio Demo';

--- a/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
@@ -42,7 +42,7 @@ export const TableOfContents = ({
         />
       </Flex>
 
-      {tableOfContents.hide_powered_by || isInResponsiveMode ? null : (
+      {tableOfContents.hide_powered_by ? null : (
         <PoweredByLink
           source={activeId}
           pathname={typeof window !== 'undefined' ? window.location.pathname : ''}

--- a/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
+++ b/packages/elements-dev-portal/src/components/TableOfContents/TableOfContents.tsx
@@ -14,6 +14,7 @@ export type TableOfContentsProps = BoxProps<'div'> & {
   Link: CustomLinkComponent;
   collapseTableOfContents?: boolean;
   externalScrollbar?: boolean;
+  isInResponsiveMode?: boolean;
   onLinkClick?(): void;
 };
 
@@ -23,11 +24,12 @@ export const TableOfContents = ({
   Link,
   collapseTableOfContents = false,
   externalScrollbar,
+  isInResponsiveMode = false,
   onLinkClick,
   ...boxProps
 }: TableOfContentsProps) => {
   return (
-    <Flex bg="canvas-100" {...boxProps} flexDirection="col" maxH="full">
+    <Flex bg={isInResponsiveMode ? 'canvas' : 'canvas-100'} {...boxProps} flexDirection="col" maxH="full">
       <Flex flexGrow flexShrink overflowY="auto">
         <ElementsTableOfContents
           tree={tableOfContents.items}
@@ -36,10 +38,11 @@ export const TableOfContents = ({
           maxDepthOpenByDefault={collapseTableOfContents ? 0 : 1}
           externalScrollbar={externalScrollbar}
           onLinkClick={onLinkClick}
+          isInResponsiveMode={isInResponsiveMode}
         />
       </Flex>
 
-      {tableOfContents.hide_powered_by ? null : (
+      {tableOfContents.hide_powered_by || isInResponsiveMode ? null : (
         <PoweredByLink
           source={activeId}
           pathname={typeof window !== 'undefined' ? window.location.pathname : ''}

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.11.0",
+  "version": "7.12.0",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.11.0",
+    "@stoplight/elements-core": "~7.12.0",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",


### PR DESCRIPTION
# Elements Default PR Template

I went ahead and made this a minor version change since it's not a bug fix, but if it should be versioned differently, please let me know!

As you will see, the icons are not the [desired](https://www.figma.com/file/BZZk7EIPmOEzKfn4TE5psF/Docs-Enhancements-2023?type=design&node-id=928-8593&mode=design&t=u4NLUp6ntgJI2C1N-0) 'far' [prefix](https://fontawesome.com/docs/web/add-icons/how-to#classic-family), and I don't know the best way to make this work with the way elements is configured. If this is a blocker, I do need some help figuring it out. 

@noor-ahmad tagging you here and adding you as a reviewer to give your thoughts on the icon issue. 

This PR changes the style of the project ToC in the following ways: 
- Icons are all on the left side of the items on screens of all sizes
- When `isInResponsiveMode` is passed through to the ToC component
      - background is lightened
      - items get larger
      - font gets larger

To interact with the changes, check out the "Embedded Search" story inside the "Search" story as well as the "TableOfContents" story in elements-dev-portal .

![2023-09-05 15 59 32](https://github.com/stoplightio/elements/assets/47359669/d1a8bf2e-f353-4a8e-8373-fe4e4ca71274)


![2023-09-05 15 33 31](https://github.com/stoplightio/elements/assets/47359669/f1768bc0-2733-4a3c-a667-84f36121a6c5)



In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
