### PR TITLE
Fix: stacked layout path

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.13.9",
+  "version": "7.13.10",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements/src/components/API/APIWithStackedLayout.tsx
+++ b/packages/elements/src/components/API/APIWithStackedLayout.tsx
@@ -171,12 +171,15 @@ const Item = React.memo<{ item: OperationNode }>(({ item }) => {
         </Box>
 
         <Box flex={1} fontWeight="medium" wordBreak="all">
-          {item.name}
+          {item.uri}
         </Box>
         {isDeprecated && <DeprecatedBadge />}
       </Flex>
 
       <Collapse isOpen={isExpanded}>
+        <Box flex={1} p={2} fontWeight="medium" mx="auto" fontSize="xl">
+          {item.name}
+        </Box>
         {hideTryIt ? (
           <Box as={ParsedDocs} layoutOptions={{ noHeading: true, hideTryItPanel: true }} node={item} p={4} />
         ) : (

--- a/packages/elements/src/components/API/APIWithStackedLayout.tsx
+++ b/packages/elements/src/components/API/APIWithStackedLayout.tsx
@@ -171,7 +171,7 @@ const Item = React.memo<{ item: OperationNode }>(({ item }) => {
         </Box>
 
         <Box flex={1} fontWeight="medium" wordBreak="all">
-          {item.uri}
+          {item.data.path}
         </Box>
         {isDeprecated && <DeprecatedBadge />}
       </Flex>

--- a/packages/elements/src/containers/API.spec.tsx
+++ b/packages/elements/src/containers/API.spec.tsx
@@ -6,7 +6,8 @@ import {
   withQueryClientProvider,
   withStyles,
 } from '@stoplight/elements-core';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
 import { flow } from 'lodash';
 import * as React from 'react';
@@ -127,5 +128,30 @@ describe('API', () => {
 
     expect(screen.queryByText('Cool object, but internal.')).not.toBeInTheDocument();
     expect(history.location.pathname).toBe('/');
+  });
+
+  describe('stackedLayout', () => {
+    it('shows operation path and method when collapsed', async () => {
+      render(<API logo="thisisarequiredprop" layout="stacked" apiDescriptionDocument={APIDocument} />);
+
+      const users = await screen.findByText('users');
+      act(() => userEvent.click(users));
+
+      expect(screen.queryByText('/users/{user-id}')).toBeInTheDocument();
+    });
+
+    it('shows operation name when expanded', async () => {
+      render(<API logo="thisisarequiredprop" layout="stacked" apiDescriptionDocument={APIDocument} />);
+
+      const users = await screen.findByText('users');
+      act(() => userEvent.click(users));
+
+      const usersPath = await screen.findByText('/users/{user-id}');
+      act(() => userEvent.click(usersPath));
+
+      const usersSummary = await screen.findByText('Get basic information about a user.');
+
+      expect(usersSummary).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
# Elements Default PR Template
Addresses https://github.com/stoplightio/elements/issues/2415

![image](https://github.com/stoplightio/elements/assets/58235624/2c7cc009-6895-4ce0-963c-609fc4871bf6)

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
