### PR TITLE
Relabel "Query Parameters" to "Query String Parameters"

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpOperation/Request.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Request.tsx
@@ -63,7 +63,7 @@ export const Request: React.FunctionComponent<IRequestProps> = ({
 
       {queryParams.length > 0 && (
         <VStack spacing={5}>
-          <SectionSubtitle title="Query Parameters" />
+          <SectionSubtitle title="Query String Parameters" />
           <Parameters parameterType="query" parameters={queryParams} />
         </VStack>
       )}


### PR DESCRIPTION
# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

<!--

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)

-->

---

Hi, I noticed that your section label says "Query Parameters". However, it seems more accurate to refer to this as "Query String Parameters". I realize the OpenAPI spec sometimes refers to the parameter object location as "query", so from that perspective, there is a thing called "query parameter". However, the audience for documentation shown in Elements is more broad than that, and so being more clear that these parameters should be placed in the _query string_ seems useful.