### PR TITLE
fix: STOP-955 handling open URL based on domain name

### DIFF
--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.4",
-    "@stoplight/elements-core": "^8.4.2",
+    "@stoplight/elements-core": "^8.4.3",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.4",
-    "@stoplight/elements-core": "^8.4.3",
+    "@stoplight/elements-core": "^8.4.2",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -130,13 +130,22 @@ const externalRegex = new RegExp('^(?:[a-z]+:)?//', 'i');
 const LinkComponent: CustomComponentMapping['a'] = ({ children, href, title }) => {
   const ctx = React.useContext(NodeLinkContext);
 
-  if (href && externalRegex.test(href)) {
-    // Open external URL in a new tab
-    return (
-      <a href={href} target="_blank" rel="noreferrer" title={title ? title : undefined}>
-        {children}
-      </a>
-    );
+  try {
+    if (href && externalRegex.test(href)) {
+      const baseURL = window.location.host;
+      const hrefURL = new URL(href).host;
+
+      if (baseURL === hrefURL) {
+        // Open URL in same tab if domain match
+        return (
+          <a href={href} rel="noreferrer" title={title ? title : undefined}>
+            {children}
+          </a>
+        );
+      }
+    }
+  } catch (error) {
+    console.error(error);
   }
 
   if (href && ctx) {
@@ -166,7 +175,11 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href, title }) =
     }
   }
 
-  return <a href={href}>{children}</a>;
+  return (
+    <a href={href} target="_blank">
+      {children}
+    </a>
+  );
 };
 
 function getBundledUrl(url: string | undefined) {

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -176,7 +176,7 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href, title }) =
   }
 
   return (
-    <a href={href} target="_blank">
+    <a href={href} target="_blank" rel="noreferrer">
       {children}
     </a>
   );

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -144,7 +144,7 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href, title }) =
         );
       }
       return (
-        <a href={href} target="_blank" rel="noreferrer">
+        <a href={href} target="_blank" rel="noreferrer" title={title ? title : undefined}>
           {children}
         </a>
       );

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -138,11 +138,16 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href, title }) =
       if (baseURL === hrefURL) {
         // Open URL in same tab if domain match
         return (
-          <a href={href} rel="noreferrer" title={title ? title : undefined}>
+          <a href={href} title={title ? title : undefined}>
             {children}
           </a>
         );
       }
+      return (
+        <a href={href} target="_blank" rel="noreferrer">
+          {children}
+        </a>
+      );
     }
   } catch (error) {
     console.error(error);
@@ -175,11 +180,7 @@ const LinkComponent: CustomComponentMapping['a'] = ({ children, href, title }) =
     }
   }
 
-  return (
-    <a href={href} target="_blank" rel="noreferrer">
-      {children}
-    </a>
-  );
+  return <a href={href}>{children}</a>;
 };
 
 function getBundledUrl(url: string | undefined) {


### PR DESCRIPTION
## Addressed
[STOP-955](https://smartbear.atlassian.net/browse/STOP-955)

## Changes
Handled URL based on domain matching

## Testing
Have checked jest and manual testing.

[STOP-955]: https://smartbear.atlassian.net/browse/STOP-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ