### PR TITLE
Fix/responsive/alignment

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@stoplight/elements": "^7.10.0",
-    "@stoplight/mosaic": "^1.33.0",
+    "@stoplight/mosaic": "^1.44.1",
     "history": "^5.0.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -63,7 +63,7 @@
     "@stoplight/json-schema-sampler": "0.2.3",
     "@stoplight/json-schema-viewer": "^4.12.0",
     "@stoplight/markdown-viewer": "^5.6.0",
-    "@stoplight/mosaic": "^1.33.0",
+    "@stoplight/mosaic": "^1.44.1",
     "@stoplight/mosaic-code-editor": "^1.33.0",
     "@stoplight/mosaic-code-viewer": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-core/src/components/Docs/HttpOperation/Body.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Body.tsx
@@ -48,7 +48,7 @@ export const Body = ({ body, onChange }: BodyProps) => {
             <Select
               aria-label="Request Body Content Type"
               value={String(chosenContent)}
-              onChange={(value: string | number) => setChosenContent(parseInt(String(value), 10))}
+              onChange={value => setChosenContent(parseInt(String(value), 10))}
               options={contents.map((content, index) => ({ label: content.mediaType, value: index }))}
               size="sm"
             />

--- a/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
@@ -198,7 +198,7 @@ const Response = ({ response, onMediaTypeChange }: ResponseProps) => {
               <Select
                 aria-label="Response Body Content Type"
                 value={String(chosenContent)}
-                onChange={(value: string | number) => setChosenContent(parseInt(String(value), 10))}
+                onChange={value => setChosenContent(parseInt(String(value), 10))}
                 options={contents.map((content, index) => ({ label: content.mediaType, value: index }))}
                 size="sm"
               />

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -118,7 +118,7 @@ const ModelExamples = React.memo(({ data, isCollapsible = false }: { data: JSONS
       aria-label="Example"
       value={String(chosenExampleIndex)}
       options={examples.map(({ label }, index) => ({ value: index, label }))}
-      onChange={(value: string | number) => setChosenExampleIndex(parseInt(String(value), 10))}
+      onChange={value => setChosenExampleIndex(parseInt(String(value), 10))}
       size="sm"
       triggerTextPrefix="Example: "
     />

--- a/packages/elements-core/src/components/Docs/Sections.tsx
+++ b/packages/elements-core/src/components/Docs/Sections.tsx
@@ -16,9 +16,9 @@ export const SectionTitle: React.FC<ISectionTitle> = ({ title, id, size = 2, chi
       <Box py={1} pr={6} as={LinkHeading} size={size} aria-label={title} id={id || slugify(title)}>
         {title}
       </Box>
-      <Box alignSelf={'center'} py={1} flexGrow style={{ minWidth: 0 }}>
+      <Flex flexDirection={'col'} alignItems={'flex-end'} alignSelf={'center'} py={1} flexGrow style={{ minWidth: 0 }}>
         {children}
-      </Box>
+      </Flex>
     </Flex>
   );
 };

--- a/packages/elements-core/src/components/Docs/Sections.tsx
+++ b/packages/elements-core/src/components/Docs/Sections.tsx
@@ -16,7 +16,7 @@ export const SectionTitle: React.FC<ISectionTitle> = ({ title, id, size = 2, chi
       <Box py={1} pr={6} as={LinkHeading} size={size} aria-label={title} id={id || slugify(title)}>
         {title}
       </Box>
-      <Flex flexDirection={'col'} alignItems={'flex-end'} alignSelf={'center'} py={1} flexGrow style={{ minWidth: 0 }}>
+      <Flex flexDirection={'col'} alignItems={'end'} alignSelf={'center'} py={1} flexGrow style={{ minWidth: 0 }}>
         {children}
       </Flex>
     </Flex>

--- a/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
+++ b/packages/elements-core/src/components/ResponseExamples/ResponseExamples.tsx
@@ -42,7 +42,7 @@ export const ResponseExamples = ({ httpOperation, responseMediaType, responseSta
       aria-label="Response Example"
       value={String(chosenExampleIndex)}
       options={userDefinedExamples.map((example, index) => ({ value: index, label: example.key }))}
-      onChange={(value: string | number) => setChosenExampleIndex(parseInt(String(value), 10))}
+      onChange={value => setChosenExampleIndex(parseInt(String(value), 10))}
       size="sm"
       triggerTextPrefix="Response Example: "
     />

--- a/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
+++ b/packages/elements-core/src/components/TryIt/Body/FormDataBody.tsx
@@ -66,9 +66,7 @@ export const FormDataBody: React.FC<FormDataBodyProps> = ({
               key={parameter.name}
               parameter={parameter}
               value={typeof value === 'string' ? value : undefined}
-              onChange={(value: string | number) =>
-                onChangeValues({ ...values, [parameter.name]: typeof value === 'number' ? String(value) : value })
-              }
+              onChange={value => onChangeValues({ ...values, [parameter.name]: String(value) })}
               onChangeOptional={value => onChangeParameterAllow({ ...isAllowedEmptyValues, [parameter.name]: value })}
               canChangeOptional={true}
               isOptional={isAllowedEmptyValues[parameter.name] ?? false}

--- a/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/OperationParameters.tsx
@@ -26,7 +26,7 @@ export const OperationParameters: React.FC<OperationParametersProps> = ({
             key={parameter.name}
             parameter={parameter}
             value={values[parameter.name]}
-            onChange={(value: string | number) => onChangeValue(parameter.name, String(value))}
+            onChange={value => onChangeValue(parameter.name, String(value))}
             validate={validate}
             isOptional={false}
             canChangeOptional={false}

--- a/packages/elements-core/src/components/TryIt/Servers/ServerVariables.tsx
+++ b/packages/elements-core/src/components/TryIt/Servers/ServerVariables.tsx
@@ -21,7 +21,7 @@ export const ServerVariables: React.FC<ServerVariablesProps> = ({ variables, val
             data-test="server-vars-try-it-row"
             variable={variable}
             value={values[variable.name]}
-            onChange={(value: string | number) => {
+            onChange={value => {
               const actualValue = String(value);
               onChangeValue(variable.enum || actualValue !== '' ? 'set' : 'unset', variable.name, actualValue);
             }}

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/elements-core": "~7.13.2",
     "@stoplight/markdown-viewer": "^5.5.0",
-    "@stoplight/mosaic": "^1.33.0",
+    "@stoplight/mosaic": "^1.44.1",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -65,7 +65,7 @@
     "@stoplight/elements-core": "~7.13.2",
     "@stoplight/http-spec": "^6.0.0",
     "@stoplight/json": "^3.18.1",
-    "@stoplight/mosaic": "^1.33.0",
+    "@stoplight/mosaic": "^1.44.1",
     "@stoplight/types": "^14.0.0",
     "@stoplight/yaml": "^4.2.3",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3661,10 +3661,40 @@
     use-resize-observer "^9.0.2"
     zustand "^3.5.2"
 
-"@stoplight/mosaic@1.33.0", "@stoplight/mosaic@^1.33.0":
+"@stoplight/mosaic@1.33.0":
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/@stoplight/mosaic/-/mosaic-1.33.0.tgz#02d5d8a80b277f891dd4f1db7f86c22838c899e8"
   integrity sha512-3WYywCTOAFawosnmNb1W+jJwypH/lcwW66S7Y2gle/U9aBysrCZaUsldsXvJjfak0862rKy4HdOpeSAyLxeZZw==
+  dependencies:
+    "@fortawesome/fontawesome-svg-core" "^6.1.1"
+    "@fortawesome/react-fontawesome" "^0.2.0"
+    "@react-hook/size" "^2.1.1"
+    "@react-hook/window-size" "^3.0.7"
+    "@react-types/button" "3.4.1"
+    "@react-types/radio" "3.1.2"
+    "@react-types/shared" "3.9.0"
+    "@react-types/switch" "3.1.2"
+    "@react-types/textfield" "3.3.0"
+    "@stoplight/types" "^13.7.0"
+    "@types/react" "^17.0.3"
+    "@types/react-dom" "^17.0.3"
+    clsx "^1.1.1"
+    copy-to-clipboard "^3.3.1"
+    dom-helpers "^3.3.1"
+    lodash.get "^4.4.2"
+    nano-memoize "^1.2.1"
+    polished "^4.1.3"
+    react-fast-compare "^3.2.0"
+    react-overflow-list "^0.5.0"
+    ts-keycode-enum "^1.0.6"
+    tslib "^2.1.0"
+    use-resize-observer "^9.0.2"
+    zustand "^3.5.2"
+
+"@stoplight/mosaic@^1.44.1":
+  version "1.44.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/mosaic/-/mosaic-1.44.1.tgz#b7e31a175ae59ce1fb33f414ca3864606d07433d"
+  integrity sha512-3Tg1HgAlNkyEJYZ+88lPrTTAm8hBp5sSZH4tnQyTVnxnKClpDNt/83T/6esM+gA6rtiH4wPcC68IAeyxYWsliQ==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/react-fontawesome" "^0.2.0"


### PR DESCRIPTION
Addresses [18160](https://app.zenhub.com/workspaces/-team-enchilotters-62ab7d6627416c001df37493/issues/gh/stoplightio/platform-internal/18160) Aligns the doc's response code dropdown/tab selector to the right of the section. 

<br />

**Compact view / Dropdown**
<img width="394" alt="Screenshot 2023-09-29 at 9 26 19 AM" src="https://github.com/stoplightio/elements/assets/2607104/317c9bf5-14c0-4cb7-b8c0-00dd373bc509">

<br />
<br />
<br />


**Standard View / Tabs**
<img width="591" alt="Screenshot 2023-09-29 at 9 27 17 AM" src="https://github.com/stoplightio/elements/assets/2607104/940d54a7-6b4f-4c18-a580-e96d07091baa">
