### PR TITLE
Fix CUSTOM_ELEMENTS_SCHEMA name

### DIFF
--- a/docs/getting-started/elements/angular.md
+++ b/docs/getting-started/elements/angular.md
@@ -86,7 +86,7 @@ const routes: Routes = [
 export class AppRoutingModule {}
 ```
 
-Finally, set up Angular to allow [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components). Head over to the `app-module.ts` file and add the [CUSTOM_PORTAL_SCHEMA](https://angular.io/api/core/CUSTOM_ELEMENTS_SCHEMA).
+Finally, set up Angular to allow [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components). Head over to the `app-module.ts` file and add the [CUSTOM_ELEMENTS_SCHEMA](https://angular.io/api/core/CUSTOM_ELEMENTS_SCHEMA).
 
 It'll end up looking like this:
 


### PR DESCRIPTION
Just a small typo in angular guide.

# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
