### PR TITLE
fix: internal schema apprears as object on logout

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.4.2",
+  "version": "8.4.3",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.4.4",
+  "version": "8.4.3",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.4.5",
+  "version": "8.4.6",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.4.3",
+  "version": "8.4.4",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/HttpOperation.tsx
@@ -159,13 +159,13 @@ function MethodPathInner({ method, path, chosenServerUrl }: MethodPathProps & { 
 
   const pathElem = (
     <Flex overflowX="hidden" fontSize="lg" userSelect="all">
-      <Box dir="rtl" textOverflow="truncate" overflowX="hidden">
-        <Box as="span" color="muted" dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
+      <Box dir="rtl" color="muted" textOverflow="truncate" overflowX="hidden">
+        <Box as="span" dir="ltr" style={{ unicodeBidi: 'bidi-override' }}>
           {chosenServerUrl}
         </Box>
-        <Box as="span" fontWeight="semibold" flex={1}>
-          {path}
-        </Box>
+      </Box>
+      <Box fontWeight="semibold" flex={1}>
+        {path}
       </Box>
     </Flex>
   );

--- a/packages/elements-core/src/utils/ref-resolving/resolvedObject.test.ts
+++ b/packages/elements-core/src/utils/ref-resolving/resolvedObject.test.ts
@@ -237,6 +237,7 @@ describe('createResolvedObject', () => {
     expect(resolvedObject).toEqual(originalObject);
   });
 
+  // If the schema is internal, the object contains 'x-sl-error-message' on logout.
   it('removes object if contains an error for oneOf', () => {
     const originalObject = {
       oneOf: [
@@ -286,7 +287,7 @@ describe('createResolvedObject', () => {
     expect(resolvedObject).toEqual(filteredObject);
   });
 
-  it('show the error if all object contains an error for anyOf', () => {
+  it('show the error if all schemas are internal for anyOf', () => {
     const originalObject = {
       anyOf: [
         [
@@ -347,7 +348,7 @@ describe('createResolvedObject', () => {
     };
     expect(resolvedObject).toEqual(filteredObject);
   });
-  it('show the error if all object contains an error for oneOf', () => {
+  it('show the error if all schemas are internal for oneOf', () => {
     const originalObject = {
       oneOf: [
         [

--- a/packages/elements-core/src/utils/ref-resolving/resolvedObject.test.ts
+++ b/packages/elements-core/src/utils/ref-resolving/resolvedObject.test.ts
@@ -236,4 +236,53 @@ describe('createResolvedObject', () => {
 
     expect(resolvedObject).toEqual(originalObject);
   });
+
+  it('removes object if contains an error for oneOf', () => {
+    const originalObject = {
+      oneOf: [
+        { $ref: '#/__bundled__/0mui9s02880hl', 'x-stoplight': { id: '19c178fc05d4a' } },
+        {
+          'x-sl-error-message': 'You do not have permission to view this reference',
+          'x-stoplight': { 'error-message': 'You do not have permission to view this reference', id: 'nezai0hyj4yak' },
+        },
+        { $ref: '#/__bundled__/iq2mwk8jvthd2', 'x-stoplight': { id: 'ovj32wmpxpg7p' } },
+      ],
+      'x-stoplight': { id: 'b73ff5df9864f' },
+    };
+
+    const resolvedObject = getOriginalObject(originalObject);
+    const filteredObject = {
+      oneOf: [
+        { $ref: '#/__bundled__/0mui9s02880hl', 'x-stoplight': { id: '19c178fc05d4a' } },
+        { $ref: '#/__bundled__/iq2mwk8jvthd2', 'x-stoplight': { id: 'ovj32wmpxpg7p' } },
+      ],
+      'x-stoplight': { id: 'b73ff5df9864f' },
+    };
+
+    expect(resolvedObject).toEqual(filteredObject);
+  });
+
+  it('removes object if contains an error for anyeOf', () => {
+    const originalObject = {
+      anyOf: [
+        { $ref: '#/__bundled__/0mui9s02880hl', 'x-stoplight': { id: '19c178fc05d4a' } },
+        {
+          'x-sl-error-message': 'You do not have permission to view this reference',
+          'x-stoplight': { 'error-message': 'You do not have permission to view this reference', id: 'nezai0hyj4yak' },
+        },
+        { $ref: '#/__bundled__/iq2mwk8jvthd2', 'x-stoplight': { id: 'ovj32wmpxpg7p' } },
+      ],
+      'x-stoplight': { id: 'b73ff5df9864f' },
+    };
+
+    const resolvedObject = getOriginalObject(originalObject);
+    const filteredObject = {
+      anyOf: [
+        { $ref: '#/__bundled__/0mui9s02880hl', 'x-stoplight': { id: '19c178fc05d4a' } },
+        { $ref: '#/__bundled__/iq2mwk8jvthd2', 'x-stoplight': { id: 'ovj32wmpxpg7p' } },
+      ],
+      'x-stoplight': { id: 'b73ff5df9864f' },
+    };
+    expect(resolvedObject).toEqual(filteredObject);
+  });
 });

--- a/packages/elements-core/src/utils/ref-resolving/resolvedObject.test.ts
+++ b/packages/elements-core/src/utils/ref-resolving/resolvedObject.test.ts
@@ -251,7 +251,6 @@ describe('createResolvedObject', () => {
       'x-stoplight': { id: 'b73ff5df9864f' },
     };
 
-    const resolvedObject = getOriginalObject(originalObject);
     const filteredObject = {
       oneOf: [
         { $ref: '#/__bundled__/0mui9s02880hl', 'x-stoplight': { id: '19c178fc05d4a' } },
@@ -259,6 +258,7 @@ describe('createResolvedObject', () => {
       ],
       'x-stoplight': { id: 'b73ff5df9864f' },
     };
+    const resolvedObject = getOriginalObject(originalObject);
 
     expect(resolvedObject).toEqual(filteredObject);
   });
@@ -276,7 +276,6 @@ describe('createResolvedObject', () => {
       'x-stoplight': { id: 'b73ff5df9864f' },
     };
 
-    const resolvedObject = getOriginalObject(originalObject);
     const filteredObject = {
       anyOf: [
         { $ref: '#/__bundled__/0mui9s02880hl', 'x-stoplight': { id: '19c178fc05d4a' } },
@@ -284,6 +283,8 @@ describe('createResolvedObject', () => {
       ],
       'x-stoplight': { id: 'b73ff5df9864f' },
     };
+    const resolvedObject = getOriginalObject(originalObject);
+
     expect(resolvedObject).toEqual(filteredObject);
   });
 
@@ -317,7 +318,6 @@ describe('createResolvedObject', () => {
       'x-stoplight': { id: 'b73ff5df9864f' },
     };
 
-    const resolvedObject = getOriginalObject(originalObject);
     const filteredObject = {
       anyOf: [
         [
@@ -346,6 +346,8 @@ describe('createResolvedObject', () => {
       ],
       'x-stoplight': { id: 'b73ff5df9864f' },
     };
+    const resolvedObject = getOriginalObject(originalObject);
+
     expect(resolvedObject).toEqual(filteredObject);
   });
   it('show the error if all schemas are internal for oneOf', () => {
@@ -378,7 +380,6 @@ describe('createResolvedObject', () => {
       'x-stoplight': { id: 'b73ff5df9864f' },
     };
 
-    const resolvedObject = getOriginalObject(originalObject);
     const filteredObject = {
       oneOf: [
         [
@@ -407,6 +408,8 @@ describe('createResolvedObject', () => {
       ],
       'x-stoplight': { id: 'b73ff5df9864f' },
     };
+    const resolvedObject = getOriginalObject(originalObject);
+
     expect(resolvedObject).toEqual(filteredObject);
   });
 });

--- a/packages/elements-core/src/utils/ref-resolving/resolvedObject.test.ts
+++ b/packages/elements-core/src/utils/ref-resolving/resolvedObject.test.ts
@@ -285,4 +285,127 @@ describe('createResolvedObject', () => {
     };
     expect(resolvedObject).toEqual(filteredObject);
   });
+
+  it('show the error if all object contains an error for anyOf', () => {
+    const originalObject = {
+      anyOf: [
+        [
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+        ],
+      ],
+      'x-stoplight': { id: 'b73ff5df9864f' },
+    };
+
+    const resolvedObject = getOriginalObject(originalObject);
+    const filteredObject = {
+      anyOf: [
+        [
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+        ],
+      ],
+      'x-stoplight': { id: 'b73ff5df9864f' },
+    };
+    expect(resolvedObject).toEqual(filteredObject);
+  });
+  it('show the error if all object contains an error for oneOf', () => {
+    const originalObject = {
+      oneOf: [
+        [
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+        ],
+      ],
+      'x-stoplight': { id: 'b73ff5df9864f' },
+    };
+
+    const resolvedObject = getOriginalObject(originalObject);
+    const filteredObject = {
+      oneOf: [
+        [
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+          {
+            'x-sl-error-message': 'You do not have permission to view this reference',
+            'x-stoplight': {
+              'error-message': 'You do not have permission to view this reference',
+              id: 'nezai0hyj4yak',
+            },
+          },
+        ],
+      ],
+      'x-stoplight': { id: 'b73ff5df9864f' },
+    };
+    expect(resolvedObject).toEqual(filteredObject);
+  });
 });

--- a/packages/elements-core/src/utils/ref-resolving/resolvedObject.ts
+++ b/packages/elements-core/src/utils/ref-resolving/resolvedObject.ts
@@ -78,7 +78,30 @@ export const isResolvedObjectProxy = (someObject: object): boolean => {
 };
 
 export const getOriginalObject = (resolvedObject: object): object => {
-  return (resolvedObject as Record<symbol, object>)[originalObjectSymbol] || resolvedObject;
+  const originalObject: any = (resolvedObject as Record<symbol, object>)[originalObjectSymbol] || resolvedObject;
+  if (!originalObject) {
+    return resolvedObject;
+  }
+
+  const hasAllSchemaErrors = (array: any[]) => {
+    return array.every(item => item['x-sl-error-message'] !== undefined);
+  };
+
+  if (originalObject.anyOf) {
+    if (hasAllSchemaErrors(originalObject.anyOf)) {
+      return { ...originalObject, anyOf: [originalObject.anyOf] };
+    }
+    const filteredArray = originalObject.anyOf.filter((item: { [x: string]: any }) => !item['x-sl-error-message']);
+    return { ...originalObject, anyOf: filteredArray };
+  } else if (originalObject.oneOf) {
+    if (hasAllSchemaErrors(originalObject.oneOf)) {
+      return { ...originalObject, oneOf: [originalObject.oneOf] };
+    }
+    const filteredArray = originalObject.oneOf.filter((item: { [x: string]: any }) => !item['x-sl-error-message']);
+    return { ...originalObject, oneOf: filteredArray };
+  }
+
+  return originalObject;
 };
 
 export const isReference = hasRef;

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.4",
-    "@stoplight/elements-core": "^8.4.2",
+    "@stoplight/elements-core": "^8.4.3",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.4.5",
+  "version": "2.4.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.4",
-    "@stoplight/elements-core": "^8.4.5",
+    "@stoplight/elements-core": "^8.4.6",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.4.4",
+  "version": "8.4.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.4.2",
+  "version": "8.4.3",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -63,7 +63,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "^8.4.2",
+    "@stoplight/elements-core": "^8.4.3",
     "@stoplight/http-spec": "^7.1.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.53.4",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.4.3",
+  "version": "8.4.4",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.4.5",
+  "version": "8.4.6",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -63,7 +63,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "^8.4.5",
+    "@stoplight/elements-core": "^8.4.6",
     "@stoplight/http-spec": "^7.1.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.53.4",


### PR DESCRIPTION
[STOP-1027](https://smartbear.atlassian.net/browse/STOP-1027)

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

Previously, if not logged in, the schema which is marked internal showing up in dropdown as an empty 'object' for oneOf/anyOf in public docs.

### Before 

<img width="324" alt="image (13)" src="https://github.com/user-attachments/assets/01bb4bcc-2bc9-4af8-b1d2-aec5dc0dcde7">
<img width="324" height="496" alt="image (14)" src="https://github.com/user-attachments/assets/0d1d48b2-37c3-4443-88d2-931ea1cec7ec">

### After 

<img width="292" alt="image (15)" src="https://github.com/user-attachments/assets/283a1e8a-c84f-41ee-a9dd-02aafa8d4f99">
<img width="292" height="420"  alt="image (16)" src="https://github.com/user-attachments/assets/56d0803e-3426-47be-ba64-32bfa196d900">


In case of every schema is internal in the list it will display the error message.

<img width="414" alt="image (18)" src="https://github.com/user-attachments/assets/26742667-5489-4688-890b-7f32e9e35263">

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)


[STOP-1027]: https://smartbear.atlassian.net/browse/STOP-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ