### PR TITLE
Stop 2417 hide button

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/Docs/HttpOperation/Body.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Body.tsx
@@ -51,10 +51,13 @@ export const Body = ({ body, onChange, isHttpWebhookOperation = false, disablePr
     const absolutePathsToHide: Array<{ path: string; required?: boolean }> = [];
     disablePropsConfig.forEach(configEntry => {
       const { location, paths } = configEntry;
-      paths.forEach(item => {
-        // Construct the full absolute path
+      paths.forEach((item: any) => {
         const fullPath = location === '#' ? item?.path : `${location}/${item.path}`;
-        absolutePathsToHide.push({ path: fullPath });
+        let object: any = { path: fullPath };
+        if (item.hasOwnProperty('required')) {
+          object = { ...object, required: item?.required };
+        }
+        absolutePathsToHide.push(object);
       });
     });
     return absolutePathsToHide;

--- a/packages/elements-core/src/components/Docs/HttpOperation/LazySchemaTreePreviewer.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/LazySchemaTreePreviewer.tsx
@@ -224,7 +224,7 @@ const LazySchemaTreePreviewer: React.FC<LazySchemaTreePreviewerProps> = ({
 
       if (resolvedItems && resolvedItems.type === 'object' && resolvedItems.properties) {
         for (const [key, child] of Object.entries(resolvedItems.properties)) {
-          const childPath = `${itemsPath}/properties/${key}`;
+          const childPath = `${itemsPath}/${key}`;
           const childRequiredOverride = isRequiredOverride(childPath, hideData);
           const shouldHideChild = isPathHidden(childPath, hideData) && childRequiredOverride === undefined;
 

--- a/packages/elements-core/src/components/Docs/HttpOperation/LazySchemaTreePreviewer.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/LazySchemaTreePreviewer.tsx
@@ -346,7 +346,6 @@ const LazySchemaTreePreviewer: React.FC<LazySchemaTreePreviewerProps> = ({
                 <span className="sl-truncate sl-text-muted">
                   {schema?.type === 'object' ? schema?.title : schema?.type || root?.title}
                   {schema?.items && schema?.items?.title !== undefined ? ` [${schema?.items?.title}] ` : null}
-                  {subType ? `[${subType}]` : ''}
                 </span>
                 <span className="text-gray-500">{schema?.format !== undefined ? `<${schema?.format}>` : null}</span>
               </Box>

--- a/packages/elements-core/src/components/Docs/HttpOperation/LazySchemaTreePreviewer.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/LazySchemaTreePreviewer.tsx
@@ -51,7 +51,11 @@ function dereference(node: any, root: any, visited: WeakSet<object> = new WeakSe
 
   if (node.$ref || node['x-iata-$ref']) {
     let refPath = node.$ref || node['x-iata-$ref'];
-    refPath = refPath.replace('__bundled__', 'definitions');
+    if (refPath.includes('#/%24defs')) {
+      refPath = refPath.replace('#/%24defs', '$defs');
+    } else {
+      refPath = refPath.replace('__bundled__', 'definitions');
+    }
     if (visited.has(node))
       return { circular: true, $ref: refPath, title: node.title, type: 'any', description: node.description };
 
@@ -318,6 +322,10 @@ const LazySchemaTreePreviewer: React.FC<LazySchemaTreePreviewerProps> = ({
   const hideDataEntry = hideData.find(hideEntry => trimSlashes(hideEntry.path) === trimSlashes(path));
   if (hideDataEntry?.required === true || (hideDataEntry?.required === undefined && isRequired)) {
     showRequiredLabel = true;
+  }
+
+  if(schema?.$ref){
+    schema = dereference(schema, root);
   }
 
   return (

--- a/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
@@ -207,8 +207,14 @@ const Response = ({ response, onMediaTypeChange, disableProps, statusCode }: Res
     const configEntries = disableProps[statusCode] || [];
     const absolutePathsToHide: Array<{ path: string; required?: boolean }> = [];
     configEntries.forEach(({ location, paths }) => {
-      paths.forEach(item => {
-        absolutePathsToHide.push({ path: location === '#' ? item?.path : `${location}/${item.path}` });
+      paths.forEach((item: any) => {
+        const fullPath = location === '#' ? item?.path : `${location}/${item.path}`;
+        let object: any = { path: fullPath };
+        if (item.hasOwnProperty('required')) {
+          object = { ...object, required: item?.required };
+        }
+        absolutePathsToHide.push(object);
+        console.log('object::', object, item);
       });
     });
     return absolutePathsToHide;

--- a/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
+++ b/packages/elements-core/src/components/Docs/HttpService/HttpService.tsx
@@ -42,8 +42,9 @@ const HttpServiceComponent = React.memo<HttpServiceProps>(
               </Heading>
               <NodeAnnotation change={nameChanged} />
             </Box>
-
-            {exportProps && !layoutOptions?.hideExport && !isCompact && <ExportButton {...exportProps} />}
+            {localStorage.getItem('use_new_mask_workflow') === 'true'
+              ? null
+              : exportProps && !layoutOptions?.hideExport && !isCompact && <ExportButton {...exportProps} />}
           </Flex>
         )}
 

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -62,8 +62,9 @@ const ModelComponent: React.FC<ModelProps> = ({
         </HStack>
         <NodeAnnotation change={titleChanged} />
       </Box>
-
-      {exportProps && !layoutOptions?.hideExport && !isCompact && <ExportButton {...exportProps} />}
+      {localStorage.getItem('use_new_mask_workflow') === 'true'
+        ? null
+        : exportProps && !layoutOptions?.hideExport && !isCompact && <ExportButton {...exportProps} />}
     </Flex>
   );
 

--- a/packages/elements-core/src/components/Docs/Model/Model.tsx
+++ b/packages/elements-core/src/components/Docs/Model/Model.tsx
@@ -80,7 +80,11 @@ const ModelComponent: React.FC<ModelProps> = ({
         const { location, paths } = configEntry;
         paths.forEach((item: any) => {
           const fullPath = location === '#' ? item?.path : `${location}/${item.path}`;
-          absolutePathsToHide.push({ path: fullPath });
+          let object: any = { path: fullPath };
+          if (item.hasOwnProperty('required')) {
+            object = { ...object, required: item?.required };
+          }
+          absolutePathsToHide.push(object);
         });
       });
     }

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.4",
-    "@stoplight/elements-core": "~9.0.4",
+    "@stoplight/elements-core": "~9.0.5",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '3.0.2';
+export const appVersion = '3.0.4';

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '3.0.1';
+export const appVersion = '3.0.2';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Doc viewer mask data is not reflecting on page, when nests model properties are masked

[STOP-2697](https://smartbear.atlassian.net/browse/STOP-2697?atlOrigin=eyJpIjoiYmU3MzEzMjhhMmE2NGJmZmJiMDZkY2ZiZWUxMjUwMDQiLCJwIjoiaiJ9)
## Description
<!-- Describe your technical changes in detail. -->
Current Behavior: 
Doc viewer mask properties of design library  is not reflecting on page with new approach

Expected Behavior: 

## How Has This Been Tested?
It was tested locally by changing mask properties assigned at request, responses and models from studio editor.
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->


[STOP-2820]: https://smartbear.atlassian.net/browse/STOP-2820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[STOP-2697]: https://smartbear.atlassian.net/browse/STOP-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ