### PR TITLE
Fix license URL vs identifier precedence issue in AdditionalInfo component

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.stories.ts
+++ b/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.stories.ts
@@ -10,8 +10,9 @@ const meta: Meta<typeof AdditionalInfo> = {
 export default meta;
 type Story = StoryObj<typeof AdditionalInfo>;
 
-export const LicenseNameAndURL: Story = {
-  name: 'License Name with URL',
+// Story when only the license URL is provided
+export const LicenseWithOnlyURL: Story = {
+  name: 'License with only URL',
   args: {
     id: 'id',
     license: {
@@ -21,8 +22,9 @@ export const LicenseNameAndURL: Story = {
   },
 };
 
-export const LicenseNameAndIdentifier: Story = {
-  name: 'License Name and Identifier',
+// Story when only the license identifier is provided
+export const LicenseWithOnlyIdentifier: Story = {
+  name: 'License with only Identifier',
   args: {
     id: 'id',
     license: {
@@ -32,8 +34,9 @@ export const LicenseNameAndIdentifier: Story = {
   },
 };
 
-export const LicenseIdentifierAndNameAndUrl: Story = {
-  name: 'License Identifier, Name and URL',
+// Story when both the license URL and identifier are provided (URL should take precedence)
+export const LicenseWithURLAndIdentifier: Story = {
+  name: 'License with URL and Identifier (URL takes precedence)',
   args: {
     id: 'id',
     license: {

--- a/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.tsx
@@ -24,8 +24,17 @@ export const AdditionalInfo: React.FC<AdditionalInfoProps> = ({ id, termsOfServi
       : '';
 
   //use spdx to look up url for license identifier if available
-  const licenseUrl =
-    license?.url || license?.identifier ? `https://spdx.org/licenses/${license?.identifier}.html` : undefined;
+  // The licenseUrl is determined based on the mutual exclusivity of the `url` and `identifier` fields.
+  // If a `license.url` is provided, it takes precedence over the `license.identifier`.
+  // This is because the OpenAPI specification defines `url` and `identifier` as mutually exclusive fields,
+  // meaning you should use either one or the other, but not both. If both are provided, the `url` should be used.
+  // See: https://spec.openapis.org/oas/latest.html#license-object
+  const licenseUrl = license?.url
+    ? license?.url
+    : license?.identifier
+    ? `https://spdx.org/licenses/${license?.identifier}.html`
+    : undefined;
+  
   const licenseLink =
     license?.name && licenseUrl
       ? `[${license.name}](${licenseUrl})`

--- a/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/AdditionalInfo.tsx
@@ -34,7 +34,7 @@ export const AdditionalInfo: React.FC<AdditionalInfoProps> = ({ id, termsOfServi
     : license?.identifier
     ? `https://spdx.org/licenses/${license?.identifier}.html`
     : undefined;
-  
+
   const licenseLink =
     license?.name && licenseUrl
       ? `[${license.name}](${licenseUrl})`

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
@@ -267,6 +267,39 @@ describe('HttpService', () => {
       expect(title).toBeInTheDocument();
     });
 
+    it('should render additional information with SPDX license identifier', () => {
+      const contact = {
+        name: 'Developer',
+        email: 'developer@stoplight.io',
+        url: 'https://stoplight.io/contact-us/',
+      };
+  
+      const license = {
+        name: 'MIT License',
+        identifier: 'MIT',
+      };
+  
+      render(
+        <AdditionalInfo id="a" contact={contact} license={license} termsOfService="https://stoplight.io/terms/" />,
+      );
+  
+      const licenseLink = screen.getByText('MIT License');
+      expect(licenseLink).toHaveAttribute('href', 'https://spdx.org/licenses/MIT.html');
+    });
+  
+    it('should prefer license URL over SPDX identifier if both are provided', () => {
+      const license = {
+        name: 'MIT License',
+        url: 'https://opensource.org/licenses/MIT',
+        identifier: 'MIT',
+      };
+  
+      render(<AdditionalInfo id="a" license={license} />);
+  
+      const licenseLink = screen.getByText('MIT License');
+      expect(licenseLink).toHaveAttribute('href', 'https://opensource.org/licenses/MIT');
+    });
+
     it('should not render if contact, license, and terms of service do not exist', () => {
       render(<AdditionalInfo id="a" />);
 

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
@@ -273,29 +273,29 @@ describe('HttpService', () => {
         email: 'developer@stoplight.io',
         url: 'https://stoplight.io/contact-us/',
       };
-  
+
       const license = {
         name: 'MIT License',
         identifier: 'MIT',
       };
-  
+
       render(
         <AdditionalInfo id="a" contact={contact} license={license} termsOfService="https://stoplight.io/terms/" />,
       );
-  
+
       const licenseLink = screen.getByText('MIT License');
       expect(licenseLink).toHaveAttribute('href', 'https://spdx.org/licenses/MIT.html');
     });
-  
+
     it('should prefer license URL over SPDX identifier if both are provided', () => {
       const license = {
         name: 'MIT License',
         url: 'https://opensource.org/licenses/MIT',
         identifier: 'MIT',
       };
-  
+
       render(<AdditionalInfo id="a" license={license} />);
-  
+
       const licenseLink = screen.getByText('MIT License');
       expect(licenseLink).toHaveAttribute('href', 'https://opensource.org/licenses/MIT');
     });


### PR DESCRIPTION
### Description of the Issue

This PR addresses [the issue](https://github.com/stoplightio/elements/issues/2711) , where the `AdditionalInfo` component prioritizes the license identifier (SPDX) over the provided license URL. [According to the OpenAPI specification](https://spec.openapis.org/oas/latest.html#license-object), the url and identifier fields in the license object are **mutually exclusive**, meaning that if both are provided, the `license.url` should take precedence.

### Suggested Fix

I updated the logic in the `AdditionalInfo` component to make sure that **if a `license.url` is provided, it takes precedence over the `license.identifier`**. In the case where only an identifier is available, the component falls back to using the SPDX license URL.

Following is the change to the license URL logic:

```ts
const licenseUrl = license?.url
  ? license.url
  : license?.identifier
  ? `https://spdx.org/licenses/${license.identifier}.html`
  : undefined;
```

### Unit Tests

The existing test already covers rendering the component when only the `license.url` is present. So, I added unit tests to cover the other two cases:

- A test to check that the component uses the provided `license.url` when both `license.url` and `license.identifier` are present.
- A test to verify that the component generates an SPDX URL when only `license.identifier` is provided.



### Storybook Changes

I also updated the Storybook stories to reflect this change, making the story names more meaningful:

- **License with only URL**: shows the component behavior when only a `license.url` is provided.
- **License with only Identifier**: shows the component behavior when only a `license.identifier` is provided.
- **License with URL and Identifier (URL takes precedence)**: shows that the component correctly uses the `license.url` when both URL and identifier are provided, with the URL taking precedence.

### Testing

I followed the contribution guidelines and did the following tests:

- Ran unit tests using `yarn elements-core test`. (screenshot 1)
- Ran Storybook using `yarn elements-core storybook` to verify the visual output and behavior of the component. (screenshot 2)

Both tests passed, and the issue seems to be resolved. I tested using Node **v18.20.4** and **v20.18.0**.

<img width="767" alt="image" src="https://github.com/user-attachments/assets/6168cc27-bb69-4bec-b3a4-fb9916499f92">

![EB97BE4E-4D9E-4C94-87D6-33E1D49C7DC4](https://github.com/user-attachments/assets/3e7eb05c-48e7-4c58-b53c-0c7dda939045)
