### PR TITLE
Stop 2417 hide docs

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/Docs/HttpOperation/LazySchemaTreePreviewer.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/LazySchemaTreePreviewer.tsx
@@ -249,7 +249,7 @@ const LazySchemaTreePreviewer: React.FC<LazySchemaTreePreviewerProps> = ({
 
       if (resolvedItems && resolvedItems.type === 'object' && resolvedItems.properties) {
         for (const [key, child] of Object.entries(resolvedItems.properties)) {
-          const childPath = `${itemsPath}/${key}`;
+          const childPath = `${itemsPath}/properties/${key}`;
           const childRequiredOverride = isRequiredOverride(childPath, hideData);
           const shouldHideChild = isPathHidden(childPath, hideData) && childRequiredOverride === undefined;
 

--- a/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
+++ b/packages/elements-core/src/components/Docs/HttpOperation/Responses.tsx
@@ -214,7 +214,6 @@ const Response = ({ response, onMediaTypeChange, disableProps, statusCode }: Res
           object = { ...object, required: item?.required };
         }
         absolutePathsToHide.push(object);
-        console.log('object::', object, item);
       });
     });
     return absolutePathsToHide;

--- a/packages/elements-core/src/components/Docs/TwoColumnLayout.tsx
+++ b/packages/elements-core/src/components/Docs/TwoColumnLayout.tsx
@@ -17,10 +17,14 @@ export const TwoColumnLayout = React.forwardRef<HTMLDivElement, TwoColumnLayoutP
           {left}
         </Box>
 
-        {right && (
-          <Box data-testid="two-column-right" ml={16} pos="relative" w="2/5" style={{ maxWidth: 500 }}>
-            {right}
-          </Box>
+       {localStorage.getItem('use_new_mask_workflow') === 'true' ? (
+          <></>
+        ) : (
+          right && (
+            <Box data-testid="two-column-right" ml={16} pos="relative" w="2/5" style={{ maxWidth: 500 }}>
+              {right}
+            </Box>
+          )
         )}
       </Flex>
     </VStack>

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.4",
-    "@stoplight/elements-core": "~9.0.5",
+    "@stoplight/elements-core": "~9.0.6",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

[STOP-2847](https://smartbear.atlassian.net/browse/STOP-2847)
[STOP-2847](https://smartbear.atlassian.net/browse/STOP-2847)
[STOP-2796](https://smartbear.atlassian.net/browse/STOP-2796)
[STOP-2859](https://smartbear.atlassian.net/browse/STOP-2859)

## Description
<!-- Describe your technical changes in detail. -->
Current Behavior: 
Mask properties of design library are not reflecting on Studio preview and doc viewer page with new approach
Masking not working at deep nested level for request, response and for local models.
Masking not working for array of objects
Required is not functioning 

Expected Behavior: 
Mask properties of design library must reflect on Studio preview and doc viewer page with new approach


[STOP-2847]: https://smartbear.atlassian.net/browse/STOP-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STOP-2847]: https://smartbear.atlassian.net/browse/STOP-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STOP-2796]: https://smartbear.atlassian.net/browse/STOP-2796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STOP-2859]: https://smartbear.atlassian.net/browse/STOP-2859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ