### PR TITLE
fix: Ref added under anyOf/oneOf/allOf remove the model description -STOP-95

### DIFF
--- a/examples/react-cra/package.json
+++ b/examples/react-cra/package.json
@@ -25,7 +25,8 @@
     "typescript": "^4.3.5"
   },
   "resolutions": {
-    "@babel/core": "^7.16.0"
+    "@babel/core": "^7.16.0",
+    "@types/react": "17.0.11"
   },
   "browserslist": {
     "production": [

--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
@@ -274,9 +274,9 @@ describe('Model', () => {
     });
     it('CombineSchema must have description', () => {
       render(<Model data={model_data} {...props} />);
-      const description = screen.queryByRole('textbox');
+      const elem = screen.getAllByText(/description from allOf Operator/);
 
-      expect(description).toBeInTheDocument();
+      expect(elem[0]).toBeInTheDocument();
     });
   });
 });

--- a/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
@@ -274,9 +274,9 @@ describe('Model', () => {
     });
     it('CombineSchema must have description', () => {
       render(<Model data={model_data} {...props} />);
-      const elem = screen.getAllByText(/description from allOf Operator/);
+      const elem = screen.queryByText(`description from allOf Operator`);
 
-      expect(elem[0]).toBeInTheDocument();
+      expect(elem).toBeInTheDocument();
     });
   });
 });

--- a/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
@@ -31,6 +31,54 @@ const exampleStringSchema: JSONSchema7 = {
   description: 'example schema description that should only show once :)',
 };
 
+const model_data: JSONSchema7 = {
+  title: 'operator_reference',
+  description: 'description from allOf Operator',
+  allOf: [
+    {
+      $ref: '#/%24defs/bird',
+    },
+    {
+      $ref: '#/%24defs/animal',
+    },
+  ],
+
+  $defs: {
+    bird: {
+      type: 'object',
+      title: 'bird',
+      description: 'this is bird model',
+      properties: {
+        id: {
+          type: 'string',
+        },
+        bird_type: {
+          type: 'string',
+        },
+      },
+    },
+    animal: {
+      $ref: '#/%24defs/bird',
+      title: 'animal',
+      description: 'This is from Animal model',
+    },
+  },
+};
+const props = {
+  nodeTitle: 'operator_reference',
+  layoutOptions: {
+    hideExport: false,
+  },
+  exportProps: {
+    original: {
+      href: 'https://stoplight-local.com:8443/api/v1/projects/venkat/stop-95/nodes/models/operator_reference.yaml?fromExportButton=true&snapshotType=model',
+    },
+    bundled: {
+      href: 'https://api.stoplight-local.com:8443/projects/cHJqOjE2NA/branches/main/export/models/operator_reference.yaml',
+    },
+  },
+};
+
 describe('Model', () => {
   it('displays examples', async () => {
     const { container } = render(<Model data={exampleSchema} />);
@@ -236,6 +284,15 @@ describe('Model', () => {
       expect(screen.queryByText('description of valueA')).toBeInTheDocument();
 
       unmount();
+    });
+    it('CombineSchema must have description', () => {
+      render(<Model data={model_data} {...props} />);
+      // const elem = screen.getByRole('paragraph', { name: /This is from Operaror_reference/ });
+      const elem = screen.getAllByText(/description from allOf Operator/);
+
+      // expect('This is from Operaror_reference').toBeInTheDocument();
+      // expect(elem).toBeInTheDocument();
+      expect(elem[0]).toBeInTheDocument();
     });
   });
 });

--- a/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
@@ -26,11 +26,6 @@ const exampleSchema: JSONSchema7 = {
   },
 };
 
-const exampleStringSchema: JSONSchema7 = {
-  type: 'string',
-  description: 'example schema description that should only show once :)',
-};
-
 const model_data: JSONSchema7 = {
   title: 'operator_reference',
   description: 'description from allOf Operator',
@@ -183,13 +178,6 @@ describe('Model', () => {
     expect(textboxDescription).toHaveTextContent('example schema description');
   });
 
-  it('does not display description at top of doc for non-objects', async () => {
-    render(<Model data={exampleStringSchema} />);
-    const description = screen.queryByRole('textbox');
-
-    expect(description).not.toBeInTheDocument();
-  });
-
   describe('export button', () => {
     it('should render correctly', () => {
       const wrapper = render(
@@ -198,7 +186,6 @@ describe('Model', () => {
             data={exampleSchema}
             exportProps={{ original: { onPress: jest.fn() }, bundled: { onPress: jest.fn() } }}
           />
-          ,
         </MosaicProvider>,
       );
 
@@ -287,12 +274,9 @@ describe('Model', () => {
     });
     it('CombineSchema must have description', () => {
       render(<Model data={model_data} {...props} />);
-      // const elem = screen.getByRole('paragraph', { name: /This is from Operaror_reference/ });
-      const elem = screen.getAllByText(/description from allOf Operator/);
+      const description = screen.queryByRole('textbox');
 
-      // expect('This is from Operaror_reference').toBeInTheDocument();
-      // expect(elem).toBeInTheDocument();
-      expect(elem[0]).toBeInTheDocument();
+      expect(description).toBeInTheDocument();
     });
   });
 });

--- a/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.spec.tsx
@@ -273,10 +273,8 @@ describe('Model', () => {
       unmount();
     });
     it('CombineSchema must have description', () => {
-      render(<Model data={model_data} {...props} />);
-      const elem = screen.queryByText(`description from allOf Operator`);
-
-      expect(elem).toBeInTheDocument();
+      const { container } = render(<Model data={model_data} {...props} />);
+      expect(container).toHaveTextContent(`description from allOf Operator`);
     });
   });
 });

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -71,7 +71,7 @@ const ModelComponent: React.FC<ModelProps> = ({
   const descriptionChanged = nodeHasChanged?.({ nodeId, attr: 'description' });
   const description = (
     <VStack spacing={10}>
-      {data.description && data.type === 'object' && (
+      {data.description && (
         <Box pos="relative">
           <MarkdownViewer role="textbox" markdown={data.description} />
           <NodeAnnotation change={descriptionChanged} />

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.4",
-    "@stoplight/elements-core": "^8.5.0",
+    "@stoplight/elements-core": "^8.5.1",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -63,7 +63,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "^8.5.0",
+    "@stoplight/elements-core": "^8.5.1",
     "@stoplight/http-spec": "^7.1.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.53.4",


### PR DESCRIPTION
[STOP-95](https://smartbear.atlassian.net/browse/STOP-95)

In general, make sure you have: (check the boxes to acknowledge you've followed this template)
This PR solves the issue getting if the first property of a model is an anyOf/oneOf/allOf and a reference is added under it then existing model description will disappear.

Before
<img width="635" alt="image" src="https://github.com/user-attachments/assets/cb5cc9f0-9875-47d0-95cd-8624c8a1a971">

After
<img width="626" alt="image" src="https://github.com/user-attachments/assets/b4df7da9-fa68-48e9-8dc4-f79a0af2cccf">

- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)


[STOP-95]: https://smartbear.atlassian.net/browse/STOP-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ