### PR TITLE
feat: render NodeVendorExtensions in the 'overview' page

### DIFF
--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.spec.tsx
@@ -10,6 +10,7 @@ import httpService from '../../../__fixtures__/services/petstore';
 import { httpServiceWithUnnamedServers } from '../../../__fixtures__/services/with-unnamed-servers';
 import { httpServiceWithUrlVariables } from '../../../__fixtures__/services/with-url-variables';
 import { httpServiceWithoutOrigin } from '../../../__fixtures__/services/without-origin';
+import { ElementsOptionsProvider } from '../../../context/Options';
 import { AdditionalInfo } from './AdditionalInfo';
 import { HttpService } from './index';
 import { SecuritySchemes } from './SecuritySchemes';
@@ -425,5 +426,19 @@ describe('useSplitUrl hook', () => {
       { kind: 'variable', value: '{username}' },
       { kind: 'static', value: '.stoplight.io{test' },
     ]);
+  });
+
+  it('HttpService renders NodeVendorExtensions', () => {
+    const wrapper = render(
+      <Router>
+        <MosaicProvider>
+          <ElementsOptionsProvider renderExtensionAddon={() => <div>Vendor Extensions</div>}>
+            <HttpService data={{ ...httpService, extensions: { ['x-test-extension']: 'test' } }} />
+          </ElementsOptionsProvider>
+        </MosaicProvider>
+      </Router>,
+    );
+
+    expect(wrapper.getByText('Vendor Extensions')).toBeInTheDocument();
   });
 });

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
@@ -11,6 +11,7 @@ import { MarkdownViewer } from '../../MarkdownViewer';
 import { PoweredByLink } from '../../PoweredByLink';
 import { DocsComponentProps } from '..';
 import { VersionBadge } from '../HttpOperation/Badges';
+import { NodeVendorExtensions } from '../NodeVendorExtensions';
 import { AdditionalInfo } from './AdditionalInfo';
 import { ExportButton } from './ExportButton';
 import { SecuritySchemes } from './SecuritySchemes';
@@ -91,6 +92,8 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(
             <NodeAnnotation change={descriptionChanged} />
           </Box>
         )}
+
+        <NodeVendorExtensions data={data} />
       </Box>
     );
   },


### PR DESCRIPTION
# What

This inserts a NodeVendorExtensions into the HttpService component, allowing one to render information based on extensions put on the root node.

# Why

We are working on replacing our Swagger UI with Elements. While we are extremely impressed with Elements, we wanted to put some extension information in our Overview page, but the HttpService never calls NodeVendorExtensions to allow this.

# Impact

This reuses existing flows, so the addons you pass to renderExtensionAddon will automatically get called if/when you add extensions to the root of your spec document. If none are set - which I expect the majority of users will have, NodeVendorExtensions doesn't render, keeping original behavior.


# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [X] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [X] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
