### PR TITLE
TOC api call is handled for zero projectID

### DIFF
--- a/packages/elements-dev-portal/src/hooks/useGetTableOfContents.ts
+++ b/packages/elements-dev-portal/src/hooks/useGetTableOfContents.ts
@@ -10,6 +10,8 @@ export function useGetTableOfContents({ projectId, branchSlug }: { projectId: st
   return useQuery(
     [...devPortalCacheKeys.branchTOC(projectId, branchSlug ?? ''), platformUrl, isLoggedIn],
     () => getTableOfContents({ projectId, branchSlug, platformUrl, platformAuthToken }),
-    { enabled: projectId ? true : false },
+    // Here projectId cHJqOjA is an encoded value of zero,
+    // hence avoiding the graphql call for invalid project id
+    { enabled: projectId !== 'cHJqOjA' ? true : false },
   );
 }


### PR DESCRIPTION
# Elements Default PR Template
_table-of-contents_  API is getting called for projectID zero and it is showing 404 error in network tab.  We have added the check to skip it.
STOP-4045


In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
