### PR TITLE
chore: export stacked layout

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.15.0",
+  "version": "7.15.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements/src/components/API/APIWithStackedLayout.tsx
+++ b/packages/elements/src/components/API/APIWithStackedLayout.tsx
@@ -24,6 +24,7 @@ type StackedLayoutProps = {
   exportProps?: ExportButtonProps;
   tryItCredentialsPolicy?: TryItCredentialsPolicy;
   tryItCorsProxy?: string;
+  showPoweredByLink?: boolean;
 };
 
 const itemMatchesHash = (hash: string, item: OperationNode) => {
@@ -47,6 +48,7 @@ export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({
   exportProps,
   tryItCredentialsPolicy,
   tryItCorsProxy,
+  showPoweredByLink = true,
 }) => {
   const location = useLocation();
   const { groups } = computeTagGroups(serviceNode);
@@ -61,7 +63,7 @@ export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({
             nodeTitle={serviceNode.name}
             nodeType={NodeType.HttpService}
             location={location}
-            layoutOptions={{ showPoweredByLink: true, hideExport }}
+            layoutOptions={{ showPoweredByLink, hideExport }}
             exportProps={exportProps}
             tryItCredentialsPolicy={tryItCredentialsPolicy}
           />

--- a/packages/elements/src/index.ts
+++ b/packages/elements/src/index.ts
@@ -1,3 +1,4 @@
+export { APIWithStackedLayout } from './components/API/APIWithStackedLayout';
 export type { APIProps } from './containers/API';
 export { API } from './containers/API';
 export { useExportDocumentProps } from './hooks/useExportDocumentProps';


### PR DESCRIPTION
Context: https://smartbear.slack.com/archives/C05T7G43M0B/p1700213734193029

Adds export of `APIWithStackedLayout` component to `elements` package.
Adds `showPoweredByLink` property to `APIWithStackedLayout`