### PR TITLE
fix: branch selector

### DIFF
--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements-dev-portal/src/__fixtures__/branches.json
+++ b/packages/elements-dev-portal/src/__fixtures__/branches.json
@@ -1,26 +1,28 @@
-[
-  {
-    "id": "YnI6NDc4MDUy",
-    "name": null,
-    "slug": "master",
-    "is_default": true,
-    "is_published": true,
-    "project_id": "cHJqOjM1ODEw"
-  },
-  {
-    "id": "YnI6OTYwNDM4",
-    "name": null,
-    "slug": "v2",
-    "is_default": false,
-    "is_published": true,
-    "project_id": "cHJqOjM1ODEw"
-  },
-  {
-    "id": "YnI6OTYwNDM5",
-    "name": null,
-    "slug": "feat/toc-file",
-    "is_default": false,
-    "is_published": true,
-    "project_id": "cHJqOjM1ODEw"
-  }
-]
+{
+  "items": [
+    {
+      "id": "YnI6NDc4MDUy",
+      "name": null,
+      "slug": "master",
+      "is_default": true,
+      "is_published": true,
+      "project_id": "cHJqOjM1ODEw"
+    },
+    {
+      "id": "YnI6OTYwNDM4",
+      "name": null,
+      "slug": "v2",
+      "is_default": false,
+      "is_published": true,
+      "project_id": "cHJqOjM1ODEw"
+    },
+    {
+      "id": "YnI6OTYwNDM5",
+      "name": null,
+      "slug": "feat/toc-file",
+      "is_default": false,
+      "is_published": true,
+      "project_id": "cHJqOjM1ODEw"
+    }
+  ]
+}

--- a/packages/elements-dev-portal/src/components/BranchSelector/BranchSelector.spec.tsx
+++ b/packages/elements-dev-portal/src/components/BranchSelector/BranchSelector.spec.tsx
@@ -4,15 +4,15 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 
+import { Branch } from '../../types';
 import { BranchSelector } from './BranchSelector';
 
-export const branches = [
+export const branches: Branch[] = [
   {
     id: 0,
     slug: 'main',
     is_default: true,
     is_published: false,
-    projectId: 123,
     name: 'main-name',
   },
   {
@@ -20,14 +20,12 @@ export const branches = [
     slug: 'beta',
     is_default: false,
     is_published: false,
-    projectId: 123,
   },
   {
     id: 2,
     slug: 'feature-branch',
     is_default: false,
     is_published: false,
-    projectId: 123,
   },
 ];
 

--- a/packages/elements-dev-portal/src/components/BranchSelector/BranchSelector.stories.tsx
+++ b/packages/elements-dev-portal/src/components/BranchSelector/BranchSelector.stories.tsx
@@ -13,7 +13,7 @@ const BranchSelectorWrapper = ({ projectId }: { projectId: string }) => {
   if (data) {
     return (
       <Box mt={10} w={40}>
-        <BranchSelector branchSlug={branchSlug} branches={data} onChange={branch => setBranchSlug(branch.slug)} />
+        <BranchSelector branchSlug={branchSlug} branches={data.items} onChange={branch => setBranchSlug(branch.slug)} />
       </Box>
     );
   }

--- a/packages/elements-dev-portal/src/containers/StoplightProject.tsx
+++ b/packages/elements-dev-portal/src/containers/StoplightProject.tsx
@@ -11,7 +11,7 @@ import {
 } from '@stoplight/elements-core';
 import { Box, Button, Icon, useModalState } from '@stoplight/mosaic';
 import * as React from 'react';
-import { Link, Redirect, Route, useHistory, useParams } from 'react-router-dom';
+import { Link, Redirect, Route, Switch, useHistory, useParams } from 'react-router-dom';
 
 import { BranchSelector } from '../components/BranchSelector';
 import { DevPortalProvider } from '../components/DevPortalProvider';
@@ -198,10 +198,10 @@ const StoplightProjectImpl: React.FC<StoplightProjectProps> = ({
       ref={container}
       sidebar={
         <>
-          {branches && branches.length > 1 ? (
+          {branches && branches.items.length > 1 ? (
             <BranchSelector
               branchSlug={branchSlug}
-              branches={branches}
+              branches={branches.items}
               onChange={branch => {
                 const encodedBranchSlug = encodeURIComponent(branch.slug);
                 history.push(branch.is_default ? `/${nodeSlug}` : `/branches/${encodedBranchSlug}/${nodeSlug}`);
@@ -238,17 +238,19 @@ const StoplightProjectRouter = ({
     <DevPortalProvider platformUrl={platformUrl}>
       <RouterTypeContext.Provider value={router}>
         <Router {...routerProps} key={basePath}>
-          <Route path="/branches/:branchSlug/:nodeSlug+" exact>
-            <StoplightProjectImpl {...props} />
-          </Route>
+          <Switch>
+            <Route path="/branches/:branchSlug/:nodeSlug+" exact>
+              <StoplightProjectImpl {...props} />
+            </Route>
 
-          <Route path="/:nodeSlug+" exact>
-            <StoplightProjectImpl {...props} />
-          </Route>
+            <Route path="/:nodeSlug+" exact>
+              <StoplightProjectImpl {...props} />
+            </Route>
 
-          <Route path="/" exact>
-            <StoplightProjectImpl {...props} />
-          </Route>
+            <Route path="/" exact>
+              <StoplightProjectImpl {...props} />
+            </Route>
+          </Switch>
         </Router>
       </RouterTypeContext.Provider>
     </DevPortalProvider>

--- a/packages/elements-dev-portal/src/handlers/getBranches.ts
+++ b/packages/elements-dev-portal/src/handlers/getBranches.ts
@@ -1,4 +1,4 @@
-import { Branch } from '../types';
+import { Branches } from '../types';
 import { appVersion } from '../version';
 
 export const getBranches = async ({
@@ -9,7 +9,7 @@ export const getBranches = async ({
   projectId: string;
   platformUrl?: string;
   platformAuthToken?: string;
-}): Promise<Branch[]> => {
+}): Promise<Branches> => {
   const encodedProjectId = encodeURIComponent(projectId);
   const response = await fetch(`${platformUrl}/api/v1/projects/${encodedProjectId}/branches`, {
     headers: {

--- a/packages/elements-dev-portal/src/types.ts
+++ b/packages/elements-dev-portal/src/types.ts
@@ -5,8 +5,11 @@ export type Branch = {
   slug: string;
   is_default: boolean;
   is_published: boolean;
-  projectId: number;
   name?: string;
+};
+
+export type Branches = {
+  items: Branch[];
 };
 
 export type ProjectTableOfContents = {


### PR DESCRIPTION
Fixes [STOP-94](https://smartbear.atlassian.net/browse/STOP-94)
Fixes rendering two `StoplightProject` components due to matching both routes.

The API for `listBranches` has changed for elements-dev-portal v2 introducing slightly different response format. 
It still responds with previous data structure for all elements-dev-portal v1 instances so its users are not affected.

Changes:
- updates response data type to follow new format
- adds Switch to router to prioritize rules - currently `/:nodeSlug+` rule matches all paths (because of `+` sign)



[STOP-87]: https://smartbear.atlassian.net/browse/STOP-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[STOP-94]: https://smartbear.atlassian.net/browse/STOP-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ