### PR TITLE
fix(tryit): stop re-render of try-it

### DIFF
--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -129,7 +129,7 @@ export const TryIt: React.FC<TryItProps> = ({
     const exists = currentUrl && servers.find(s => s.url === currentUrl);
     if (!exists) {
       setChosenServer(firstServer);
-    } else if (exists !== chosenServer) {
+    } else if (exists.id !== chosenServer.id) {
       setChosenServer(exists);
     }
   }, [servers, firstServer, chosenServer, setChosenServer]);


### PR DESCRIPTION
fixes #2467. multiple copies of the server list caused this to render out of control. the server id should allow us to keep it in sync