### PR TITLE
Fix: stoplight project branch bug

### DIFF
--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.16.6",
+  "version": "1.16.7",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -82,8 +82,8 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
   tryItCredentialsPolicy,
   tryItCorsProxy,
 }) => {
-  let { branchSlug = '', nodeSlug = '' } = useParams<{ branchSlug?: string; nodeSlug: string }>();
-  branchSlug = decodeURIComponent(branchSlug);
+  const { branchSlug: encodedBranchSlug = '', nodeSlug = '' } = useParams<{ branchSlug?: string; nodeSlug: string }>();
+  const branchSlug = decodeURIComponent(encodedBranchSlug);
   const history = useHistory();
 
   const { data: tableOfContents, isFetched: isTocFetched } = useGetTableOfContents({ projectId, branchSlug });
@@ -156,11 +156,10 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
             <BranchSelector
               branchSlug={branchSlug}
               branches={branches}
-              onChange={branch =>
-                history.push(
-                  branch.is_default ? `/${nodeSlug}` : `/branches/${encodeURIComponent(branch.slug)}/${nodeSlug}`,
-                )
-              }
+              onChange={branch => {
+                const encodedBranchSlug = encodeURIComponent(branch.slug);
+                history.push(branch.is_default ? `/${nodeSlug}` : `/branches/${encodedBranchSlug}/${nodeSlug}`);
+              }}
             />
           ) : null}
           {tableOfContents ? (

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -82,7 +82,8 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
   tryItCredentialsPolicy,
   tryItCorsProxy,
 }) => {
-  const { branchSlug = '', nodeSlug = '' } = useParams<{ branchSlug?: string; nodeSlug: string }>();
+  let { branchSlug = '', nodeSlug = '' } = useParams<{ branchSlug?: string; nodeSlug: string }>();
+  branchSlug = decodeURIComponent(branchSlug);
   const history = useHistory();
 
   const { data: tableOfContents, isFetched: isTocFetched } = useGetTableOfContents({ projectId, branchSlug });
@@ -156,7 +157,9 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
               branchSlug={branchSlug}
               branches={branches}
               onChange={branch =>
-                history.push(branch.is_default ? `/${nodeSlug}` : `/branches/${branch.slug}/${nodeSlug}`)
+                history.push(
+                  branch.is_default ? `/${nodeSlug}` : `/branches/${encodeURIComponent(branch.slug)}/${nodeSlug}`,
+                )
               }
             />
           ) : null}


### PR DESCRIPTION
# Elements Default PR Template
Reproducing bug (if you go to a branch that is NOT the default branch and has a '/' in it stoplight project will break):

https://github.com/stoplightio/elements/assets/58235624/77464eaa-b14b-4e17-810b-47a65baaf216


After fix:

https://github.com/stoplightio/elements/assets/58235624/c887087d-ba11-47ae-b23b-d41cfd55615f



In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
