### PR TITLE
STOP-4188 : Get node uri parts

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "9.0.11",
+  "version": "9.0.12",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.5",
-    "@stoplight/elements-core": "~9.0.11",
+    "@stoplight/elements-core": "~9.0.12",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
+++ b/packages/elements-dev-portal/src/components/NodeContent/NodeContent.tsx
@@ -227,6 +227,8 @@ export const getNodeUriParts = (uri: string): { fileUri: string; pointer: string
   if (!parts || parts.length === 1) {
     return { fileUri: '', pointer: parts[0] || '' };
   }
+
   const fileUri = `${parts[0] || ''}${parts[1] || ''}`;
+
   return { fileUri, pointer: parts[2] || '' };
 };

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "9.0.11",
+  "version": "9.0.12",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -63,7 +63,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~9.0.11",
+    "@stoplight/elements-core": "~9.0.12",
     "@stoplight/http-spec": "^7.1.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.53.5",


### PR DESCRIPTION
# Elements Default PR Template

- We have added fix for console error : can not read property of undefined length
- Added check for URI types
- Also add check for empty and undefined node parts and then check for length
- We have revert IATA related changes from elements-core in this PR