### PR TITLE
fix: bump json-schema-viewer 

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/elements": "^8.0.3",
+    "@stoplight/elements": "^8.1.3",
     "@stoplight/mosaic": "^1.53.1",
     "history": "^5.0.0",
     "react": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.1.3",
+  "version": "8.1.4",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",
@@ -62,7 +62,7 @@
     "@stoplight/json-schema-ref-parser": "^9.0.5",
     "@stoplight/json-schema-sampler": "0.2.3",
     "@stoplight/json-schema-tree": "^4.0.0",
-    "@stoplight/json-schema-viewer": "^4.15.1",
+    "@stoplight/json-schema-viewer": "4.16.1",
     "@stoplight/markdown-viewer": "^5.7.0",
     "@stoplight/mosaic": "^1.53.1",
     "@stoplight/mosaic-code-editor": "^1.53.1",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~8.1.3",
+    "@stoplight/elements-core": "~8.1.4",
     "@stoplight/markdown-viewer": "^5.7.0",
     "@stoplight/mosaic": "^1.53.1",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -63,7 +63,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~8.1.3",
+    "@stoplight/elements-core": "~8.1.4",
     "@stoplight/http-spec": "^7.0.3",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.53.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3976,10 +3976,10 @@
     "@types/json-schema" "^7.0.7"
     magic-error "0.0.1"
 
-"@stoplight/json-schema-viewer@^4.15.1":
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.15.1.tgz#6ecfe2ce65cec7b1a2dac77de70c2029361f4637"
-  integrity sha512-xvu0ctzEce2FYSrgDNYYuENlWndiELJ4f7ng39xjyBw2hMl0QoBy8JlhCrAIiRM1tVs8cmBc/ENQk7GsdJ7Ejg==
+"@stoplight/json-schema-viewer@4.16.1":
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.16.1.tgz#2e1ddb33afae9e5c46257d9bf58bb61eec9f43ca"
+  integrity sha512-gQ1v9/Dj1VP43zERuZoFMOr7RQDBZlgfF7QFh+R0sadP6W30oYFJtD7y2PG2gIQDohKElVuPjhFUbVH/81MnSg==
   dependencies:
     "@stoplight/json" "^3.20.1"
     "@stoplight/json-schema-tree" "^4.0.0"


### PR DESCRIPTION
json-schema-viewer version updated for binary format
[STOP-464](https://smartbear.atlassian.net/browse/STOP-464)

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)


[STOP-464]: https://smartbear.atlassian.net/browse/STOP-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ