### PR TITLE
Fix(elements-dev-portal): hook cache invalidation on jwt refresh

### DIFF
--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements-dev-portal/src/hooks/useGetBranches.ts
+++ b/packages/elements-dev-portal/src/hooks/useGetBranches.ts
@@ -8,7 +8,7 @@ import { getBranches } from '../handlers/getBranches';
 export function useGetBranches({ projectId }: { projectId: string }) {
   const { platformUrl, platformAuthToken } = React.useContext(PlatformContext);
   return useQuery(
-    [...devPortalCacheKeys.branchesList(projectId), platformUrl, platformAuthToken],
+    [...devPortalCacheKeys.branchesList(projectId), platformUrl],
     () => getBranches({ projectId, platformUrl, platformAuthToken }),
     {
       enabled: projectId ? true : false,

--- a/packages/elements-dev-portal/src/hooks/useGetNodeContent.ts
+++ b/packages/elements-dev-portal/src/hooks/useGetNodeContent.ts
@@ -17,7 +17,7 @@ export function useGetNodeContent({
   const { platformUrl, platformAuthToken } = React.useContext(PlatformContext);
 
   return useQuery(
-    [...devPortalCacheKeys.branchNodeDetails(projectId, branchSlug ?? '', nodeSlug), platformUrl, platformAuthToken],
+    [...devPortalCacheKeys.branchNodeDetails(projectId, branchSlug ?? '', nodeSlug), platformUrl],
     () => getNodeContent({ nodeSlug, projectId, branchSlug, platformUrl, platformAuthToken }),
     { enabled: nodeSlug && projectId ? true : false },
   );

--- a/packages/elements-dev-portal/src/hooks/useGetNodes.ts
+++ b/packages/elements-dev-portal/src/hooks/useGetNodes.ts
@@ -25,7 +25,6 @@ export function useGetNodes({
     [
       ...devPortalCacheKeys.searchNodes({ projectIds, branchSlug: branch, workspaceId, search: debounceSearch }),
       platformUrl,
-      platformAuthToken,
     ],
     () =>
       getNodes({ workspaceId, projectIds, branchSlug: branch, search: debounceSearch, platformUrl, platformAuthToken }),

--- a/packages/elements-dev-portal/src/hooks/useGetTableOfContents.ts
+++ b/packages/elements-dev-portal/src/hooks/useGetTableOfContents.ts
@@ -8,7 +8,7 @@ import { getTableOfContents } from '../handlers/getTableOfContents';
 export function useGetTableOfContents({ projectId, branchSlug }: { projectId: string; branchSlug?: string }) {
   const { platformUrl, platformAuthToken } = React.useContext(PlatformContext);
   return useQuery(
-    [...devPortalCacheKeys.branchTOC(projectId, branchSlug ?? ''), platformUrl, platformAuthToken],
+    [...devPortalCacheKeys.branchTOC(projectId, branchSlug ?? ''), platformUrl],
     () => getTableOfContents({ projectId, branchSlug, platformUrl, platformAuthToken }),
     { enabled: projectId ? true : false },
   );


### PR DESCRIPTION
# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
