### PR TITLE
chore: consistent dropdown

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.13.2",
+  "version": "7.13.3",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
@@ -87,6 +87,7 @@ export const Responses = ({
         style={{
           color: `var(--color-${codeToIntentVal(activeResponseId)})`,
         }}
+        appearance="minimal"
       >
         {activeResponseId}
       </Button>
@@ -141,7 +142,9 @@ export const Responses = ({
 
   return (
     <VStack spacing={8} as={Tabs} selectedId={activeResponseId} onChange={setActiveResponseId} appearance="pill">
-      <SectionTitle title="Responses">{isCompact ? compactResponses : tabResponses}</SectionTitle>
+      <SectionTitle title="Responses" isCompact={isCompact}>
+        {isCompact ? compactResponses : tabResponses}
+      </SectionTitle>
 
       {isCompact ? (
         <Response response={response} onMediaTypeChange={onMediaTypeChange} />

--- a/packages/elements-core/src/components/Docs/Sections.tsx
+++ b/packages/elements-core/src/components/Docs/Sections.tsx
@@ -8,17 +8,18 @@ export interface ISectionTitle {
   title: string;
   id?: string;
   size?: HeadingProps['size'];
+  isCompact?: boolean;
 }
 
-export const SectionTitle: React.FC<ISectionTitle> = ({ title, id, size = 2, children }) => {
+export const SectionTitle: React.FC<ISectionTitle> = ({ title, id, size = 2, isCompact = false, children }) => {
   return (
     <Flex w="full">
       <Box py={1} pr={6} as={LinkHeading} size={size} aria-label={title} id={id || slugify(title)}>
         {title}
       </Box>
-      <Box alignSelf={'center'} py={1} flexGrow style={{ minWidth: 0 }}>
+      <Flex alignSelf={'center'} py={1} flexGrow style={{ minWidth: 0 }} justify={isCompact ? 'end' : undefined}>
         {children}
-      </Box>
+      </Flex>
     </Flex>
   );
 };

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.13.2",
+    "@stoplight/elements-core": "~7.13.3",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.13.2",
+  "version": "7.13.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.13.2",
+    "@stoplight/elements-core": "~7.13.3",
     "@stoplight/http-spec": "^6.0.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",


### PR DESCRIPTION
# Elements Default PR Template
Addresses #[18159](https://app.zenhub.com/workspaces/-team-enchilotters-62ab7d6627416c001df37493/issues/gh/stoplightio/platform-internal/18159)

<img width="426" alt="Screenshot 2023-09-28 at 3 48 20 PM" src="https://github.com/stoplightio/elements/assets/47359669/5ca797e7-1b8c-45d5-b7cc-853f578ec3b7">

<img width="881" alt="Screenshot 2023-09-28 at 3 48 29 PM" src="https://github.com/stoplightio/elements/assets/47359669/ab72d9ff-8d67-48a5-ac77-c4e8396d98a0">



In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
