### PR TITLE
fix: empty callbacks

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -85,7 +85,7 @@ const HttpOperationComponent = React.memo<HttpOperationProps>(
           />
         )}
 
-        {data.callbacks?.length && <Callbacks callbacks={data.callbacks} isCompact={isCompact} />}
+        {data.callbacks?.length ? <Callbacks callbacks={data.callbacks} isCompact={isCompact} /> : null}
 
         {isCompact && tryItPanel}
       </VStack>


### PR DESCRIPTION
Fixes HttpOperation doc with empty callbacks array. Removes 0 from the callback section of the doc.

![image](https://github.com/stoplightio/elements/assets/14196079/92bc2503-50aa-49cc-ae07-fa72e8c1eb5f)
