### PR TITLE
fix: flaky e2e tests

### DIFF
--- a/cypress/e2e/stoplight-project.cy.ts
+++ b/cypress/e2e/stoplight-project.cy.ts
@@ -92,7 +92,9 @@ describe('Stoplight component', () => {
       cy.findByRole('menuitemradio', { name: /mock server/i }).then(enabled => {
         enabled.trigger('click');
       });
+      cy.intercept('https://stoplight.io/mocks/**').as('getData');
       cy.findByRole('button', { name: /send api request/i }).click();
+      cy.wait('@getData');
       cy.findByText('200 OK').should('exist');
     });
   });
@@ -131,8 +133,10 @@ describe('Stoplight component', () => {
 
 function loadStoplightProjectPage() {
   cy.intercept('https://stoplight.io/api/v1/projects/cHJqOjYwNjYx/nodes/**').as('getNode');
+  cy.intercept(`https://stoplight.io/api/v1/projects/cHJqOjYwNjYx/table-of-contents`).as('getToc');
   cy.visit('/stoplight-project');
   cy.wait('@getNode');
+  cy.wait('@getToc');
 }
 
 function loadCreateTodoPage() {
@@ -153,6 +157,8 @@ function loadMarkdownPage() {
 
 function visitNode(nodeId: string, nodeSlug: string) {
   cy.intercept(`https://stoplight.io/api/v1/projects/cHJqOjYwNjYx/nodes/${nodeId}-${nodeSlug}`).as('getNode');
+  cy.intercept(`https://stoplight.io/api/v1/projects/cHJqOjYwNjYx/table-of-contents`).as('getToc');
   cy.visit(`/stoplight-project/${nodeId}-${nodeSlug}`);
   cy.wait('@getNode');
+  cy.wait('@getToc');
 }

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '2.3.3';
+export const appVersion = '2.4.4';


### PR DESCRIPTION
# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)

This PR resolves issues with flaky e2e tests. 
