### PR TITLE
Fix lockfile-maintenance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: weekly_lockfile_maintenance.sh
+          command: weekly-lockfile-maintenance.sh
   release:
     docker:
       - image: cimg/node:18.20


### PR DESCRIPTION
The `lockfile-maintenance` task has been broken for some time e.g. see https://app.circleci.com/pipelines/github/stoplightio/elements/10065/workflows/297cd28c-c660-4d1f-87be-5837984512fc/jobs/46146

Either the command needs to be updated or the script renamed.
