### PR TITLE
fix: Example response is not rendered with Elements when we use oneOf…

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "9.0.20",
+  "version": "9.0.21",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
@@ -1,7 +1,7 @@
 import * as Sampler from '@stoplight/json-schema-sampler';
 import { JSONSchema7 } from 'json-schema';
 
-import { generateExamplesFromJsonSchema } from './exampleGeneration';
+import { generateExampleFromMediaTypeContent, generateExamplesFromJsonSchema } from './exampleGeneration';
 
 const modelWithNoExamples: JSONSchema7 = require('../../__fixtures__/models/model-with-no-examples.json');
 
@@ -14,5 +14,87 @@ describe('generateExamplesFromJsonSchema', () => {
 
     const example = generateExamplesFromJsonSchema(modelWithNoExamples);
     expect(example).toEqual([{ label: '', data: `Example cannot be created for this schema\nError: ${errorMessage}` }]);
+  });
+
+  it('generates examples for schemas with oneOf', () => {
+    const schemaWithOneOf: JSONSchema7 = {
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            age: { type: 'number' },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            title: { type: 'string' },
+            description: { type: 'string' },
+          },
+        },
+      ],
+    };
+
+    const examples = generateExamplesFromJsonSchema(schemaWithOneOf);
+    expect(examples.length).toBeGreaterThan(0);
+    expect(examples[0].data).not.toBe('{}');
+    expect(examples[0].data).not.toBe('');
+  });
+
+  it('generates examples for schemas with anyOf', () => {
+    const schemaWithAnyOf: JSONSchema7 = {
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            username: { type: 'string' },
+            password: { type: 'string' },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            token: { type: 'string' },
+          },
+        },
+      ],
+    };
+
+    const examples = generateExamplesFromJsonSchema(schemaWithAnyOf);
+    expect(examples.length).toBeGreaterThan(0);
+    expect(examples[0].data).not.toBe('{}');
+    expect(examples[0].data).not.toBe('');
+  });
+});
+
+describe('generateExampleFromMediaTypeContent', () => {
+  it('generates examples for media type content with oneOf in schema', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        oneOf: [
+          {
+            type: 'object',
+            properties: {
+              id: { type: 'number' },
+              name: { type: 'string' },
+            },
+          },
+          {
+            type: 'object',
+            properties: {
+              code: { type: 'string' },
+              message: { type: 'string' },
+            },
+          },
+        ],
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    expect(example).not.toBe('{}');
+    expect(example).not.toBe('');
+    expect(example.length).toBeGreaterThan(2);
   });
 });

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
@@ -8,7 +8,7 @@ const modelWithNoExamples: JSONSchema7 = require('../../__fixtures__/models/mode
 describe('generateExamplesFromJsonSchema', () => {
   it('returns error message when example generation fails ', () => {
     const errorMessage = 'This is a mocked Error message';
-    jest.spyOn(Sampler, 'sample').mockImplementation(() => {
+    jest.spyOn(Sampler, 'sample').mockImplementationOnce(() => {
       throw Error(errorMessage);
     });
 
@@ -38,8 +38,11 @@ describe('generateExamplesFromJsonSchema', () => {
 
     const examples = generateExamplesFromJsonSchema(schemaWithOneOf);
     expect(examples.length).toBeGreaterThan(0);
-    expect(examples[0].data).not.toBe('{}');
-    expect(examples[0].data).not.toBe('');
+    expect(examples[0].data).not.toContain('Example cannot be created');
+
+    const parsed = JSON.parse(examples[0].data);
+    expect(parsed).toHaveProperty('name');
+    expect(parsed).toHaveProperty('age');
   });
 
   it('generates examples for schemas with anyOf', () => {
@@ -63,8 +66,11 @@ describe('generateExamplesFromJsonSchema', () => {
 
     const examples = generateExamplesFromJsonSchema(schemaWithAnyOf);
     expect(examples.length).toBeGreaterThan(0);
-    expect(examples[0].data).not.toBe('{}');
-    expect(examples[0].data).not.toBe('');
+    expect(examples[0].data).not.toContain('Example cannot be created');
+
+    const parsed = JSON.parse(examples[0].data);
+    expect(parsed).toHaveProperty('username');
+    expect(parsed).toHaveProperty('password');
   });
 });
 
@@ -93,8 +99,10 @@ describe('generateExampleFromMediaTypeContent', () => {
     };
 
     const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
-    expect(example).not.toBe('{}');
-    expect(example).not.toBe('');
-    expect(example.length).toBeGreaterThan(2);
+    expect(example).not.toContain('Example cannot be created');
+
+    const parsed = JSON.parse(example);
+    expect(parsed).toHaveProperty('id');
+    expect(parsed).toHaveProperty('name');
   });
 });

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
@@ -90,11 +90,10 @@ export const generateExampleFromMediaTypeContent = (
       );
     } else if (textRequestBodySchema) {
       let unwrappedSchema = getResolvedObject(textRequestBodySchema) as any;
-      const unwrappedDocument = document ? getResolvedObject(document) : document;
 
       unwrappedSchema = mergeOneOfAnyOf(unwrappedSchema);
 
-      const generated = Sampler.sample(unwrappedSchema, options, unwrappedDocument);
+      const generated = Sampler.sample(unwrappedSchema, options, document);
 
       return generated !== null ? safeStringify(generated, undefined, 2) ?? '' : '';
     }

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
@@ -5,10 +5,49 @@ import { JSONSchema7 } from 'json-schema';
 import React from 'react';
 
 import { useDocument } from '../../context/InlineRefResolver';
+import { getResolvedObject } from '../ref-resolving/resolvedObject';
 
 type Example = {
   label: string;
   data: string;
+};
+
+// Merges oneOf/anyOf with their first option because @stoplight/json-schema-sampler cannot handle them.
+const mergeOneOfAnyOf = (schema: any): any => {
+  if (!isPlainObject(schema)) {
+    return schema;
+  }
+
+  let result: any = { ...schema };
+
+  if (result.oneOf && result.oneOf.length > 0) {
+    const firstOption = result.oneOf[0];
+    const { oneOf, ...rest } = result;
+    result = { ...rest, ...firstOption };
+  } else if (result.anyOf && result.anyOf.length > 0) {
+    const firstOption = result.anyOf[0];
+    const { anyOf, ...rest } = result;
+    result = { ...rest, ...firstOption };
+  }
+
+  if (result.properties) {
+    result.properties = Object.fromEntries(
+      Object.entries(result.properties).map(([key, value]) => [key, mergeOneOfAnyOf(value)]),
+    );
+  }
+
+  if (result.items) {
+    result.items = mergeOneOfAnyOf(result.items);
+  }
+
+  if (result.allOf) {
+    result.allOf = result.allOf.map((item: any) => mergeOneOfAnyOf(item));
+  }
+
+  delete result.oneOf;
+  delete result.anyOf;
+
+  return result;
 };
 
 export type GenerateExampleFromMediaTypeContentOptions = Sampler.Options;
@@ -50,7 +89,13 @@ export const generateExampleFromMediaTypeContent = (
         ) ?? ''
       );
     } else if (textRequestBodySchema) {
-      const generated = Sampler.sample(textRequestBodySchema, options, document);
+      let unwrappedSchema = getResolvedObject(textRequestBodySchema) as any;
+      const unwrappedDocument = document ? getResolvedObject(document) : document;
+
+      unwrappedSchema = mergeOneOfAnyOf(unwrappedSchema);
+
+      const generated = Sampler.sample(unwrappedSchema, options, unwrappedDocument);
+
       return generated !== null ? safeStringify(generated, undefined, 2) ?? '' : '';
     }
   } catch (e) {
@@ -87,7 +132,10 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7 & { 'x-exampl
   }
 
   try {
-    const generated = Sampler.sample(schema, {
+    let resolvedSchema = getResolvedObject(schema);
+    resolvedSchema = mergeOneOfAnyOf(resolvedSchema);
+
+    const generated = Sampler.sample(resolvedSchema, {
       maxSampleDepth: 4,
       ticks: 6000,
     });

--- a/packages/elements-core/src/utils/ref-resolving/resolvedObject.ts
+++ b/packages/elements-core/src/utils/ref-resolving/resolvedObject.ts
@@ -77,6 +77,83 @@ export const isResolvedObjectProxy = (someObject: object): boolean => {
   return !!(someObject as Record<symbol, unknown>)[originalObjectSymbol];
 };
 
+// Resolves $refs by accessing properties through Proxy wrappers, ensuring nested references are resolved.
+export const getResolvedObject = (obj: any, cache = new WeakMap()): any => {
+  if (cache.has(obj)) {
+    return cache.get(obj);
+  }
+
+  if (!isPlainObject(obj) && !isArray(obj)) {
+    return obj;
+  }
+
+  if (isArray(obj)) {
+    const result = obj.map(item => getResolvedObject(item, cache));
+    cache.set(obj, result);
+    return result;
+  }
+
+  const result: any = {};
+  cache.set(obj, result);
+
+  for (const key in obj) {
+    if (!obj.hasOwnProperty(key)) continue;
+
+    const value = obj[key];
+
+    if (isArray(value)) {
+      result[key] = getResolvedObject(value, cache);
+    } else if (isPlainObject(value)) {
+      result[key] = getResolvedObject(value, cache);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Unwraps Proxy objects recursively, needed for oneOf/anyOf schemas with nested $refs.
+ */
+const deepUnwrapObject = (obj: any, cache = new WeakMap()): any => {
+  if (cache.has(obj)) {
+    return cache.get(obj);
+  }
+
+  const unwrapped = (obj as Record<symbol, object>)?.[originalObjectSymbol] || obj;
+
+  if (!isPlainObject(unwrapped)) {
+    return unwrapped;
+  }
+
+  const hasComposition =
+    unwrapped.hasOwnProperty('oneOf') || unwrapped.hasOwnProperty('anyOf') || unwrapped.hasOwnProperty('allOf');
+
+  if (!hasComposition && unwrapped === obj) {
+    return unwrapped;
+  }
+
+  const result: any = {};
+  cache.set(obj, result);
+
+  for (const key in unwrapped) {
+    if (!unwrapped.hasOwnProperty(key)) continue;
+
+    const value = (unwrapped as any)[key];
+
+    if (isArray(value)) {
+      result[key] = value.map(item => (isPlainObject(item) || isArray(item) ? deepUnwrapObject(item, cache) : item));
+    } else if (isPlainObject(value)) {
+      result[key] = deepUnwrapObject(value, cache);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+};
+
 export const getOriginalObject = (resolvedObject: object): object => {
   const originalObject: any = (resolvedObject as Record<symbol, object>)[originalObjectSymbol] || resolvedObject;
   if (!originalObject) {
@@ -87,21 +164,25 @@ export const getOriginalObject = (resolvedObject: object): object => {
     return array.every(item => item['x-sl-error-message'] !== undefined);
   };
 
-  if (originalObject.anyOf) {
-    if (hasAllSchemaErrors(originalObject.anyOf)) {
-      return { ...originalObject, anyOf: [originalObject.anyOf] };
+  // Deep unwrap the entire object tree
+  const deepUnwrapped = deepUnwrapObject(originalObject);
+
+  // Handle error filtering for anyOf/oneOf
+  if (deepUnwrapped.anyOf) {
+    if (hasAllSchemaErrors(deepUnwrapped.anyOf)) {
+      return { ...deepUnwrapped, anyOf: [deepUnwrapped.anyOf] };
     }
-    const filteredArray = originalObject.anyOf.filter((item: { [x: string]: any }) => !item['x-sl-error-message']);
-    return { ...originalObject, anyOf: filteredArray };
-  } else if (originalObject.oneOf) {
-    if (hasAllSchemaErrors(originalObject.oneOf)) {
-      return { ...originalObject, oneOf: [originalObject.oneOf] };
+    const filteredArray = deepUnwrapped.anyOf.filter((item: { [x: string]: any }) => !item['x-sl-error-message']);
+    return { ...deepUnwrapped, anyOf: filteredArray };
+  } else if (deepUnwrapped.oneOf) {
+    if (hasAllSchemaErrors(deepUnwrapped.oneOf)) {
+      return { ...deepUnwrapped, oneOf: [deepUnwrapped.oneOf] };
     }
-    const filteredArray = originalObject.oneOf.filter((item: { [x: string]: any }) => !item['x-sl-error-message']);
-    return { ...originalObject, oneOf: filteredArray };
+    const filteredArray = deepUnwrapped.oneOf.filter((item: { [x: string]: any }) => !item['x-sl-error-message']);
+    return { ...deepUnwrapped, oneOf: filteredArray };
   }
 
-  return originalObject;
+  return deepUnwrapped;
 };
 
 export const isReference = hasRef;

--- a/packages/elements-core/src/utils/ref-resolving/resolvedObject.ts
+++ b/packages/elements-core/src/utils/ref-resolving/resolvedObject.ts
@@ -79,17 +79,20 @@ export const isResolvedObjectProxy = (someObject: object): boolean => {
 
 // Resolves $refs by accessing properties through Proxy wrappers, ensuring nested references are resolved.
 export const getResolvedObject = (obj: any, cache = new WeakMap()): any => {
-  if (cache.has(obj)) {
-    return cache.get(obj);
-  }
-
   if (!isPlainObject(obj) && !isArray(obj)) {
     return obj;
   }
 
+  if (cache.has(obj)) {
+    return cache.get(obj);
+  }
+
   if (isArray(obj)) {
-    const result = obj.map(item => getResolvedObject(item, cache));
+    const result: any[] = [];
     cache.set(obj, result);
+    for (let i = 0; i < obj.length; i++) {
+      result[i] = getResolvedObject(obj[i], cache);
+    }
     return result;
   }
 
@@ -97,7 +100,7 @@ export const getResolvedObject = (obj: any, cache = new WeakMap()): any => {
   cache.set(obj, result);
 
   for (const key in obj) {
-    if (!obj.hasOwnProperty(key)) continue;
+    if (!Object.prototype.hasOwnProperty.call(obj, key)) continue;
 
     const value = obj[key];
 
@@ -115,18 +118,20 @@ export const getResolvedObject = (obj: any, cache = new WeakMap()): any => {
 
 // Unwraps Proxy objects recursively, needed for oneOf/anyOf schemas with nested $refs.
 const deepUnwrapObject = (obj: any, cache = new WeakMap()): any => {
-  if (cache.has(obj)) {
-    return cache.get(obj);
-  }
-
   const unwrapped = (obj as Record<symbol, object>)?.[originalObjectSymbol] || obj;
 
   if (!isPlainObject(unwrapped)) {
     return unwrapped;
   }
 
+  if (cache.has(obj)) {
+    return cache.get(obj);
+  }
+
   const hasComposition =
-    unwrapped.hasOwnProperty('oneOf') || unwrapped.hasOwnProperty('anyOf') || unwrapped.hasOwnProperty('allOf');
+    Object.prototype.hasOwnProperty.call(unwrapped, 'oneOf') ||
+    Object.prototype.hasOwnProperty.call(unwrapped, 'anyOf') ||
+    Object.prototype.hasOwnProperty.call(unwrapped, 'allOf');
 
   if (!hasComposition && unwrapped === obj) {
     return unwrapped;
@@ -136,7 +141,7 @@ const deepUnwrapObject = (obj: any, cache = new WeakMap()): any => {
   cache.set(obj, result);
 
   for (const key in unwrapped) {
-    if (!unwrapped.hasOwnProperty(key)) continue;
+    if (!Object.prototype.hasOwnProperty.call(unwrapped, key)) continue;
 
     const value = (unwrapped as any)[key];
 

--- a/packages/elements-core/src/utils/ref-resolving/resolvedObject.ts
+++ b/packages/elements-core/src/utils/ref-resolving/resolvedObject.ts
@@ -113,9 +113,7 @@ export const getResolvedObject = (obj: any, cache = new WeakMap()): any => {
   return result;
 };
 
-/**
- * Unwraps Proxy objects recursively, needed for oneOf/anyOf schemas with nested $refs.
- */
+// Unwraps Proxy objects recursively, needed for oneOf/anyOf schemas with nested $refs.
 const deepUnwrapObject = (obj: any, cache = new WeakMap()): any => {
   if (cache.has(obj)) {
     return cache.get(obj);
@@ -164,10 +162,8 @@ export const getOriginalObject = (resolvedObject: object): object => {
     return array.every(item => item['x-sl-error-message'] !== undefined);
   };
 
-  // Deep unwrap the entire object tree
   const deepUnwrapped = deepUnwrapObject(originalObject);
 
-  // Handle error filtering for anyOf/oneOf
   if (deepUnwrapped.anyOf) {
     if (hasAllSchemaErrors(deepUnwrapped.anyOf)) {
       return { ...deepUnwrapped, anyOf: [deepUnwrapped.anyOf] };

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -66,7 +66,7 @@
   "dependencies": {
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.5",
-    "@stoplight/elements-core": "~9.0.20",
+    "@stoplight/elements-core": "~9.0.21",
     "@stoplight/path": "^1.3.2",
     "@stoplight/types": "^14.0.0",
     "classnames": "^2.2.6",

--- a/packages/elements-dev-portal/src/version.ts
+++ b/packages/elements-dev-portal/src/version.ts
@@ -1,2 +1,2 @@
 // auto-updated during build
-export const appVersion = '3.0.16';
+export const appVersion = '3.0.21';

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "9.0.20",
+  "version": "9.0.21",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -63,7 +63,7 @@
     ]
   },
   "dependencies": {
-    "@stoplight/elements-core": "~9.0.20",
+    "@stoplight/elements-core": "~9.0.21",
     "@stoplight/http-spec": "^7.1.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.53.5",


### PR DESCRIPTION
… or anyOf keyword with multiple refs/properties (PROVCON-5069)

# Elements Default PR Template

In general, make sure you have: (check the boxes to acknowledge you've followed this template)

- [ ] Read [`CONTRIBUTING.md`](../CONTRIBUTING.md)

#### Other Available PR Templates:

- Release: https://github.com/stoplightio/elements/compare?template=release.md
  - [ ] [Read the release section of `CONTRIBUTING.md`](../CONTRIBUTING.md#releasing-elements)
