### PR TITLE
fix: update responsive components to be test friendly

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.12.1",
+  "version": "7.12.2",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
@@ -81,6 +81,7 @@ export const Responses = ({
   const compactResponses = (
     <>
       <Button
+        aria-label="response-codes"
         onPress={open}
         iconRight={<Icon icon="chevron-down" color="var(--color-border-button)" />}
         style={{
@@ -113,7 +114,7 @@ export const Responses = ({
         >
           {(response: IHttpOperationResponse) => (
             <ListBoxItem key={response.id}>
-              <Box p={3} bg={{ hover: 'primary-tint' }}>
+              <Box data-test={response.code} p={3} bg={{ hover: 'primary-tint' }}>
                 <Flex w="2xl" align="center" justify="end">
                   {response.code === activeResponseId && <Box as={Icon} icon="check" />}
                   <Text ml={3} fontWeight="medium">

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.12.0",
+    "@stoplight/elements-core": "~7.12.2",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '1.13.0';
+export const appVersion = '1.15.1';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.12.1",
+  "version": "7.12.2",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.12.1",
+    "@stoplight/elements-core": "~7.12.2",
     "@stoplight/http-spec": "^5.1.4",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",


### PR DESCRIPTION
# Elements Default PR Template
Updated response code components on workspace docs page with attributes to make them easy to find for testing

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
