### PR TITLE
feat: add scarf tracking pixel to all README pages (OSS-1362)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,5 @@ If you would like to thank us for creating Elements, we ask that you [**buy the 
 [npm]: https://www.npmjs.com/package/@stoplight/elements
 [npm_image]: https://img.shields.io/npm/dw/@stoplight/elements?color=blue
 [stoplight_forest]: https://ecologi.com/stoplightinc
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=e0230c47-5810-4815-807b-15379323ff1b&page=README.md" />

--- a/packages/elements-core/README.md
+++ b/packages/elements-core/README.md
@@ -42,3 +42,5 @@ Licensed under the Apache 2.0 License, Copyright © 2020-present Stoplight.
 See [LICENSE](LICENSE) for more information.
 
 [stoplight]: https://stoplight.io/?utm_source=github&utm_medium=elements-core&utm_campaign=readme
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=82ad9f18-94ee-4fc6-8b1e-a2e5d1cd5cab&page=README.md" />

--- a/packages/elements-dev-portal/README.md
+++ b/packages/elements-dev-portal/README.md
@@ -42,3 +42,5 @@ Licensed under the Apache 2.0 License, Copyright © 2020-present Stoplight.
 See [LICENSE](LICENSE) for more information.
 
 [stoplight]: https://stoplight.io/?utm_source=github&utm_medium=elements-dev-portal&utm_campaign=readme
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=29891943-74f9-4ab6-9cb8-b10eb93abded&page=README.md" />

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -39,3 +39,5 @@ installs your npm packages, e.g., `SCARF_ANALYTICS=false npm install`.
 Licensed under the Apache 2.0 License, Copyright © 2020-present Stoplight.
 
 See [LICENSE](LICENSE) for more information.
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=b694b779-b187-40da-90ff-362f918454f5&page=README.md" />


### PR DESCRIPTION
This pull request adds tracking pixel images to the `README.md` files across the repository to enable analytics via Scarf. These images are included at the bottom of each README and are configured with a unique identifier for each package.
