### PR TITLE
fix:Extra newline added when copying URLs from documentation issue re…

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -159,13 +159,13 @@ function MethodPathInner({ method, path, chosenServerUrl }: MethodPathProps & { 
 
   const pathElem = (
     <Flex overflowX="hidden" fontSize="lg" userSelect="all">
-      <Box dir="rtl" color="muted" textOverflow="truncate" overflowX="hidden">
-        <Box as="span" dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
+      <Box dir="rtl" textOverflow="truncate" overflowX="hidden">
+        <Box as="span" color="muted" dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
           {chosenServerUrl}
         </Box>
-      </Box>
-      <Box fontWeight="semibold" flex={1}>
-        {path}
+        <Box as="span" fontWeight="semibold" flex={1}>
+          {path}
+        </Box>
       </Box>
     </Flex>
   );


### PR DESCRIPTION

# Addressed 
STOP-979
# Changes
have made change the order of the element of pathElem in HttpOperation.tsx file.

# Testing
have checked jest, playwright and manual testing.



