### PR TITLE
feat(elements): group models under schemas category

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/index.ts
+++ b/packages/elements-core/src/index.ts
@@ -16,6 +16,7 @@ export { PoweredByLink } from './components/PoweredByLink';
 export { TableOfContents } from './components/TableOfContents';
 export {
   CustomLinkComponent,
+  TableOfContentsGroup,
   TableOfContentsItem,
   TableOfContentsNode,
   TableOfContentsNodeGroup,

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -62,7 +62,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~8.0.3",
+    "@stoplight/elements-core": "~8.0.4",
     "@stoplight/http-spec": "^7.0.2",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.46.1",

--- a/packages/elements/src/components/API/utils.ts
+++ b/packages/elements/src/components/API/utils.ts
@@ -1,5 +1,10 @@
-import { isHttpOperation, isHttpService, isHttpWebhookOperation, TableOfContentsItem } from '@stoplight/elements-core';
-import { TableOfContentsGroup } from '@stoplight/elements-core/components/TableOfContents';
+import {
+  isHttpOperation,
+  isHttpService,
+  isHttpWebhookOperation,
+  TableOfContentsGroup,
+  TableOfContentsItem,
+} from '@stoplight/elements-core';
 import { NodeType } from '@stoplight/types';
 import { defaults } from 'lodash';
 

--- a/packages/elements/src/components/API/utils.ts
+++ b/packages/elements/src/components/API/utils.ts
@@ -1,10 +1,11 @@
 import { isHttpOperation, isHttpService, isHttpWebhookOperation, TableOfContentsItem } from '@stoplight/elements-core';
+import { TableOfContentsGroup } from '@stoplight/elements-core/components/TableOfContents';
 import { NodeType } from '@stoplight/types';
 import { defaults } from 'lodash';
 
-import { OperationNode, ServiceChildNode, ServiceNode, WebhookNode } from '../../utils/oas/types';
+import { OperationNode, SchemaNode, ServiceChildNode, ServiceNode, WebhookNode } from '../../utils/oas/types';
 
-type GroupableNode = OperationNode | WebhookNode;
+type GroupableNode = OperationNode | WebhookNode | SchemaNode;
 
 export type TagGroup<T extends GroupableNode> = { title: string; items: T[] };
 
@@ -85,42 +86,7 @@ export const computeAPITree = (serviceNode: ServiceNode, config: ComputeAPITreeC
     });
 
     const { groups, ungrouped } = computeTagGroups<OperationNode>(serviceNode, NodeType.HttpOperation);
-
-    // Show ungrouped operations above tag groups
-    ungrouped.forEach(operationNode => {
-      if (mergedConfig.hideInternal && operationNode.data.internal) {
-        return;
-      }
-      tree.push({
-        id: operationNode.uri,
-        slug: operationNode.uri,
-        title: operationNode.name,
-        type: operationNode.type,
-        meta: operationNode.data.method,
-      });
-    });
-
-    groups.forEach(group => {
-      const items = group.items.flatMap(operationNode => {
-        if (mergedConfig.hideInternal && operationNode.data.internal) {
-          return [];
-        }
-        return {
-          id: operationNode.uri,
-          slug: operationNode.uri,
-          title: operationNode.name,
-          type: operationNode.type,
-          meta: operationNode.data.method,
-        };
-      });
-      if (items.length > 0) {
-        tree.push({
-          title: group.title,
-          items,
-          itemsType: 'http_operation',
-        });
-      }
-    });
+    addTagGroupsToTree(groups, ungrouped, tree, NodeType.HttpOperation, mergedConfig.hideInternal);
   }
 
   const hasWebhookNodes = serviceNode.children.some(node => node.type === NodeType.HttpWebhook);
@@ -130,42 +96,7 @@ export const computeAPITree = (serviceNode: ServiceNode, config: ComputeAPITreeC
     });
 
     const { groups, ungrouped } = computeTagGroups<WebhookNode>(serviceNode, NodeType.HttpWebhook);
-
-    // Show ungrouped operations above tag groups
-    ungrouped.forEach(operationNode => {
-      if (mergedConfig.hideInternal && operationNode.data.internal) {
-        return;
-      }
-      tree.push({
-        id: operationNode.uri,
-        slug: operationNode.uri,
-        title: operationNode.name,
-        type: operationNode.type,
-        meta: operationNode.data.method,
-      });
-    });
-
-    groups.forEach(group => {
-      const items = group.items.flatMap(operationNode => {
-        if (mergedConfig.hideInternal && operationNode.data.internal) {
-          return [];
-        }
-        return {
-          id: operationNode.uri,
-          slug: operationNode.uri,
-          title: operationNode.name,
-          type: operationNode.type,
-          meta: operationNode.data.method,
-        };
-      });
-      if (items.length > 0) {
-        tree.push({
-          title: group.title,
-          items,
-          itemsType: 'http_webhook',
-        });
-      }
-    });
+    addTagGroupsToTree(groups, ungrouped, tree, NodeType.HttpWebhook, mergedConfig.hideInternal);
   }
 
   let schemaNodes = serviceNode.children.filter(node => node.type === NodeType.Model);
@@ -178,15 +109,8 @@ export const computeAPITree = (serviceNode: ServiceNode, config: ComputeAPITreeC
       title: 'Schemas',
     });
 
-    schemaNodes.forEach(node => {
-      tree.push({
-        id: node.uri,
-        slug: node.uri,
-        title: node.name,
-        type: node.type,
-        meta: '',
-      });
-    });
+    const { groups, ungrouped } = computeTagGroups<SchemaNode>(serviceNode, NodeType.Model);
+    addTagGroupsToTree(groups, ungrouped, tree, NodeType.Model, mergedConfig.hideInternal);
   }
   return tree;
 };
@@ -220,4 +144,48 @@ export const isInternal = (node: ServiceChildNode | ServiceNode): boolean => {
   }
 
   return !!data['x-internal'];
+};
+
+const addTagGroupsToTree = <T extends GroupableNode>(
+  groups: TagGroup<T>[],
+  ungrouped: T[],
+  tree: TableOfContentsItem[],
+  itemsType: TableOfContentsGroup['itemsType'],
+  hideInternal: boolean,
+) => {
+  // Show ungrouped nodes above tag groups
+  ungrouped.forEach(node => {
+    if (hideInternal && isInternal(node)) {
+      return;
+    }
+    tree.push({
+      id: node.uri,
+      slug: node.uri,
+      title: node.name,
+      type: node.type,
+      meta: isHttpOperation(node.data) || isHttpWebhookOperation(node.data) ? node.data.method : '',
+    });
+  });
+
+  groups.forEach(group => {
+    const items = group.items.flatMap(node => {
+      if (hideInternal && isInternal(node)) {
+        return [];
+      }
+      return {
+        id: node.uri,
+        slug: node.uri,
+        title: node.name,
+        type: node.type,
+        meta: isHttpOperation(node.data) || isHttpWebhookOperation(node.data) ? node.data.method : '',
+      };
+    });
+    if (items.length > 0) {
+      tree.push({
+        title: group.title,
+        items,
+        itemsType,
+      });
+    }
+  });
 };


### PR DESCRIPTION
Addresses: [STOP-22](https://smartbear.atlassian.net/browse/STOP-22)
In `elements` package we are grouping operations and webhooks separately under their categories.
This PR adds grouping models under Schemas category so it stays consistent with others.

<img width="279" alt="Screenshot 2024-02-08 at 00 44 04" src="https://github.com/stoplightio/elements/assets/14196079/f0148089-5cbf-4317-be71-208a52053693">


[STOP-22]: https://smartbear.atlassian.net/browse/STOP-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ