### PR TITLE
fix: remove the unnecessary rounded style

### DIFF
--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -331,7 +331,7 @@ export const TryIt: React.FC<TryItProps> = ({
     );
   } else {
     tryItPanelElem = (
-      <Box className="TryItPanel" bg="canvas-100" rounded="lg">
+      <Box className="TryItPanel" bg="canvas-100">
         {tryItPanelContents}
       </Box>
     );


### PR DESCRIPTION
# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

This PR removes the unnecessary rounded style from the "TryIt" response area.

https://github.com/stoplightio/elements/assets/761462/13debea3-a8ed-4493-a5d2-95866c193262

## Current style

<img src="https://github.com/stoplightio/elements/assets/761462/98e77e84-28ca-460c-a838-066145dff224" width="30%">

## Fixed style with this PR

<img src="https://github.com/stoplightio/elements/assets/761462/6eaa6c19-2457-424e-9689-8c556d15b1a6" width="30%">


