### PR TITLE
feat: export oas utils

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.13.10",
+  "version": "7.13.11",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements/src/index.ts
+++ b/packages/elements/src/index.ts
@@ -1,2 +1,4 @@
 export type { APIProps } from './containers/API';
 export { API } from './containers/API';
+export { useExportDocumentProps } from './hooks/useExportDocumentProps';
+export { transformOasToServiceNode } from './utils/oas';


### PR DESCRIPTION
Exports `transformOasToServiceNode` and `useExportDocumentProps` functions to let users transform oas documents and use internal elements components independently (SwaggerHub Portal use case).