### PR TITLE
feat: allow to use `x-tagGroups` extension to define tree structure

### DIFF
--- a/packages/elements/src/components/API/APIWithResponsiveSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithResponsiveSidebarLayout.tsx
@@ -10,7 +10,8 @@ import * as React from 'react';
 import { Redirect, useLocation } from 'react-router-dom';
 
 import { ServiceNode } from '../../utils/oas/types';
-import { computeAPITree, findFirstNodeSlug, isInternal } from './utils';
+import { isInternal } from './utils';
+import { computeAPITree, findFirstNodeSlug } from './computeAPITree';
 
 type SidebarLayoutProps = {
   serviceNode: ServiceNode;

--- a/packages/elements/src/components/API/APIWithSidebarLayout.tsx
+++ b/packages/elements/src/components/API/APIWithSidebarLayout.tsx
@@ -15,7 +15,8 @@ import * as React from 'react';
 import { Link, Redirect, useLocation } from 'react-router-dom';
 
 import { ServiceNode } from '../../utils/oas/types';
-import { computeAPITree, findFirstNodeSlug, isInternal } from './utils';
+import { isInternal } from './utils';
+import { computeAPITree, findFirstNodeSlug } from './computeAPITree';
 
 type SidebarLayoutProps = {
   serviceNode: ServiceNode;

--- a/packages/elements/src/components/API/APIWithStackedLayout.tsx
+++ b/packages/elements/src/components/API/APIWithStackedLayout.tsx
@@ -79,8 +79,15 @@ export const APIWithStackedLayout: React.FC<StackedLayoutProps> = ({
   showPoweredByLink = true,
   location,
 }) => {
-  const { groups: operationGroups } = computeTagGroups<OperationNode>(serviceNode, NodeType.HttpOperation);
-  const { groups: webhookGroups } = computeTagGroups<WebhookNode>(serviceNode, NodeType.HttpWebhook);
+  const rootVendorExtensions = Object.keys(serviceNode.data.extensions ?? {}).map(item => item.toLowerCase());
+  const isHavingTagGroupsExtension = typeof rootVendorExtensions['x-taggroups'] !== undefined;
+
+  const { groups: operationGroups } = computeTagGroups<OperationNode>(serviceNode, NodeType.HttpOperation, {
+    useTagGroups: isHavingTagGroupsExtension,
+  });
+  const { groups: webhookGroups } = computeTagGroups<WebhookNode>(serviceNode, NodeType.HttpWebhook, {
+    useTagGroups: isHavingTagGroupsExtension,
+  });
 
   return (
     <LocationContext.Provider value={{ location }}>
@@ -125,7 +132,7 @@ const Group = React.memo<{ group: TagGroup<OperationNode | WebhookNode> }>(({ gr
   const onClick = React.useCallback(() => setIsExpanded(!isExpanded), [isExpanded]);
 
   const shouldExpand = React.useMemo(() => {
-    return urlHashMatches || group.items.some(item => itemMatchesHash(hash, item));
+    return urlHashMatches || group.items!.some(item => itemMatchesHash(hash, item));
   }, [group, hash, urlHashMatches]);
 
   React.useEffect(() => {
@@ -159,7 +166,7 @@ const Group = React.memo<{ group: TagGroup<OperationNode | WebhookNode> }>(({ gr
       </Flex>
 
       <Collapse isOpen={isExpanded}>
-        {group.items.map(item => {
+        {group.items!.map(item => {
           return <Item key={item.uri} item={item} />;
         })}
       </Collapse>

--- a/packages/elements/src/components/API/__tests__/computeAPITreeByTagGroups.test.ts
+++ b/packages/elements/src/components/API/__tests__/computeAPITreeByTagGroups.test.ts
@@ -1,0 +1,623 @@
+import { NodeType } from '@stoplight/types';
+import { OpenAPIObject as _OpenAPIObject, PathObject } from 'openapi3-ts';
+
+import { transformOasToServiceNode } from '../../../utils/oas';
+import { computeAPITree } from '../computeAPITree';
+
+type OpenAPIObject = Partial<_OpenAPIObject> & {
+  webhooks?: PathObject;
+};
+describe.each([['paths', NodeType.HttpOperation, 'path']] as const)(
+  'when grouping from "%s" as %s',
+  (pathProp, nodeType, parentKeyProp) => {
+    describe('computeAPITreeByTagGroups', () => {
+      it('generates API ToC tree', () => {
+        const apiDocument: OpenAPIObject = {
+          openapi: '3.0.0',
+          info: {
+            title: 'some api',
+            version: '1.0.0',
+            description: 'some description',
+          },
+          'x-tagGroups': [
+            {
+              name: 'Accounts',
+              tags: ['Account Closure'],
+            },
+            {
+              name: 'Processes',
+              tags: ['Account Processes'],
+            },
+          ],
+          [pathProp]: {
+            '/something': {
+              get: {
+                tags: ['Account Closure'],
+                responses: {
+                  200: {
+                    schema: { $ref: '#/definitions/schemas/ImportantSchema' },
+                  },
+                },
+              },
+            },
+            '/something/process': {
+              get: {
+                tags: ['Account Processes'],
+                responses: {
+                  200: {
+                    schema: { $ref: '#/definitions/schemas/ImportantSchema' },
+                  },
+                },
+              },
+            },
+          },
+          components: {
+            schemas: {
+              ImportantSchema: {
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
+              },
+            },
+          },
+        };
+
+        const apiTree = computeAPITree(transformOasToServiceNode(apiDocument)!);
+        expect(apiTree).toEqual([
+          {
+            id: '/',
+            meta: '',
+            slug: '/',
+            title: 'Overview',
+            type: 'overview',
+          },
+          {
+            title: 'Endpoints',
+          },
+          {
+            title: 'Accounts',
+          },
+          {
+            title: 'Account Closure',
+            itemsType: 'http_operation',
+            items: [
+              {
+                id: '/paths/something/get',
+                meta: 'get',
+                slug: '/paths/something/get',
+                title: '/something',
+                type: 'http_operation',
+              },
+            ],
+          },
+          {
+            title: 'Processes',
+          },
+          {
+            title: 'Account Processes',
+            itemsType: 'http_operation',
+            items: [
+              {
+                id: '/paths/something-process/get',
+                meta: 'get',
+                slug: '/paths/something-process/get',
+                title: '/something/process',
+                type: 'http_operation',
+              },
+            ],
+          },
+          {
+            title: 'Schemas',
+          },
+          {
+            id: '/schemas/ImportantSchema',
+            meta: '',
+            slug: '/schemas/ImportantSchema',
+            title: 'ImportantSchema',
+            type: 'model',
+          },
+        ]);
+      });
+
+      it('allows to customise tag name with x-displayName extension', () => {
+        const apiDocument: OpenAPIObject = {
+          openapi: '3.0.0',
+          info: {
+            title: 'some api',
+            version: '1.0.0',
+            description: 'some description',
+          },
+          'x-tagGroups': [
+            {
+              name: 'Accounts',
+              tags: ['Account Closure'],
+            },
+            {
+              name: 'Processes',
+              tags: ['Account Processes'],
+            },
+          ],
+          tags: [
+            {
+              name: 'Account Closure',
+              'x-displayName': 'Account Offboarding Processes',
+            },
+            {
+              name: 'Account Processes',
+              'x-displayName': 'Account Onboarding Processes',
+            },
+          ],
+          [pathProp]: {
+            '/something': {
+              get: {
+                tags: ['Account Closure'],
+                responses: {
+                  200: {
+                    schema: { $ref: '#/definitions/schemas/ImportantSchema' },
+                  },
+                },
+              },
+            },
+            '/something/process': {
+              get: {
+                tags: ['Account Processes'],
+                responses: {
+                  200: {
+                    schema: { $ref: '#/definitions/schemas/ImportantSchema' },
+                  },
+                },
+              },
+            },
+          },
+          components: {
+            schemas: {
+              ImportantSchema: {
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
+              },
+            },
+          },
+        };
+
+        const apiTree = computeAPITree(transformOasToServiceNode(apiDocument)!);
+        expect(apiTree).toEqual([
+          {
+            id: '/',
+            meta: '',
+            slug: '/',
+            title: 'Overview',
+            type: 'overview',
+          },
+          {
+            title: 'Endpoints',
+          },
+          {
+            title: 'Accounts',
+          },
+          {
+            title: 'Account Offboarding Processes',
+            itemsType: 'http_operation',
+            items: [
+              {
+                id: '/paths/something/get',
+                meta: 'get',
+                slug: '/paths/something/get',
+                title: '/something',
+                type: 'http_operation',
+              },
+            ],
+          },
+          {
+            title: 'Processes',
+          },
+          {
+            title: 'Account Onboarding Processes',
+            itemsType: 'http_operation',
+            items: [
+              {
+                id: '/paths/something-process/get',
+                meta: 'get',
+                slug: '/paths/something-process/get',
+                title: '/something/process',
+                type: 'http_operation',
+              },
+            ],
+          },
+          {
+            title: 'Schemas',
+          },
+          {
+            id: '/schemas/ImportantSchema',
+            meta: '',
+            slug: '/schemas/ImportantSchema',
+            title: 'ImportantSchema',
+            type: 'model',
+          },
+        ]);
+      });
+
+      it('allows to hide schemas from ToC', () => {
+        const apiDocument: OpenAPIObject = {
+          openapi: '3.0.0',
+          info: {
+            title: 'some api',
+            version: '1.0.0',
+            description: 'some description',
+          },
+          'x-tagGroups': [
+            {
+              name: 'Accounts',
+              tags: ['Account Closure'],
+            },
+            {
+              name: 'Processes',
+              tags: ['Account Processes'],
+            },
+          ],
+          [pathProp]: {
+            '/something': {
+              get: {
+                tags: ['Account Closure'],
+                responses: {
+                  200: {
+                    schema: { $ref: '#/definitions/schemas/ImportantSchema' },
+                  },
+                },
+              },
+            },
+          },
+          components: {
+            schemas: {
+              ImportantSchema: {
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
+              },
+            },
+          },
+        };
+
+        expect(computeAPITree(transformOasToServiceNode(apiDocument)!, { hideSchemas: true })).toEqual([
+          {
+            id: '/',
+            meta: '',
+            slug: '/',
+            title: 'Overview',
+            type: 'overview',
+          },
+          {
+            title: 'Endpoints',
+          },
+          {
+            title: 'Accounts',
+          },
+          {
+            title: 'Account Closure',
+            itemsType: 'http_operation',
+            items: [
+              {
+                id: '/paths/something/get',
+                meta: 'get',
+                slug: '/paths/something/get',
+                title: '/something',
+                type: 'http_operation',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('allows to hide internal operations from ToC', () => {
+        const apiDocument: OpenAPIObject = {
+          openapi: '3.0.0',
+          info: {
+            title: 'some api',
+            version: '1.0.0',
+            description: 'some description',
+          },
+          'x-tagGroups': [
+            {
+              name: 'Accounts',
+              tags: ['Account Closure'],
+            },
+            {
+              name: 'Processes',
+              tags: ['Account Processes'],
+            },
+          ],
+          [pathProp]: {
+            '/something': {
+              get: {
+                tags: ['Account Closure'],
+              },
+              post: {
+                tags: ['Account Closure'],
+                'x-internal': true,
+              },
+            },
+          },
+        };
+
+        const apiTree = computeAPITree(transformOasToServiceNode(apiDocument)!, { hideInternal: true });
+        expect(apiTree).toEqual([
+          {
+            id: '/',
+            meta: '',
+            slug: '/',
+            title: 'Overview',
+            type: 'overview',
+          },
+          {
+            title: 'Endpoints',
+          },
+          {
+            title: 'Accounts',
+          },
+          {
+            title: 'Account Closure',
+            itemsType: 'http_operation',
+            items: [
+              {
+                id: '/paths/something/get',
+                slug: '/paths/something/get',
+                title: '/something',
+                type: 'http_operation',
+                meta: 'get',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('allows to hide nested internal operations from ToC', () => {
+        const apiDocument: OpenAPIObject = {
+          openapi: '3.0.0',
+          info: {
+            title: 'some api',
+            version: '1.0.0',
+            description: 'some description',
+          },
+          'x-tagGroups': [
+            {
+              name: 'Accounts',
+              tags: ['Account Closure'],
+            },
+            {
+              name: 'Processes',
+              tags: ['Account Processes'],
+            },
+          ],
+          tags: [
+            {
+              name: 'Account Processes',
+            },
+          ],
+          [pathProp]: {
+            '/something': {
+              get: {
+                tags: ['Account Processes'],
+              },
+              post: {
+                'x-internal': true,
+                tags: ['Account Processes'],
+              },
+            },
+          },
+        };
+
+        expect(computeAPITree(transformOasToServiceNode(apiDocument)!, { hideInternal: true })).toEqual([
+          {
+            id: '/',
+            meta: '',
+            slug: '/',
+            title: 'Overview',
+            type: 'overview',
+          },
+          {
+            title: 'Endpoints',
+          },
+          {
+            title: 'Processes',
+          },
+          {
+            title: 'Account Processes',
+            itemsType: 'http_operation',
+            items: [
+              {
+                id: '/paths/something/get',
+                meta: 'get',
+                slug: '/paths/something/get',
+                title: '/something',
+                type: 'http_operation',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('allows to hide internal models from ToC', () => {
+        const apiDocument: OpenAPIObject = {
+          openapi: '3.0.0',
+          info: {
+            title: 'some api',
+            version: '1.0.0',
+            description: 'some description',
+          },
+          'x-tagGroups': [
+            {
+              name: 'Accounts',
+              tags: ['Account Closure'],
+            },
+            {
+              name: 'Processes',
+              tags: ['Account Processes'],
+            },
+          ],
+          [pathProp]: {},
+          components: {
+            schemas: {
+              SomeInternalSchema: {
+                'x-internal': true,
+              },
+            },
+          },
+        };
+
+        expect(computeAPITree(transformOasToServiceNode(apiDocument)!, { hideInternal: true })).toEqual([
+          {
+            id: '/',
+            meta: '',
+            slug: '/',
+            title: 'Overview',
+            type: 'overview',
+          },
+        ]);
+      });
+
+      it('allows to hide nested internal models from ToC', () => {
+        const apiDocument: OpenAPIObject = {
+          openapi: '3.0.0',
+          info: {
+            title: 'some api',
+            version: '1.0.0',
+            description: 'some description',
+          },
+          'x-tagGroups': [
+            {
+              name: 'Accounts',
+              tags: ['Account Closure'],
+            },
+            {
+              name: 'Processes',
+              tags: ['Account Processes'],
+            },
+          ],
+          tags: [
+            {
+              name: 'Account Processes',
+            },
+          ],
+          [pathProp]: {},
+          components: {
+            schemas: {
+              a: {
+                'x-tags': ['Account Processes'],
+              },
+              b: {
+                'x-tags': ['Account Processes'],
+                'x-internal': true,
+              },
+            },
+          },
+        };
+
+        expect(computeAPITree(transformOasToServiceNode(apiDocument)!, { hideInternal: true })).toEqual([
+          {
+            id: '/',
+            meta: '',
+            slug: '/',
+            title: 'Overview',
+            type: 'overview',
+          },
+          { title: 'Schemas' },
+          {
+            title: 'Processes',
+          },
+          {
+            title: 'Account Processes',
+            itemsType: NodeType.Model,
+            items: [
+              {
+                id: '/schemas/a',
+                slug: '/schemas/a',
+                title: 'a',
+                type: 'model',
+                meta: '',
+              },
+            ],
+          },
+        ]);
+      });
+
+      it('excludes groups with no items', () => {
+        const apiDocument: OpenAPIObject = {
+          openapi: '3.0.0',
+          info: {
+            title: 'some api',
+            version: '1.0.0',
+            description: 'some description',
+          },
+          'x-tagGroups': [
+            {
+              name: 'Accounts',
+              tags: ['Account Closure'],
+            },
+            {
+              name: 'Processes',
+              tags: ['Account Processes'],
+            },
+          ],
+          tags: [
+            {
+              name: 'Account Processes',
+            },
+          ],
+          [pathProp]: {
+            '/something': {
+              post: {
+                'x-internal': true,
+                tags: ['Account Processes'],
+              },
+            },
+            '/something-else': {
+              post: {
+                tags: ['Account Processes'],
+              },
+            },
+          },
+          components: {
+            schemas: {
+              a: {
+                'x-tags': ['Account Processes'],
+                'x-internal': true,
+              },
+            },
+          },
+        };
+
+        expect(computeAPITree(transformOasToServiceNode(apiDocument)!, { hideInternal: true })).toEqual([
+          {
+            id: '/',
+            meta: '',
+            slug: '/',
+            title: 'Overview',
+            type: 'overview',
+          },
+          {
+            title: 'Endpoints',
+          },
+          {
+            title: 'Processes',
+          },
+          {
+            title: 'Account Processes',
+            itemsType: nodeType,
+            items: [
+              {
+                id: `/${pathProp}/something-else/post`,
+                meta: 'post',
+                slug: `/${pathProp}/something-else/post`,
+                title: '/something-else',
+                type: nodeType,
+              },
+            ],
+          },
+        ]);
+      });
+    });
+  },
+);

--- a/packages/elements/src/components/API/__tests__/utils.test.ts
+++ b/packages/elements/src/components/API/__tests__/utils.test.ts
@@ -3,7 +3,8 @@ import { OpenAPIObject as _OpenAPIObject, PathObject } from 'openapi3-ts';
 
 import { transformOasToServiceNode } from '../../../utils/oas';
 import { OperationNode, SchemaNode, WebhookNode } from '../../../utils/oas/types';
-import { computeAPITree, computeTagGroups } from '../utils';
+import { computeAPITree } from '../computeAPITree';
+import { computeTagGroups } from '../utils';
 
 type OpenAPIObject = Partial<_OpenAPIObject> & {
   webhooks?: PathObject;
@@ -44,7 +45,11 @@ describe.each([
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType) : null).toEqual({
+      expect(
+        serviceNode
+          ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType, { useTagGroups: false })
+          : null,
+      ).toEqual({
         groups: [
           {
             title: 'beta',
@@ -153,7 +158,11 @@ describe.each([
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType) : null).toEqual({
+      expect(
+        serviceNode
+          ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType, { useTagGroups: false })
+          : null,
+      ).toEqual({
         groups: [
           {
             title: 'beta',
@@ -258,7 +267,11 @@ describe.each([
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType) : null).toEqual({
+      expect(
+        serviceNode
+          ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType, { useTagGroups: false })
+          : null,
+      ).toEqual({
         groups: [
           {
             title: 'beta',
@@ -344,7 +357,11 @@ describe.each([
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType) : null).toEqual({
+      expect(
+        serviceNode
+          ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType, { useTagGroups: false })
+          : null,
+      ).toEqual({
         groups: [],
         ungrouped: [],
       });
@@ -381,7 +398,11 @@ describe.each([
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType) : null).toEqual({
+      expect(
+        serviceNode
+          ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType, { useTagGroups: false })
+          : null,
+      ).toEqual({
         groups: [
           {
             title: 'Beta',
@@ -485,7 +506,11 @@ describe.each([
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType) : null).toEqual({
+      expect(
+        serviceNode
+          ? computeTagGroups<OperationNode | WebhookNode>(serviceNode, nodeType, { useTagGroups: false })
+          : null,
+      ).toEqual({
         groups: [
           {
             title: 'Beta',
@@ -941,7 +966,9 @@ describe('when grouping models', () => {
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<SchemaNode>(serviceNode, NodeType.Model) : null).toEqual({
+      expect(
+        serviceNode ? computeTagGroups<SchemaNode>(serviceNode, NodeType.Model, { useTagGroups: false }) : null,
+      ).toEqual({
         groups: [
           {
             title: 'beta',
@@ -1008,7 +1035,9 @@ describe('when grouping models', () => {
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<SchemaNode>(serviceNode, NodeType.Model) : null).toEqual({
+      expect(
+        serviceNode ? computeTagGroups<SchemaNode>(serviceNode, NodeType.Model, { useTagGroups: false }) : null,
+      ).toEqual({
         groups: [
           {
             title: 'beta',
@@ -1081,7 +1110,9 @@ describe('when grouping models', () => {
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<SchemaNode>(serviceNode, NodeType.Model) : null).toEqual({
+      expect(
+        serviceNode ? computeTagGroups<SchemaNode>(serviceNode, NodeType.Model, { useTagGroups: false }) : null,
+      ).toEqual({
         groups: [
           {
             title: 'Beta',
@@ -1145,7 +1176,9 @@ describe('when grouping models', () => {
       };
 
       const serviceNode = transformOasToServiceNode(apiDocument);
-      expect(serviceNode ? computeTagGroups<SchemaNode>(serviceNode, NodeType.Model) : null).toEqual({
+      expect(
+        serviceNode ? computeTagGroups<SchemaNode>(serviceNode, NodeType.Model, { useTagGroups: false }) : null,
+      ).toEqual({
         groups: [
           {
             title: 'Beta',

--- a/packages/elements/src/components/API/computeAPITree.ts
+++ b/packages/elements/src/components/API/computeAPITree.ts
@@ -1,0 +1,102 @@
+import { OperationNode, SchemaNode, ServiceNode, WebhookNode } from '@stoplight/elements/utils/oas/types';
+import { TableOfContentsItem } from '@stoplight/elements-core';
+import { NodeType } from '@stoplight/types';
+import { defaults } from 'lodash';
+
+import { addTagGroupsToTree, computeTagGroups, isInternal } from './utils';
+
+export interface ComputeAPITreeConfig {
+  hideSchemas?: boolean;
+  hideInternal?: boolean;
+}
+
+export const defaultComputerAPITreeConfig = {
+  hideSchemas: false,
+  hideInternal: false,
+};
+
+export const computeAPITree = (serviceNode: ServiceNode, config: ComputeAPITreeConfig = {}) => {
+  const mergedConfig = defaults(config, defaultComputerAPITreeConfig);
+  const tree: TableOfContentsItem[] = [];
+
+  //
+  const rootVendorExtensions = Object.keys(serviceNode.data.extensions ?? {}).map(item => item.toLowerCase());
+  const isHavingTagGroupsExtension = typeof rootVendorExtensions['x-taggroups'] !== undefined;
+
+  tree.push({
+    id: '/',
+    slug: '/',
+    title: 'Overview',
+    type: 'overview',
+    meta: '',
+  });
+
+  const hasOperationNodes = serviceNode.children.some(node => node.type === NodeType.HttpOperation);
+  if (hasOperationNodes) {
+    tree.push({
+      title: 'Endpoints',
+    });
+
+    const { groups, ungrouped } = computeTagGroups<OperationNode>(serviceNode, NodeType.HttpOperation, {
+      useTagGroups: isHavingTagGroupsExtension,
+    });
+    addTagGroupsToTree(groups, ungrouped, tree, NodeType.HttpOperation, {
+      hideInternal: mergedConfig.hideInternal,
+      useTagGroups: isHavingTagGroupsExtension,
+    });
+  }
+
+  const hasWebhookNodes = serviceNode.children.some(node => node.type === NodeType.HttpWebhook, {
+    useTagGroups: isHavingTagGroupsExtension,
+  });
+  if (hasWebhookNodes) {
+    tree.push({
+      title: 'Webhooks',
+    });
+
+    const { groups, ungrouped } = computeTagGroups<WebhookNode>(serviceNode, NodeType.HttpWebhook, {
+      useTagGroups: isHavingTagGroupsExtension,
+    });
+    addTagGroupsToTree(groups, ungrouped, tree, NodeType.HttpWebhook, {
+      hideInternal: mergedConfig.hideInternal,
+      useTagGroups: isHavingTagGroupsExtension,
+    });
+  }
+
+  let schemaNodes = serviceNode.children.filter(node => node.type === NodeType.Model);
+  if (mergedConfig.hideInternal) {
+    schemaNodes = schemaNodes.filter(n => !isInternal(n));
+  }
+
+  if (!mergedConfig.hideSchemas && schemaNodes.length) {
+    tree.push({
+      title: 'Schemas',
+    });
+
+    const { groups, ungrouped } = computeTagGroups<SchemaNode>(serviceNode, NodeType.Model, {
+      useTagGroups: isHavingTagGroupsExtension,
+    });
+    addTagGroupsToTree(groups, ungrouped, tree, NodeType.Model, {
+      hideInternal: mergedConfig.hideInternal,
+      useTagGroups: isHavingTagGroupsExtension,
+    });
+  }
+  return tree;
+};
+
+export const findFirstNodeSlug = (tree: TableOfContentsItem[]): string | void => {
+  for (const item of tree) {
+    if ('slug' in item) {
+      return item.slug;
+    }
+
+    if ('items' in item) {
+      const slug = findFirstNodeSlug(item.items);
+      if (slug) {
+        return slug;
+      }
+    }
+  }
+
+  return;
+};


### PR DESCRIPTION
Allow to use the `x-tagGroups` and `x-displayName` vendor extensions to define the structure of table of contents

# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [X] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
