### PR TITLE
fix: unspecified field is undefined

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/Parameters.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Parameters.tsx
@@ -86,7 +86,12 @@ const httpOperationParamsToSchema = ({ parameters, parameterType }: ParametersPr
     const paramDescription = description || paramSchema.description;
 
     const paramDeprecated = !!(deprecated || paramSchema.deprecated);
-    const paramStyle = style && defaultStyle[parameterType] !== style ? readableStyles[style] || style : undefined;
+    const paramStyleUnspecified = style === HttpParamStyles.Unspecified;
+    const paramStyle = paramStyleUnspecified
+      ? undefined
+      : style && defaultStyle[parameterType] !== style
+      ? readableStyles[style] || style
+      : undefined;
 
     if (isPlainObject(schema.properties)) {
       schema.properties![p.name] = {


### PR DESCRIPTION
To avoid confusion for published OAS 2.0 docs, we want to hide the query parameter Style field if it is `unspecified`.