### PR TITLE
fix: background colors added for trace, options and head method

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/TableOfContents/constants.ts
+++ b/packages/elements-core/src/components/TableOfContents/constants.ts
@@ -38,4 +38,7 @@ export const NODE_META_COLOR = {
   put: 'warning',
   patch: 'warning',
   delete: 'danger',
+  head: '#9061F9',
+  options: '#0D5AA7',
+  trace: '#0D0B28',
 };

--- a/packages/elements-core/src/constants.ts
+++ b/packages/elements-core/src/constants.ts
@@ -80,6 +80,9 @@ export const HttpMethodColors = {
   put: 'warning',
   patch: 'warning',
   delete: 'danger',
+  head: '#9061F9',
+  options: '#0D5AA7',
+  trace: '#0D0B28',
 } as const;
 
 export const HttpCodeColor = {

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~8.3.0",
+    "@stoplight/elements-core": "~8.3.1",
     "@stoplight/markdown-viewer": "^5.7.0",
     "@stoplight/mosaic": "^1.53.1",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -63,7 +63,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~8.3.0",
+    "@stoplight/elements-core": "~8.3.1",
     "@stoplight/http-spec": "^7.0.3",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.53.1",


### PR DESCRIPTION
STOP-477 
   - Verbs on Docs page are not colored (OPTIONS, HEAD, TRACE). Added background color for these methods.

# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
