### PR TITLE
FIX: Do not render undefined when license has not been defined

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.tsx
@@ -31,7 +31,7 @@ export const AdditionalInfo: React.FC<AdditionalInfoProps> = ({ id, termsOfServi
       ? `[${license.name}](${licenseUrl})`
       : license?.identifier && licenseUrl
       ? `[${license?.identifier}](${licenseUrl})`
-      : undefined;
+      : '';
   const tosLink = termsOfService ? `[Terms of Service](${termsOfService})` : '';
 
   return contactLink || licenseLink || tosLink ? (


### PR DESCRIPTION

<img width="744" alt="image" src="https://github.com/user-attachments/assets/a48ae15d-d7e7-4be9-95b6-7f88047f8c22">


Currently renders undefined if no license has been provided
