### PR TITLE
fix: server info long url

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
@@ -33,7 +33,7 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(
     const descriptionChanged = nodeHasChanged?.({ nodeId: data.id, attr: 'description' });
 
     return (
-      <Box ref={layoutRef} mb={10}>
+      <Box ref={layoutRef} mb={10} className="HttpService">
         {data.name && !layoutOptions?.noHeading && (
           <Flex justifyContent="between" alignItems="center">
             <Box pos="relative">

--- a/packages/elements-core/src/components/Docs/HttpService/ServerInfo.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/ServerInfo.tsx
@@ -76,7 +76,13 @@ const ServerUrl: React.FC<IServer & { hasAnyServerVariables: boolean; defaultIsO
   );
 
   return (
-    <Panel isCollapsible={!!variablesSchema} defaultIsOpen={defaultIsOpen} w="full" data-test="server-row">
+    <Panel
+      isCollapsible={!!variablesSchema}
+      defaultIsOpen={defaultIsOpen}
+      w="full"
+      className="ServerInfo"
+      data-test="server-row"
+    >
       <Panel.Titlebar whitespace="nowrap">
         <Text pl={titlePaddingLeft} pr={2} fontWeight="bold">
           {description}:
@@ -85,7 +91,7 @@ const ServerUrl: React.FC<IServer & { hasAnyServerVariables: boolean; defaultIsO
         <Tooltip
           placement="right"
           renderTrigger={() => (
-            <Text aria-label={description} whitespace="normal" style={{ wordBreak: 'break-word' }}>
+            <Text aria-label={description} whitespace="normal" py={2} style={{ wordBreak: 'break-word' }}>
               {urlFragments.map(({ kind, value }, i) => (
                 <Text key={i} fontWeight={kind === 'variable' ? 'semibold' : 'normal'}>
                   {value}

--- a/packages/elements-core/src/core.css
+++ b/packages/elements-core/src/core.css
@@ -90,3 +90,8 @@
   /* Enables horizontal scrolling for response tabs */
   overflow-x: auto;
 }
+
+.sl-elements .HttpService .ServerInfo .sl-panel__titlebar div {
+  height: 100%;
+  min-height: 36px;
+}


### PR DESCRIPTION
Addresses: https://github.com/stoplightio/platform-internal/issues/18263

Fixes `ServerInfo` component to handle longer urls.

Before:
<img width="350" alt="Screenshot 2023-10-09 at 14 22 56" src="https://github.com/stoplightio/elements/assets/14196079/81f669a8-4712-4d26-a78a-20592b559a77">

After:
<img width="346" alt="Screenshot 2023-10-09 at 14 23 09" src="https://github.com/stoplightio/elements/assets/14196079/84543228-34f9-4830-ad13-c90cb6e6190d">

