### PR TITLE
chore(deps): Bump json-schema-viever from 4.16.1 to 4.16.3

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -62,7 +62,7 @@
     "@stoplight/json-schema-ref-parser": "^9.2.7",
     "@stoplight/json-schema-sampler": "0.3.0",
     "@stoplight/json-schema-tree": "^4.0.0",
-    "@stoplight/json-schema-viewer": "4.16.1",
+    "@stoplight/json-schema-viewer": "4.16.3",
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.4",
     "@stoplight/mosaic-code-editor": "^1.53.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6205,10 +6205,10 @@
     "@types/json-schema" "^7.0.7"
     magic-error "0.0.1"
 
-"@stoplight/json-schema-viewer@4.16.1":
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.16.1.tgz#2e1ddb33afae9e5c46257d9bf58bb61eec9f43ca"
-  integrity sha512-gQ1v9/Dj1VP43zERuZoFMOr7RQDBZlgfF7QFh+R0sadP6W30oYFJtD7y2PG2gIQDohKElVuPjhFUbVH/81MnSg==
+"@stoplight/json-schema-viewer@4.16.3":
+  version "4.16.3"
+  resolved "https://registry.yarnpkg.com/@stoplight/json-schema-viewer/-/json-schema-viewer-4.16.3.tgz#d9ccdea065eb869ad2a3b70be4f3976b8986794d"
+  integrity sha512-cQDxmyAkR3l8Pem1EuGMR+JKM8ePTSr/aqzJscp+hJ4R2geUNbdEleBHnJkZLLLfNr+PMlP+WiFO6GajCSxzUA==
   dependencies:
     "@stoplight/json" "^3.20.1"
     "@stoplight/json-schema-tree" "^4.0.0"


### PR DESCRIPTION
[STOP-231](https://smartbear.atlassian.net/browse/STOP-231)

Previously range was getting displayed without being defined in the schema for int64. solved this issue in json-schema-viewer.
 
In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)


[STOP-231]: https://smartbear.atlassian.net/browse/STOP-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ