### PR TITLE
feat: default boolean schema value is not shown in parameters dropdown

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.3.2",
+  "version": "8.3.3",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
+++ b/packages/elements-core/src/components/TryIt/Parameters/ParameterEditor.tsx
@@ -5,6 +5,7 @@ import { useUniqueId } from '../../../hooks/useUniqueId';
 import {
   exampleOptions,
   getPlaceholderForParameter,
+  getPlaceholderForSelectedParameter,
   parameterOptions,
   ParameterSpec,
   selectExampleOption,
@@ -52,6 +53,7 @@ export const ParameterEditor: React.FC<ParameterProps> = ({
             options={parameterValueOptions}
             value={value || ''}
             onChange={onChange}
+            placeholder={getPlaceholderForSelectedParameter(parameter)}
           />
         ) : (
           <Flex flex={1}>

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
@@ -90,7 +90,7 @@ describe('Parameter Utils', () => {
   describe('getPlaceholderForSelectedParameter', () => {
     let parameter: ParameterSpec;
 
-    it('should return placeholder text when parameterValue is truthy and isDefault is true', () => {
+    it('should return placeholder text with default value when parameter has a default value', () => {
       parameter = {
         name: 'name',
         schema: {
@@ -100,10 +100,10 @@ describe('Parameter Utils', () => {
       };
 
       const result = getPlaceholderForSelectedParameter(parameter);
-      expect(result).toEqual(`defaults to: ${parameter?.schema?.default}`);
+      expect(result).toEqual(`select an option (defaults to: ${parameter?.schema?.default})`);
     });
 
-    it('should return undefined when isDefault is false', () => {
+    it('should return undefined when parameter does not have a default value', () => {
       parameter = {
         name: 'name',
         schema: {

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
@@ -94,19 +94,6 @@ describe('Parameter Utils', () => {
       parameter = {
         name: 'name',
         schema: {
-          default: 1,
-          enum: [0, 1, 3],
-        },
-      };
-
-      const result = getPlaceholderForSelectedParameter(parameter);
-      expect(result).toEqual(`select an option (defaults to: ${parameter?.schema?.default})`);
-    });
-
-    it('should return placeholder text with default value when parameter has a default value, which is falsy', () => {
-      parameter = {
-        name: 'name',
-        schema: {
           default: 0,
           enum: [0, 1, 3],
         },

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
@@ -103,7 +103,7 @@ describe('Parameter Utils', () => {
       expect(result).toEqual(`select an option (defaults to: ${parameter?.schema?.default})`);
     });
 
-    it('returns placeholder indicating the default value when it is present and falsy', () => {
+    it('should return placeholder text with default value when parameter has a default value, which is falsy', () => {
       parameter = {
         name: 'name',
         schema: {

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
@@ -1,7 +1,12 @@
 import { JSONSchema7Definition } from 'json-schema';
 
 import { httpOperation } from '../../../__fixtures__/operations/put-todos';
-import { initialParameterValues, mapSchemaPropertiesToParameters } from './parameter-utils';
+import {
+  getPlaceholderForSelectedParameter,
+  initialParameterValues,
+  mapSchemaPropertiesToParameters,
+  ParameterSpec,
+} from './parameter-utils';
 
 describe('Parameter Utils', () => {
   describe('initialParameterValues.name', () => {
@@ -79,6 +84,35 @@ describe('Parameter Utils', () => {
           name: 'boolean',
         },
       ]);
+    });
+  });
+
+  describe('getPlaceholderForSelectedParameter', () => {
+    let parameter: ParameterSpec;
+
+    it('should return placeholder text when parameterValue is truthy and isDefault is true', () => {
+      parameter = {
+        name: 'name',
+        schema: {
+          default: 1,
+          enum: [0, 1, 3],
+        },
+      };
+
+      const result = getPlaceholderForSelectedParameter(parameter);
+      expect(result).toEqual(`defaults to: ${parameter?.schema?.default}`);
+    });
+
+    it('should return undefined when isDefault is false', () => {
+      parameter = {
+        name: 'name',
+        schema: {
+          enum: [0, 1, 3],
+        },
+      };
+
+      const result = getPlaceholderForSelectedParameter(parameter);
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.spec.ts
@@ -103,6 +103,19 @@ describe('Parameter Utils', () => {
       expect(result).toEqual(`select an option (defaults to: ${parameter?.schema?.default})`);
     });
 
+    it('returns placeholder indicating the default value when it is present and falsy', () => {
+      parameter = {
+        name: 'name',
+        schema: {
+          default: 0,
+          enum: [0, 1, 3],
+        },
+      };
+
+      const result = getPlaceholderForSelectedParameter(parameter);
+      expect(result).toEqual(`select an option (defaults to: ${parameter?.schema?.default})`);
+    });
+
     it('should return undefined when parameter does not have a default value', () => {
       parameter = {
         name: 'name',

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -68,6 +68,14 @@ export function getPlaceholderForParameter(parameter: ParameterSpec) {
   return String(parameter.schema?.type ?? '');
 }
 
+export function getPlaceholderForSelectedParameter(parameter: ParameterSpec) {
+  const { value: parameterValue, isDefault } = getValueForParameter(parameter);
+
+  if (parameterValue && isDefault) return `defaults to: ${parameterValue}`;
+
+  return undefined;
+}
+
 function retrieveDefaultFromSchema(parameter: ParameterSpec) {
   const defaultValue = parameter.schema?.default;
   return isObject(defaultValue) ? safeStringify(defaultValue) : defaultValue;

--- a/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
+++ b/packages/elements-core/src/components/TryIt/Parameters/parameter-utils.ts
@@ -71,7 +71,9 @@ export function getPlaceholderForParameter(parameter: ParameterSpec) {
 export function getPlaceholderForSelectedParameter(parameter: ParameterSpec) {
   const { value: parameterValue, isDefault } = getValueForParameter(parameter);
 
-  if (parameterValue && isDefault) return `defaults to: ${parameterValue}`;
+  if (isDefault) {
+    return `select an option (defaults to: ${parameterValue})`;
+  }
 
   return undefined;
 }

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -244,7 +244,7 @@ describe('TryIt', () => {
 
       // query params
       const limitField = screen.getByLabelText('limit');
-      expect(limitField).toHaveTextContent('defaults to: 1');
+      expect(limitField).toHaveTextContent('select an option (defaults to: 1)');
 
       const typeField = screen.getByLabelText('type');
       expect(typeField).toHaveTextContent('something');

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -240,6 +240,7 @@ describe('TryIt', () => {
       // path param
       const completedField = screen.getByLabelText('completed');
       expect(completedField).toHaveValue('');
+      expect(completedField).toHaveTextContent('select an option');
 
       // query params
       const limitField = screen.getByLabelText('limit');

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -243,7 +243,7 @@ describe('TryIt', () => {
 
       // query params
       const limitField = screen.getByLabelText('limit');
-      expect(limitField).toHaveTextContent('select an option');
+      expect(limitField).toHaveTextContent('defaults to: 1');
 
       const typeField = screen.getByLabelText('type');
       expect(typeField).toHaveTextContent('something');

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~8.3.2",
+    "@stoplight/elements-core": "~8.3.3",
     "@stoplight/markdown-viewer": "^5.7.0",
     "@stoplight/mosaic": "^1.53.1",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -63,7 +63,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~8.3.2",
+    "@stoplight/elements-core": "~8.3.3",
     "@stoplight/http-spec": "^7.1.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.53.1",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.3.2",
+  "version": "8.3.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [


### PR DESCRIPTION
PR change placeholder for selectable values with default value to `defaults to: {defaultValue}` https://github.com/stoplightio/elements/issues/2585

---

# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
