### PR TITLE
Add support for `x-tagGroups`

### DIFF
--- a/packages/elements/src/components/API/__tests__/utils.test.ts
+++ b/packages/elements/src/components/API/__tests__/utils.test.ts
@@ -1047,6 +1047,120 @@ describe.each([
         },
       ]);
     });
+
+    it('generates API ToC tree with x-tagGroups', () => {
+      const apiDocument: OpenAPIObject = {
+        openapi: '3.0.0',
+        info: {
+          title: 'some api',
+          version: '1.0.0',
+          description: 'some description',
+          'x-tagGroups': [
+            {
+              name: 'User Management',
+              tags: ['Users', 'Authentication'],
+            },
+            {
+              name: 'Product Catalog',
+              tags: ['Products', 'Categories'],
+            },
+          ],
+        },
+        paths: {
+          '/users': {
+            get: {
+              tags: ['Users'],
+            },
+          },
+          '/products': {
+            get: {
+              tags: ['Products'],
+            },
+          },
+          '/auth/login': {
+            post: {
+              tags: ['Authentication'],
+            },
+          },
+          '/categories': {
+            get: {
+              tags: ['Categories'],
+            },
+          },
+        },
+      };
+
+      expect(computeAPITree(transformOasToServiceNode(apiDocument)!)).toEqual([
+        {
+          id: '/',
+          meta: '',
+          slug: '/',
+          title: 'Overview',
+          type: 'overview',
+        },
+        {
+          title: 'Endpoints',
+        },
+        {
+          title: 'User Management',
+        },
+        {
+          title: 'Users',
+          items: [
+            {
+              id: '/paths/users/get',
+              meta: 'get',
+              slug: '/paths/users/get',
+              title: '/users',
+              type: NodeType.HttpOperation,
+            },
+          ],
+          itemsType: NodeType.HttpOperation,
+        },
+        {
+          title: 'Authentication',
+          items: [
+            {
+              id: '/paths/auth-login/post',
+              meta: 'post',
+              slug: '/paths/auth-login/post',
+              title: '/auth/login',
+              type: NodeType.HttpOperation,
+            },
+          ],
+          itemsType: NodeType.HttpOperation,
+        },
+        {
+          title: 'Product Catalog',
+        },
+        {
+          title: 'Products',
+          items: [
+            {
+              id: '/paths/products/get',
+              meta: 'get',
+              slug: '/paths/products/get',
+              title: '/products',
+              type: NodeType.HttpOperation,
+            },
+          ],
+          itemsType: NodeType.HttpOperation,
+        },
+        {
+          title: 'Categories',
+          items: [
+            {
+              id: '/paths/categories/get',
+              meta: 'get',
+              slug: '/paths/categories/get',
+              title: '/categories',
+              type: NodeType.HttpOperation,
+            },
+          ],
+          itemsType: NodeType.HttpOperation,
+        },
+      ]);
+    });
   });
 });
 

--- a/packages/elements/src/containers/API.stories.tsx
+++ b/packages/elements/src/containers/API.stories.tsx
@@ -115,3 +115,45 @@ WithExtensionRenderer.args = {
   apiDescriptionDocument: zoomApiYaml,
 };
 WithExtensionRenderer.storyName = 'With Extension Renderer';
+
+export const TagGroupingDemo = Template.bind({});
+TagGroupingDemo.args = {
+  apiDescriptionDocument: `
+    openapi: 3.0.0
+    info:
+      title: Tag Grouping Demo API
+      version: 1.0.0
+      x-tagGroups:
+        - name: User Management
+          tags: ["Users", "Authentication"]
+        - name: Product Catalog
+          tags: ["Products", "Categories"]
+    paths:
+      /users:
+        get:
+          summary: Get all users
+          tags: ["Users"]
+      /users/{id}:
+        get:
+          summary: Get user by ID
+          tags: ["Users"]
+      /products:
+        get:
+          summary: Get all products
+          tags: ["Products"]
+      /products/{id}:
+        get:
+          summary: Get product by ID
+          tags: ["Products"]
+      /auth/login:
+        post:
+          summary: User login
+          tags: ["Authentication"]
+      /categories:
+        get:
+          summary: Get all categories
+          tags: ["Categories"]
+  `,
+  layout: 'sidebar',
+};
+TagGroupingDemo.storyName = 'Tag Grouping Demo';

--- a/packages/elements/src/web-components/__stories__/Api.stories.tsx
+++ b/packages/elements/src/web-components/__stories__/Api.stories.tsx
@@ -61,3 +61,131 @@ APIWithJSONProvidedDirectly.args = {
   apiDescriptionDocument: JSON.stringify(parse(zoomApiYaml), null, '  '),
 };
 APIWithJSONProvidedDirectly.storyName = 'API With JSON Provided Directly';
+
+// Tag Groups
+export const TagGroups = Template.bind({});
+TagGroups.args = {
+  apiDescriptionDocument: JSON.stringify({
+    openapi: '3.0.0',
+    info: {
+      title: 'Tag Groups',
+      version: '1.0.0',
+      description: 'An example API with x-tagGroups',
+      'x-tagGroups': [
+        {
+          name: 'User',
+          tags: ['User'],
+        },
+        {
+          name: 'Admin',
+          tags: ['Admin'],
+        },
+      ],
+    },
+    paths: {
+      '/users': {
+        get: {
+          summary: 'Get all users',
+          tags: ['User'],
+          responses: {
+            '200': {
+              description: 'A list of users',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                        email: { type: 'string' },
+                      },
+                      required: ['id', 'name', 'email'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/users/{id}': {
+        get: {
+          summary: 'Get a user by ID',
+          tags: ['User'],
+          parameters: [
+            {
+              name: 'id',
+              in: 'path',
+              required: true,
+              schema: {
+                type: 'string',
+              },
+            },
+          ],
+          responses: {
+            '200': {
+              description: 'A user object',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      id: { type: 'string' },
+                      name: { type: 'string' },
+                      email: { type: 'string' },
+                    },
+                    required: ['id', 'name', 'email'],
+                  },
+                },
+              },
+            },
+            '404': {
+              description: 'User not found',
+            },
+          },
+        },
+      },
+      '/admin': {
+        get: {
+          summary: 'Get admin dashboard',
+          tags: ['Admin'],
+          responses: {
+            '200': {
+              description: 'Admin dashboard data',
+            },
+          },
+        },
+      },
+      '/admin/users': {
+        get: {
+          summary: 'Get all admin users',
+          tags: ['Admin'],
+          responses: {
+            '200': {
+              description: 'A list of admin users',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                        role: { type: 'string' },
+                      },
+                      required: ['id', 'name', 'role'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  }),
+};
+TagGroups.storyName = 'Tag Groups Example';


### PR DESCRIPTION
# Add Support for `x-tagGroups`

See: https://redocly.com/docs-legacy/api-reference-docs/specification-extensions/x-tag-groups

- Added sidebar support for x-tagGroups
- Updated react and web component stories
- Added unit test case to ensure tree layout is correct when `x-tagGroups` is defined.

Screenshot:
<img width="1727" alt="Screenshot 2025-06-27 at 02 26 12" src="https://github.com/user-attachments/assets/10ac1cda-caaf-4e4b-abd4-d842e64df3d7" />


- [x] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [x] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
