### PR TITLE
fix: allow to display the code samples when try it panel is hidden

### DIFF
--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -57,6 +57,11 @@ export interface TryItProps {
   embeddedInMd?: boolean;
 
   /**
+   * True when TryIt Panel should be hidden
+   */
+  hideTryIt?: boolean;
+
+  /**
    * Fetch credentials policy for TryIt component
    * For more information: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
    * @default "omit"
@@ -78,6 +83,7 @@ export const TryIt: React.FC<TryItProps> = ({
   onRequestChange,
   requestBodyIndex,
   embeddedInMd = false,
+  hideTryIt = false,
   tryItCredentialsPolicy,
   corsProxy,
 }) => {
@@ -337,6 +343,11 @@ export const TryIt: React.FC<TryItProps> = ({
         {tryItPanelContents}
       </Box>
     );
+  }
+
+  // If hiding of the TryIt panel is requested, we should not render it the component itself
+  if (hideTryIt) {
+    return null;
   }
 
   return (

--- a/packages/elements-core/src/components/TryIt/TryItWithRequestSamples.stories.tsx
+++ b/packages/elements-core/src/components/TryIt/TryItWithRequestSamples.stories.tsx
@@ -23,3 +23,10 @@ WithVariables.args = {
   httpOperation: operationWithUrlVariables,
 };
 WithVariables.storyName = 'With Server Variables';
+
+export const WithoutTryItPanel = Template.bind({});
+WithoutTryItPanel.args = {
+  hideTryIt: true,
+  httpOperation: operationWithUrlVariables,
+};
+WithoutTryItPanel.storyName = 'Without Try It Panel';

--- a/packages/elements-core/src/components/TryIt/TryItWithRequestSamples.tsx
+++ b/packages/elements-core/src/components/TryIt/TryItWithRequestSamples.tsx
@@ -16,12 +16,15 @@ export const TryItWithRequestSamples: React.FC<TryItWithRequestSamplesProps> = (
 
   return (
     <VStack spacing={6}>
-      {!hideTryIt && (
+      {!hideTryIt ? (
         <InvertTheme>
           <Box>
-            <TryIt {...props} onRequestChange={setRequestData} />
+            <TryIt {...props} hideTryIt={hideTryIt} onRequestChange={setRequestData} />
           </Box>
         </InvertTheme>
+      ) : (
+        // The TryIt is responsible for generating the Request Data so it should always be rendered
+        <TryIt {...props} hideTryIt={hideTryIt} onRequestChange={setRequestData} />
       )}
 
       {requestData && <RequestSamples request={requestData} customCodeSamples={customCodeSamples} />}


### PR DESCRIPTION
# Changes
- Modified the rendering logic of the TryIt component to ensure it generates request data regardless of the TryIt panel's visibility.
- Ensured that the request sample is consistently displayed on the page by decoupling the request data generation from the TryIt panel's display state.

# Rationale
Previously, the request sample could not be displayed without rendering the TryIt panel, which was a limitation. This change allows the request sample by not visually rendering the TryIt Panel when its opted out off.

# Testing
- Verified that the request sample is correctly displayed when the TryIt panel is hidden.
- Ensured no regressions in the display of the TryIt panel and its functionality.

# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [X] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
