### PR TITLE
fix(dev-portal): fix broken hash router links

### DIFF
--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -192,11 +192,11 @@ const StoplightProjectRouter = ({
     <DevPortalProvider platformUrl={platformUrl}>
       <RouterTypeContext.Provider value={router}>
         <Router {...routerProps} key={basePath}>
-          <Route path="/branches/:branchSlug/:nodeSlug" exact>
+          <Route path="/branches/:branchSlug/:nodeSlug+" exact>
             <StoplightProjectImpl {...props} />
           </Route>
 
-          <Route path="/:nodeSlug" exact>
+          <Route path="/:nodeSlug+" exact>
             <StoplightProjectImpl {...props} />
           </Route>
 


### PR DESCRIPTION
when using elements-dev-portal and the hash router, a custom toc with slugs would result in a broken page. this fixes the route matching and makes the routes absolute