### PR TITLE
chore(deps): Bump @stoplight/mosaic, @stoplight/mosaic-code-editor and @stoplight/mosaic-code-viewer

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -10,8 +10,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@stoplight/mosaic": "^1.53.3",
-    "@stoplight/elements": "^8.4.0",
+    "@stoplight/mosaic": "^1.53.4",
+    "@stoplight/elements": "^8.4.2",
     "history": "^5.0.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.4.1",
+  "version": "8.4.2",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",
@@ -64,9 +64,9 @@
     "@stoplight/json-schema-tree": "^4.0.0",
     "@stoplight/json-schema-viewer": "4.16.1",
     "@stoplight/markdown-viewer": "^5.7.1",
-    "@stoplight/mosaic": "^1.53.3",
-    "@stoplight/mosaic-code-editor": "^1.53.1",
-    "@stoplight/mosaic-code-viewer": "^1.53.1",
+    "@stoplight/mosaic": "^1.53.4",
+    "@stoplight/mosaic-code-editor": "^1.53.4",
+    "@stoplight/mosaic-code-viewer": "^1.53.4",
     "@stoplight/path": "^1.3.2",
     "@stoplight/react-error-boundary": "^3.0.0",
     "@stoplight/types": "^14.1.1",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -65,8 +65,8 @@
   },
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
-    "@stoplight/mosaic": "^1.53.3",
-    "@stoplight/elements-core": "~8.4.1",
+    "@stoplight/mosaic": "^1.53.4",
+    "@stoplight/elements-core": "^8.4.2",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '2.4.0';
+export const appVersion = '2.4.2';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.4.1",
+  "version": "8.4.2",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -63,10 +63,10 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~8.4.1",
+    "@stoplight/elements-core": "^8.4.2",
     "@stoplight/http-spec": "^7.1.0",
     "@stoplight/json": "^3.18.1",
-    "@stoplight/mosaic": "^1.53.3",
+    "@stoplight/mosaic": "^1.53.4",
     "@stoplight/types": "^14.1.1",
     "@stoplight/yaml": "^4.3.0",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6342,10 +6342,10 @@
     unist-util-select "^4.0.0"
     unist-util-visit "^3.1.0"
 
-"@stoplight/mosaic-code-editor@^1.53.1":
-  version "1.53.1"
-  resolved "https://registry.npmjs.org/@stoplight/mosaic-code-editor/-/mosaic-code-editor-1.53.1.tgz#01d08f094e721320fd94c6c9efa8b81f8a2d2f94"
-  integrity sha512-xA6kgWTelz/oLphI+2pU1MId92zGG9ZLQb9mY1UoeqCZLxC7oH/UxIuNW7JGG5yCOEppgW4fiIBgLBDKGlt8wA==
+"@stoplight/mosaic-code-editor@^1.53.4":
+  version "1.53.4"
+  resolved "https://registry.yarnpkg.com/@stoplight/mosaic-code-editor/-/mosaic-code-editor-1.53.4.tgz#a8d2c9f38d735cff4a187950de05c03a3a69caf8"
+  integrity sha512-StVEXVq5ZlVGvfdsKIYw/h76jb22CKCBUcgNmGyKSQx9ZmLc1wA24CWvbRvSxXKm3/0/P/IyVZ61aaYItqhmrg==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/react-fontawesome" "^0.2.0"
@@ -6354,8 +6354,8 @@
     "@react-types/radio" "3.1.2"
     "@react-types/shared" "3.9.0"
     "@react-types/switch" "3.1.2"
-    "@stoplight/mosaic" "1.53.1"
-    "@stoplight/mosaic-code-viewer" "1.53.1"
+    "@stoplight/mosaic" "1.53.4"
+    "@stoplight/mosaic-code-viewer" "1.53.4"
     "@stoplight/types" "^13.7.0"
     clsx "^1.1.1"
     copy-to-clipboard "^3.3.1"
@@ -6372,10 +6372,10 @@
     use-resize-observer "^9.0.2"
     zustand "^3.5.2"
 
-"@stoplight/mosaic-code-viewer@1.53.1", "@stoplight/mosaic-code-viewer@^1.53.1":
-  version "1.53.1"
-  resolved "https://registry.npmjs.org/@stoplight/mosaic-code-viewer/-/mosaic-code-viewer-1.53.1.tgz#6de139524b6bba45fc16d84c6e966d53961216b9"
-  integrity sha512-SqIR1dEZaj+o7PDnT+nMy7AAWMyVZ4LV/9Y3xJ9AGBJiszyyBN0uJS/OHsYBXzZvD+I8I5NsZymmDiG7xEatSw==
+"@stoplight/mosaic-code-viewer@1.53.4", "@stoplight/mosaic-code-viewer@^1.53.4":
+  version "1.53.4"
+  resolved "https://registry.yarnpkg.com/@stoplight/mosaic-code-viewer/-/mosaic-code-viewer-1.53.4.tgz#650ea524d62baada0c0b92f19c1de2135f0ed179"
+  integrity sha512-RZEZ7+UodFQtuuVHyCONg/8wNDlFCuDz0knneGrDaQ1vDa3ddePPjBQnpqVFY0ndXqoaxZTuQu4GvcC8wKdk0Q==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/react-fontawesome" "^0.2.0"
@@ -6384,7 +6384,7 @@
     "@react-types/radio" "3.1.2"
     "@react-types/shared" "3.9.0"
     "@react-types/switch" "3.1.2"
-    "@stoplight/mosaic" "1.53.1"
+    "@stoplight/mosaic" "1.53.4"
     "@stoplight/types" "^13.7.0"
     clsx "^1.1.1"
     copy-to-clipboard "^3.3.1"
@@ -6401,40 +6401,10 @@
     use-resize-observer "^9.0.2"
     zustand "^3.5.2"
 
-"@stoplight/mosaic@1.53.1":
-  version "1.53.1"
-  resolved "https://registry.npmjs.org/@stoplight/mosaic/-/mosaic-1.53.1.tgz#b0d3951fc365c1bd66c7a0c793f5cb3bd8c74bdb"
-  integrity sha512-zLh81fUGHlUUFYI2JKTreOU9osIkJPAsWPPbVAQ8o1RQPCEdI+zZTIdzsFvZxnwVzSf+lEDfzBeT0ZxOAHVzww==
-  dependencies:
-    "@fortawesome/fontawesome-svg-core" "^6.1.1"
-    "@fortawesome/react-fontawesome" "^0.2.0"
-    "@react-hook/size" "^2.1.1"
-    "@react-hook/window-size" "^3.0.7"
-    "@react-types/button" "3.4.1"
-    "@react-types/radio" "3.1.2"
-    "@react-types/shared" "3.9.0"
-    "@react-types/switch" "3.1.2"
-    "@react-types/textfield" "3.3.0"
-    "@stoplight/types" "^13.7.0"
-    "@types/react" "^17.0.3"
-    "@types/react-dom" "^17.0.3"
-    clsx "^1.1.1"
-    copy-to-clipboard "^3.3.1"
-    dom-helpers "^3.3.1"
-    lodash.get "^4.4.2"
-    nano-memoize "^1.2.1"
-    polished "^4.1.3"
-    react-fast-compare "^3.2.0"
-    react-overflow-list "^0.5.0"
-    ts-keycode-enum "^1.0.6"
-    tslib "^2.1.0"
-    use-resize-observer "^9.0.2"
-    zustand "^3.5.2"
-
-"@stoplight/mosaic@^1.53.3":
-  version "1.53.3"
-  resolved "https://registry.yarnpkg.com/@stoplight/mosaic/-/mosaic-1.53.3.tgz#1573c888d5492eff838a9f8c81ef6f071bb21298"
-  integrity sha512-tT8vywRTMrqA/S3X7WHGm9EsPiz0tlga2HcJM+WpMRGd51JsZ0QLni3WOizbBrB5SnQyqj6mA6ordshuRP0DQg==
+"@stoplight/mosaic@1.53.4", "@stoplight/mosaic@^1.53.4":
+  version "1.53.4"
+  resolved "https://registry.yarnpkg.com/@stoplight/mosaic/-/mosaic-1.53.4.tgz#04e03a4dfb95e0a451cd2bde6e14ad66103a684d"
+  integrity sha512-k3D9B2bM/Ko7ibKKWxJuhomHCOAxooPNPZNX0aY+3kTmQf7tJL+70iwcwD7TbrMyOj7L8SzJPRpJ9fcM8LaDNA==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/react-fontawesome" "^0.2.0"


### PR DESCRIPTION
This is fix for https://github.com/stoplightio/elements/issues/2655.

There were mismatches in versions of `@stoplight/mosaic` and `@stoplight/mosaic-code-editor`/`@stoplight/mosaic-code-viewer`. Someone has bumped mosaic, but forgot to bump code-editor and code-viewer. Still not sure why it caused the issue with inverted colours (the changes are not related at all), but bumping all versions fixed the issue locally. Let's see if it will work in preview.

# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
