### PR TITLE
fix: array child pattern match validation

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "7.16.5",
+  "version": "7.16.6",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",
@@ -62,7 +62,7 @@
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.3",
     "@stoplight/json-schema-tree": "^3.0.0",
-    "@stoplight/json-schema-viewer": "^4.14.1",
+    "@stoplight/json-schema-viewer": "^4.14.2",
     "@stoplight/markdown-viewer": "^5.6.0",
     "@stoplight/mosaic": "^1.46.1",
     "@stoplight/mosaic-code-editor": "^1.46.1",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "1.19.5",
+  "version": "1.19.6",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.16.5",
+    "@stoplight/elements-core": "~7.16.6",
     "@stoplight/markdown-viewer": "^5.5.0",
     "@stoplight/mosaic": "^1.46.1",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "7.16.5",
+  "version": "7.16.6",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~7.16.5",
+    "@stoplight/elements-core": "~7.16.6",
     "@stoplight/http-spec": "^6.0.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.46.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4036,10 +4036,10 @@
     "@types/json-schema" "^7.0.7"
     magic-error "0.0.1"
 
-"@stoplight/json-schema-viewer@^4.14.1":
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.14.1.tgz#39472c8a11d39654457bef98bf9e9d1b5daeb55f"
-  integrity sha512-Igjdf4n5JaPRKVbPL+UKgw6hwwjskEwCDzi/ch47nNBFKFyX3TSshB5PfyJQZ72mpYZFbt1rF1Y0vtk24oFoew==
+"@stoplight/json-schema-viewer@^4.14.2":
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.14.2.tgz#81b7a8a4287be0ba05de310ba7482ece0e5153d6"
+  integrity sha512-qZl2qjR7w5wTjdoLrjgMKYtmQWPvSe/XVWM4jalmYq/c1C3nwO2b7uEH5TR/Wnqn1TmQBo3T4BaIbScC4L9Xhg==
   dependencies:
     "@stoplight/json" "^3.20.1"
     "@stoplight/json-schema-tree" "^3.0.0"


### PR DESCRIPTION
# Elements Default PR Template


Bumps json schema viewer. See https://github.com/stoplightio/json-schema-viewer/pull/248


Needed for  https://app.zenhub.com/workspaces/-team-honey-hackers-62ab7d6627416c001df37493/issues/gh/stoplightio/platform-internal/12705

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
