### PR TITLE
fix: mobile export button

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.13.4",
+  "version": "7.13.5",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",
@@ -61,7 +61,7 @@
     "@stoplight/json": "^3.18.1",
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.3",
-    "@stoplight/json-schema-viewer": "^4.12.0",
+    "@stoplight/json-schema-viewer": "^4.12.1",
     "@stoplight/markdown-viewer": "^5.6.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/mosaic-code-editor": "^1.33.0",

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.stories.ts
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.stories.ts
@@ -6,4 +6,4 @@ const { meta, createHoistedStory } = createStoriesForDocsComponent(HttpService, 
 
 export default meta;
 
-export const Story = createHoistedStory({ data: httpService });
+export const Story = createHoistedStory({ data: httpService, layoutOptions: { compact: 600 } });

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { MockingContext } from '../../../containers/MockingProvider';
 import { useResolvedObject } from '../../../context/InlineRefResolver';
 import { useOptionsCtx } from '../../../context/Options';
+import { useIsCompact } from '../../../hooks/useIsCompact';
 import { MarkdownViewer } from '../../MarkdownViewer';
 import { PoweredByLink } from '../../PoweredByLink';
 import { DocsComponentProps } from '..';
@@ -21,6 +22,7 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(
   ({ data: unresolvedData, location = {}, layoutOptions, exportProps }) => {
     const { nodeHasChanged } = useOptionsCtx();
     const data = useResolvedObject(unresolvedData) as IHttpService;
+    const { ref: layoutRef, isCompact } = useIsCompact(layoutOptions);
 
     const { search, pathname } = location;
     const mocking = React.useContext(MockingContext);
@@ -31,7 +33,7 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(
     const descriptionChanged = nodeHasChanged?.({ nodeId: data.id, attr: 'description' });
 
     return (
-      <Box mb={10}>
+      <Box ref={layoutRef} mb={10}>
         {data.name && !layoutOptions?.noHeading && (
           <Flex justifyContent="between" alignItems="center">
             <Box pos="relative">
@@ -41,7 +43,7 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(
               <NodeAnnotation change={nameChanged} />
             </Box>
 
-            {exportProps && !layoutOptions?.hideExport && <ExportButton {...exportProps} />}
+            {exportProps && !layoutOptions?.hideExport && !isCompact && <ExportButton {...exportProps} />}
           </Flex>
         )}
 

--- a/packages/elements-core/src/components/Docs/Model/Model.stories.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.stories.tsx
@@ -8,4 +8,4 @@ const { meta, createHoistedStory } = createStoriesForDocsComponent(Model);
 
 export default meta;
 
-export const Story = createHoistedStory({ data: model as JSONSchema7 });
+export const Story = createHoistedStory({ data: model as JSONSchema7, layoutOptions: { compact: 600 } });

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -61,7 +61,7 @@ const ModelComponent: React.FC<ModelProps> = ({
         <NodeAnnotation change={titleChanged} />
       </Box>
 
-      {exportProps && !layoutOptions?.hideExport && <ExportButton {...exportProps} />}
+      {exportProps && !layoutOptions?.hideExport && !isCompact && <ExportButton {...exportProps} />}
     </Flex>
   );
 

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.13.4",
+    "@stoplight/elements-core": "~7.13.5",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.33.0",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.13.4",
+  "version": "7.13.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.13.4",
+    "@stoplight/elements-core": "~7.13.5",
     "@stoplight/http-spec": "^6.0.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3529,10 +3529,10 @@
     "@types/json-schema" "^7.0.7"
     magic-error "0.0.1"
 
-"@stoplight/json-schema-viewer@^4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.12.0.tgz#ab578b75b07d524d06f48b22ce4db1153b3cc104"
-  integrity sha512-RS2Z6Jpx0ffweKQhoS7GTJggfKc4w4vtbmkBwNSD036OW6zDrLR6FfD8BjfWPNyOymGU/yhdESbl4FrxnDqIZw==
+"@stoplight/json-schema-viewer@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.12.1.tgz#dc28bde019b24876db003881e41dc505c2af024c"
+  integrity sha512-oMx0WrggjDPbIUcoqO7gx8dx1QA9bs7Y2jYNGAWnDe1wmsGcOOevkJ5LaruoCbuYAvsoGsBfqyJv8Ec8ATHBGQ==
   dependencies:
     "@stoplight/json" "^3.20.1"
     "@stoplight/json-schema-tree" "^2.2.5"


### PR DESCRIPTION
Hides the export button for a compact layout in http service and modal components.


https://github.com/stoplightio/elements/assets/14196079/aadbcc68-3a2f-41be-bec3-1da42e50e80a

