### PR TITLE
Stop-6047-Fixed Example Data of Type Integer(int64,32) and Number(double/float)

### DIFF
--- a/packages/elements-core/package.json
+++ b/packages/elements-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-core",
-  "version": "9.0.24",
+  "version": "9.0.25",
   "sideEffects": [
     "web-components.min.js",
     "src/web-components/**",

--- a/packages/elements-core/src/components/TryIt/Response/Response.tsx
+++ b/packages/elements-core/src/components/TryIt/Response/Response.tsx
@@ -13,6 +13,7 @@ export interface ResponseState {
   bodyText?: string;
   contentType: string | null;
   blob?: Blob;
+  skipBodyParsing?: boolean;
 }
 
 export interface ErrorState {
@@ -86,7 +87,7 @@ export const TryItResponse: React.FC<{ response: ResponseState }> = ({ response 
             <ResponseCodeViewer
               language="json"
               value={
-                responseType && bodyFormat === 'preview'
+                responseType && bodyFormat === 'preview' && !response.skipBodyParsing
                   ? parseBody(response.bodyText, responseType)
                   : response.bodyText
               }

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -133,6 +133,66 @@ describe('TryIt', () => {
     expect(container).toHaveTextContent('awesome response, but hardly a json one');
   });
 
+  it('normalizes inferred numeric bounds in mocked JSON responses', async () => {
+    const operationWithNumericResponse: IHttpOperation = {
+      ...basicOperation,
+      responses: [
+        {
+          id: 'response-200',
+          code: '200',
+          contents: [
+            {
+              id: 'response-application-json',
+              mediaType: 'application/json',
+              schema: {
+                type: 'object',
+                properties: {
+                  age: {
+                    type: 'integer',
+                    format: 'int32',
+                    minimum: 0 - 2 ** 31,
+                    maximum: 2 ** 31 - 1,
+                    'x-stoplight': { explicitProperties: ['type', 'format'] },
+                  },
+                  price: {
+                    type: 'number',
+                    format: 'float',
+                    minimum: 0 - 2 ** 128,
+                    maximum: 2 ** 128 - 1,
+                    'x-stoplight': { explicitProperties: ['type', 'format'] },
+                  },
+                },
+              } as any,
+            },
+          ],
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValue(
+      new Response('{"age":-2147483648,"price":-3.402823669209385e+38}', {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { container } = render(
+      <TryItWithPersistence httpOperation={operationWithNumericResponse} mockUrl="https://mock-todos.stoplight.io" />,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: /server/i }));
+    userEvent.click(screen.getByRole('menuitemradio', { name: /mock server/i }));
+    clickSend();
+
+    await screen.findByText('Response');
+
+    expect(container).toHaveTextContent('"age": 0');
+    expect(container).toHaveTextContent('"price": 0.0');
+    expect(container).not.toHaveTextContent('-2147483648');
+    expect(container).not.toHaveTextContent('-3.402823669209385e+38');
+  });
+
   it('Handles error', async () => {
     fetchMock.mockReject(new Error('sample error'));
 

--- a/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.spec.tsx
@@ -139,7 +139,7 @@ describe('TryIt', () => {
       responses: [
         {
           id: 'response-200',
-          code: '200',
+          code: '2XX',
           contents: [
             {
               id: 'response-application-json',
@@ -191,6 +191,57 @@ describe('TryIt', () => {
     expect(container).toHaveTextContent('"price": 0.0');
     expect(container).not.toHaveTextContent('-2147483648');
     expect(container).not.toHaveTextContent('-3.402823669209385e+38');
+  });
+
+  it('normalizes inferred numeric bounds for 3XX response ranges', async () => {
+    const operationWithNumericResponse: IHttpOperation = {
+      ...basicOperation,
+      responses: [
+        {
+          id: 'response-3xx',
+          code: '3XX',
+          contents: [
+            {
+              id: 'response-application-json',
+              mediaType: 'application/json',
+              schema: {
+                type: 'object',
+                properties: {
+                  age: {
+                    type: 'integer',
+                    format: 'int32',
+                    minimum: 0 - 2 ** 31,
+                    maximum: 2 ** 31 - 1,
+                    'x-stoplight': { explicitProperties: ['type', 'format'] },
+                  },
+                },
+              } as any,
+            },
+          ],
+        },
+      ],
+    };
+
+    fetchMock.mockResolvedValue(
+      new Response('{"age":-2147483648}', {
+        status: 302,
+        statusText: 'Found',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const { container } = render(
+      <TryItWithPersistence httpOperation={operationWithNumericResponse} mockUrl="https://mock-todos.stoplight.io" />,
+    );
+
+    userEvent.click(screen.getByRole('button', { name: /server/i }));
+    userEvent.click(screen.getByRole('menuitemradio', { name: /mock server/i }));
+    clickSend();
+
+    await screen.findByText('Response');
+
+    expect(container).toHaveTextContent('"age": 0');
+    expect(container).not.toHaveTextContent('-2147483648');
   });
 
   it('Handles error', async () => {

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -5,6 +5,7 @@ import { useAtom } from 'jotai';
 import * as React from 'react';
 
 import { HttpMethodColors } from '../../constants';
+import { stringifyExampleWithResolvedSchema } from '../../utils/exampleGeneration/exampleGeneration';
 import { isHttpOperation, isHttpWebhookOperation } from '../../utils/guards';
 import { getServersToDisplay, getServerVariables } from '../../utils/http-spec/IServer';
 import { extractCodeSamples, RequestSamples } from '../RequestSamples';
@@ -232,8 +233,26 @@ export const TryIt: React.FC<TryItProps> = ({
         const contentType = response.headers.get('Content-Type');
         const type = contentType ? getResponseType(contentType) : undefined;
 
-        const bodyText = type !== 'image' ? await response.text() : undefined;
+        let bodyText = type !== 'image' ? await response.text() : undefined;
         const blob = type === 'image' ? await response.blob() : undefined;
+
+        let skipBodyParsing = false;
+
+        if (mockData && type === 'json' && bodyText) {
+          const responseMediaType = contentType?.split(';')[0];
+          const responseSchema = httpOperation.responses
+            .find(({ code }) => code === String(response?.status))
+            ?.contents?.find(({ mediaType }) => mediaType === responseMediaType)?.schema;
+
+          if (responseSchema) {
+            try {
+              bodyText = stringifyExampleWithResolvedSchema(JSON.parse(bodyText), responseSchema);
+              skipBodyParsing = true;
+            } catch {
+              // Preserve the original mock response if it is not valid JSON.
+            }
+          }
+        }
 
         setResponse(undefined); // setting undefined to handle rendering large responses
         setResponse({
@@ -241,6 +260,7 @@ export const TryIt: React.FC<TryItProps> = ({
           bodyText,
           blob,
           contentType,
+          skipBodyParsing,
         });
       }
     } catch (e: any) {

--- a/packages/elements-core/src/components/TryIt/TryIt.tsx
+++ b/packages/elements-core/src/components/TryIt/TryIt.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, HStack, Icon, ITextColorProps, Panel, useThemeIsDark } from '@stoplight/mosaic';
-import type { HttpMethod, IHttpEndpointOperation, IServer } from '@stoplight/types';
+import type { HttpMethod, IHttpEndpointOperation, IHttpOperation, IServer } from '@stoplight/types';
 import { Request as HarRequest } from 'har-format';
 import { useAtom } from 'jotai';
 import * as React from 'react';
@@ -78,6 +78,17 @@ export interface TryItProps {
  */
 
 const defaultServers: IServer[] = [];
+
+const findResponseForStatus = (httpOperation: IHttpOperation, status: number) => {
+  const statusCode = String(status);
+  const statusRange = `${Math.floor(status / 100)}XX`;
+
+  return (
+    httpOperation.responses.find(({ code }) => code === statusCode) ??
+    httpOperation.responses.find(({ code }) => code.toUpperCase() === statusRange) ??
+    httpOperation.responses.find(({ code }) => code === 'default')
+  );
+};
 
 export const TryIt: React.FC<TryItProps> = ({
   httpOperation,
@@ -240,9 +251,9 @@ export const TryIt: React.FC<TryItProps> = ({
 
         if (mockData && type === 'json' && bodyText) {
           const responseMediaType = contentType?.split(';')[0];
-          const responseSchema = httpOperation.responses
-            .find(({ code }) => code === String(response?.status))
-            ?.contents?.find(({ mediaType }) => mediaType === responseMediaType)?.schema;
+          const responseSchema = findResponseForStatus(httpOperation, response.status)?.contents?.find(
+            ({ mediaType }) => mediaType === responseMediaType,
+          )?.schema;
 
           if (responseSchema) {
             try {

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
@@ -106,3 +106,213 @@ describe('generateExampleFromMediaTypeContent', () => {
     expect(parsed).toHaveProperty('name');
   });
 });
+
+describe('stripInferredNumericBounds - Format-injected min/max handling', () => {
+  it('strips format-injected minimum/maximum from int32 (internal model case - double-processed)', () => {
+    const internalModelSchema: JSONSchema7 = {
+      type: 'integer',
+      format: 'int32',
+      minimum: 0 - 2 ** 31, // -2147483648
+      maximum: 2 ** 31 - 1, // 2147483647
+      ['x-stoplight']: {
+        explicitProperties: ['type', 'format', 'minimum', 'maximum'], // incorrectly includes min/max due to double-processing
+      },
+    } as any;
+
+    const examples = generateExamplesFromJsonSchema(internalModelSchema);
+    const parsed = JSON.parse(examples[0].data);
+    // After stripping, sampler should generate a normal value like 0, not -2147483648
+    expect(parsed).not.toBe(-2147483648);
+    expect(parsed).not.toBe(2147483647);
+    expect(typeof parsed).toBe('number');
+  });
+
+  it('strips format-injected bounds from int64', () => {
+    const schema: JSONSchema7 = {
+      type: 'integer',
+      format: 'int64',
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+      ['x-stoplight']: {
+        explicitProperties: ['type', 'format', 'minimum', 'maximum'],
+      },
+    } as any;
+
+    const examples = generateExamplesFromJsonSchema(schema);
+    const parsed = JSON.parse(examples[0].data);
+    expect(parsed).not.toBe(Number.MIN_SAFE_INTEGER);
+    expect(parsed).not.toBe(Number.MAX_SAFE_INTEGER);
+    expect(typeof parsed).toBe('number');
+  });
+
+  it('strips format-injected bounds from float', () => {
+    const schema: JSONSchema7 = {
+      type: 'number',
+      format: 'float',
+      minimum: 0 - 2 ** 128,
+      maximum: 2 ** 128 - 1,
+      ['x-stoplight']: {
+        explicitProperties: ['type', 'format', 'minimum', 'maximum'],
+      },
+    } as any;
+
+    const examples = generateExamplesFromJsonSchema(schema);
+    const parsed = JSON.parse(examples[0].data);
+    expect(typeof parsed).toBe('number');
+    expect(parsed).not.toBe(0 - 2 ** 128);
+  });
+
+  it('keeps user-set minimum/maximum that differ from format default', () => {
+    const schema: JSONSchema7 = {
+      type: 'integer',
+      format: 'int32',
+      minimum: 0, // User explicitly set to 0, not the format default -2147483648
+      maximum: 100,
+      ['x-stoplight']: {
+        explicitProperties: ['type', 'format', 'minimum', 'maximum'],
+      },
+    } as any;
+
+    const examples = generateExamplesFromJsonSchema(schema);
+    const parsed = JSON.parse(examples[0].data);
+    // Sampler should respect user's constraints
+    expect(parsed).toBeGreaterThanOrEqual(0);
+    expect(parsed).toBeLessThanOrEqual(100);
+  });
+
+  it('does not affect component model schemas (no x-stoplight)', () => {
+    const componentModelSchema: JSONSchema7 = {
+      type: 'integer',
+      format: 'int32',
+      // No minimum/maximum, no x-stoplight
+    };
+
+    const examples = generateExamplesFromJsonSchema(componentModelSchema);
+    const parsed = JSON.parse(examples[0].data);
+    expect(typeof parsed).toBe('number');
+    expect(parsed).not.toBe(0 - 2 ** 31); // Should not be format boundary
+  });
+
+  it('handles nested properties with format-injected bounds', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        count: {
+          type: 'integer',
+          format: 'int32',
+          minimum: 0 - 2 ** 31,
+          maximum: 2 ** 31 - 1,
+          ['x-stoplight']: {
+            explicitProperties: ['type', 'format', 'minimum', 'maximum'],
+          },
+        },
+        total: {
+          type: 'number',
+          format: 'float',
+          minimum: 0 - 2 ** 128,
+          maximum: 2 ** 128 - 1,
+          ['x-stoplight']: {
+            explicitProperties: ['type', 'format', 'minimum', 'maximum'],
+          },
+        },
+      },
+    } as any;
+
+    const examples = generateExamplesFromJsonSchema(schema);
+    const parsed = JSON.parse(examples[0].data);
+    expect(parsed).toHaveProperty('count');
+    expect(parsed).toHaveProperty('total');
+    expect(typeof parsed.count).toBe('number');
+    expect(typeof parsed.total).toBe('number');
+    // Neither should be format boundary values
+    expect(parsed.count).not.toBe(0 - 2 ** 31);
+    expect(parsed.total).not.toBe(0 - 2 ** 128);
+  });
+
+  it('handles allOf with format-injected bounds', () => {
+    const schema: JSONSchema7 = {
+      allOf: [
+        {
+          type: 'object',
+          properties: {
+            value: {
+              type: 'integer',
+              format: 'int32',
+              minimum: 0 - 2 ** 31,
+              maximum: 2 ** 31 - 1,
+              ['x-stoplight']: {
+                explicitProperties: ['type', 'format', 'minimum', 'maximum'],
+              },
+            },
+          },
+        },
+      ],
+    } as any;
+
+    const examples = generateExamplesFromJsonSchema(schema);
+    const parsed = JSON.parse(examples[0].data);
+    expect(parsed).toHaveProperty('value');
+    expect(typeof parsed.value).toBe('number');
+    expect(parsed.value).not.toBe(0 - 2 ** 31);
+  });
+
+  it('handles oneOf with format-injected bounds in options', () => {
+    const schema: JSONSchema7 = {
+      oneOf: [
+        {
+          type: 'integer',
+          format: 'int32',
+          minimum: 0 - 2 ** 31,
+          maximum: 2 ** 31 - 1,
+          ['x-stoplight']: {
+            explicitProperties: ['type', 'format', 'minimum', 'maximum'],
+          },
+        },
+        {
+          type: 'string',
+        },
+      ],
+    } as any;
+
+    const examples = generateExamplesFromJsonSchema(schema);
+    const parsed = JSON.parse(examples[0].data);
+    // Should be either string or a reasonable integer, not format boundary
+    expect(parsed === 0 - 2 ** 31 ? false : true).toBe(true);
+  });
+
+  it('keeps minimum only without maximum when only minimum is user-set', () => {
+    const schema: JSONSchema7 = {
+      type: 'integer',
+      format: 'int32',
+      minimum: 10, // User-set, differs from format default
+      ['x-stoplight']: {
+        explicitProperties: ['type', 'format', 'minimum'],
+      },
+    } as any;
+
+    const examples = generateExamplesFromJsonSchema(schema);
+    const parsed = JSON.parse(examples[0].data);
+    expect(parsed).toBeGreaterThanOrEqual(10);
+  });
+
+  it('handles double-processed schema correctly - does not throw error', () => {
+    const doubleProcessedSchema: JSONSchema7 = {
+      type: 'integer',
+      format: 'int32',
+      minimum: 0 - 2 ** 31,
+      maximum: 2 ** 31 - 1,
+      ['x-stoplight']: {
+        explicitProperties: ['type', 'format', 'minimum', 'maximum'],
+      },
+      description: 'This was processed twice',
+    } as any;
+
+    expect(() => {
+      generateExamplesFromJsonSchema(doubleProcessedSchema);
+    }).not.toThrow();
+
+    const examples = generateExamplesFromJsonSchema(doubleProcessedSchema);
+    expect(examples.length).toBeGreaterThan(0);
+    expect(examples[0].data).not.toContain('Example cannot be created');
+  });
+});

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
@@ -275,6 +275,50 @@ describe('generateExampleFromMediaTypeContent', () => {
     expect(parsed).not.toBe(0 - 2 ** 31);
     expect(typeof parsed).toBe('number');
   });
+
+  it('renders float field with no default as "0.0" not "0"', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: { type: 'number', format: 'float' },
+    };
+
+    expect(generateExampleFromMediaTypeContent(mediaTypeContent as any, {}).trim()).toBe('0.0');
+  });
+
+  it('renders double field with no default as "0.0" not "0"', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: { type: 'number', format: 'double' },
+    };
+
+    expect(generateExampleFromMediaTypeContent(mediaTypeContent as any, {}).trim()).toBe('0.0');
+  });
+
+  it('renders float property inside object as 0.0 in the output string', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        type: 'object',
+        properties: {
+          price: { type: 'number', format: 'float' },
+          qty: { type: 'integer' },
+        },
+      },
+    };
+
+    const raw = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    expect(raw).toContain('"price": 0.0');
+    expect(raw).toContain('"qty": 0');
+  });
+
+  it('does not render plain number (no format) as 0.0', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: { type: 'number' },
+    };
+
+    expect(generateExampleFromMediaTypeContent(mediaTypeContent as any, {}).trim()).toBe('0');
+  });
 });
 
 describe('stripInferredNumericBounds - Format-injected min/max handling', () => {
@@ -484,5 +528,29 @@ describe('stripInferredNumericBounds - Format-injected min/max handling', () => 
     const examples = generateExamplesFromJsonSchema(doubleProcessedSchema);
     expect(examples.length).toBeGreaterThan(0);
     expect(examples[0].data).not.toContain('Example cannot be created');
+  });
+
+  it('renders float field in Example section as "0.0" not "0"', () => {
+    const schema: JSONSchema7 = { type: 'number', format: 'float' };
+    expect(generateExamplesFromJsonSchema(schema)[0].data.trim()).toBe('0.0');
+  });
+
+  it('renders double field in Example section as "0.0" not "0"', () => {
+    const schema: JSONSchema7 = { type: 'number', format: 'double' };
+    expect(generateExamplesFromJsonSchema(schema)[0].data.trim()).toBe('0.0');
+  });
+
+  it('renders float property inside object as 0.0 in Example section', () => {
+    const schema: JSONSchema7 = {
+      type: 'object',
+      properties: {
+        rate: { type: 'number', format: 'float' } as any,
+        code: { type: 'integer' },
+      },
+    };
+
+    const data = generateExamplesFromJsonSchema(schema)[0].data;
+    expect(data).toContain('"rate": 0.0');
+    expect(data).toContain('"code": 0');
   });
 });

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
@@ -105,6 +105,176 @@ describe('generateExampleFromMediaTypeContent', () => {
     expect(parsed).toHaveProperty('id');
     expect(parsed).toHaveProperty('name');
   });
+
+  it('does not use format-injected int32 minimum as generated value (double-processed internal model)', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        type: 'integer',
+        format: 'int32',
+        minimum: 0 - 2 ** 31,
+        maximum: 2 ** 31 - 1,
+        'x-stoplight': { explicitProperties: ['type', 'format', 'minimum', 'maximum'] },
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    const parsed = JSON.parse(example);
+    expect(parsed).not.toBe(0 - 2 ** 31);
+  });
+
+  it('does not use format-injected int64 minimum as generated value', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        type: 'integer',
+        format: 'int64',
+        minimum: Number.MIN_SAFE_INTEGER,
+        maximum: Number.MAX_SAFE_INTEGER,
+        'x-stoplight': { explicitProperties: ['type', 'format', 'minimum', 'maximum'] },
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    const parsed = JSON.parse(example);
+    expect(parsed).not.toBe(Number.MIN_SAFE_INTEGER);
+  });
+
+  it('preserves user-set minimum in request body schema that differs from format default', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        type: 'integer',
+        format: 'int32',
+        minimum: 0, // user-authored, different from int32 default (-2147483648)
+        'x-stoplight': { explicitProperties: ['type', 'format', 'minimum'] },
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    const parsed = JSON.parse(example);
+    expect(parsed).toBeGreaterThanOrEqual(0);
+  });
+
+  it('strips format-injected bounds from nested object properties in request body', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        type: 'object',
+        properties: {
+          count: {
+            type: 'integer',
+            format: 'int32',
+            minimum: 0 - 2 ** 31,
+            maximum: 2 ** 31 - 1,
+            'x-stoplight': { explicitProperties: ['type', 'format', 'minimum', 'maximum'] },
+          },
+        },
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    const parsed = JSON.parse(example);
+    expect(parsed.count).not.toBe(0 - 2 ** 31);
+  });
+
+  it('does not use format-injected float minimum as generated value', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        type: 'number',
+        format: 'float',
+        minimum: 0 - 2 ** 128,
+        maximum: 2 ** 128 - 1,
+        'x-stoplight': { explicitProperties: ['type', 'format', 'minimum', 'maximum'] },
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    const parsed = JSON.parse(example);
+    expect(parsed).not.toBe(0 - 2 ** 128);
+    expect(typeof parsed).toBe('number');
+  });
+
+  it('does not use format-injected double minimum as generated value', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        type: 'number',
+        format: 'double',
+        minimum: 0 - Number.MAX_VALUE,
+        maximum: Number.MAX_VALUE,
+        'x-stoplight': { explicitProperties: ['type', 'format', 'minimum', 'maximum'] },
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    const parsed = JSON.parse(example);
+    expect(parsed).not.toBe(0 - Number.MAX_VALUE);
+    expect(typeof parsed).toBe('number');
+  });
+
+  it('strips format-injected bounds from component model schema (no x-stoplight metadata)', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        type: 'integer',
+        format: 'int32',
+        // no x-stoplight — raw OpenAPI component model, minimum injected by convertToJsonSchema
+        minimum: 0 - 2 ** 31,
+        maximum: 2 ** 31 - 1,
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    const parsed = JSON.parse(example);
+    expect(parsed).not.toBe(0 - 2 ** 31);
+    expect(typeof parsed).toBe('number');
+  });
+
+  it('strips format-injected bounds from allOf members in request body', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        allOf: [
+          {
+            type: 'integer',
+            format: 'int32',
+            minimum: 0 - 2 ** 31,
+            maximum: 2 ** 31 - 1,
+            'x-stoplight': { explicitProperties: ['type', 'format', 'minimum', 'maximum'] },
+          },
+        ],
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    const parsed = JSON.parse(example);
+    expect(parsed).not.toBe(0 - 2 ** 31);
+    expect(typeof parsed).toBe('number');
+  });
+
+  it('strips format-injected bounds from oneOf members in request body', () => {
+    const mediaTypeContent = {
+      mediaType: 'application/json',
+      schema: {
+        oneOf: [
+          {
+            type: 'integer',
+            format: 'int32',
+            minimum: 0 - 2 ** 31,
+            maximum: 2 ** 31 - 1,
+            'x-stoplight': { explicitProperties: ['type', 'format', 'minimum', 'maximum'] },
+          },
+        ],
+      },
+    };
+
+    const example = generateExampleFromMediaTypeContent(mediaTypeContent as any, {});
+    const parsed = JSON.parse(example);
+    expect(parsed).not.toBe(0 - 2 ** 31);
+    expect(typeof parsed).toBe('number');
+  });
 });
 
 describe('stripInferredNumericBounds - Format-injected min/max handling', () => {

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.spec.tsx
@@ -1,7 +1,11 @@
 import * as Sampler from '@stoplight/json-schema-sampler';
 import { JSONSchema7 } from 'json-schema';
 
-import { generateExampleFromMediaTypeContent, generateExamplesFromJsonSchema } from './exampleGeneration';
+import {
+  generateExampleFromMediaTypeContent,
+  generateExamplesFromJsonSchema,
+  stringifyExampleWithResolvedSchema,
+} from './exampleGeneration';
 
 const modelWithNoExamples: JSONSchema7 = require('../../__fixtures__/models/model-with-no-examples.json');
 
@@ -552,5 +556,109 @@ describe('stripInferredNumericBounds - Format-injected min/max handling', () => 
     const data = generateExamplesFromJsonSchema(schema)[0].data;
     expect(data).toContain('"rate": 0.0');
     expect(data).toContain('"code": 0');
+  });
+});
+
+describe('stringifyExampleWithResolvedSchema', () => {
+  it('normalizes inferred numeric bounds inside array items', () => {
+    const schema: JSONSchema7 = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          age: {
+            type: 'integer',
+            format: 'int32',
+            minimum: 0 - 2 ** 31,
+            maximum: 2 ** 31 - 1,
+            ['x-stoplight']: { explicitProperties: ['type', 'format'] },
+          },
+          price: {
+            type: 'number',
+            format: 'float',
+            minimum: 0 - 2 ** 128,
+            maximum: 2 ** 128 - 1,
+            ['x-stoplight']: { explicitProperties: ['type', 'format'] },
+          },
+        },
+      },
+    } as any;
+
+    const data = stringifyExampleWithResolvedSchema([{ age: 0 - 2 ** 31, price: 0 - 2 ** 128 }], schema);
+    expect(data).toContain('"age": 0');
+    expect(data).toContain('"price": 0.0');
+  });
+
+  it('normalizes inferred numeric bounds inside allOf response schemas', () => {
+    const schema: JSONSchema7 = {
+      allOf: [
+        {
+          type: 'object',
+          properties: {
+            age: {
+              type: 'integer',
+              format: 'int32',
+              minimum: 0 - 2 ** 31,
+              maximum: 2 ** 31 - 1,
+              ['x-stoplight']: { explicitProperties: ['type', 'format'] },
+            },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            price: {
+              type: 'number',
+              format: 'float',
+              minimum: 0 - 2 ** 128,
+              maximum: 2 ** 128 - 1,
+              ['x-stoplight']: { explicitProperties: ['type', 'format'] },
+            },
+          },
+        },
+      ],
+    } as any;
+
+    const data = stringifyExampleWithResolvedSchema({ age: 0 - 2 ** 31, price: 0 - 2 ** 128 }, schema);
+    expect(data).toContain('"age": 0');
+    expect(data).toContain('"price": 0.0');
+  });
+
+  it('normalizes inferred numeric bounds inside oneOf and anyOf response schemas', () => {
+    const oneOfSchema: JSONSchema7 = {
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            age: {
+              type: 'integer',
+              format: 'int32',
+              minimum: 0 - 2 ** 31,
+              maximum: 2 ** 31 - 1,
+              ['x-stoplight']: { explicitProperties: ['type', 'format'] },
+            },
+          },
+        },
+      ],
+    } as any;
+    const anyOfSchema: JSONSchema7 = {
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            price: {
+              type: 'number',
+              format: 'float',
+              minimum: 0 - 2 ** 128,
+              maximum: 2 ** 128 - 1,
+              ['x-stoplight']: { explicitProperties: ['type', 'format'] },
+            },
+          },
+        },
+      ],
+    } as any;
+
+    expect(stringifyExampleWithResolvedSchema({ age: 0 - 2 ** 31 }, oneOfSchema)).toContain('"age": 0');
+    expect(stringifyExampleWithResolvedSchema({ price: 0 - 2 ** 128 }, anyOfSchema)).toContain('"price": 0.0');
   });
 });

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
@@ -157,6 +157,7 @@ export const generateExampleFromMediaTypeContent = (
     } else if (textRequestBodySchema) {
       let unwrappedSchema = getResolvedObject(textRequestBodySchema) as any;
 
+      unwrappedSchema = stripInferredNumericBounds(unwrappedSchema);
       unwrappedSchema = mergeOneOfAnyOf(unwrappedSchema);
 
       const generated = Sampler.sample(unwrappedSchema, options, document);

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
@@ -123,6 +123,18 @@ const FLOAT_ZERO_MARKER = '__FLOAT_ZERO__';
 const markFloatZeros = (value: any, schema: any): any => {
   if (!isPlainObject(schema)) return value;
 
+  if (Array.isArray(schema.allOf)) {
+    return schema.allOf.reduce((currentValue: any, item: any) => markFloatZeros(currentValue, item), value);
+  }
+
+  if (Array.isArray(schema.oneOf) && schema.oneOf.length > 0) {
+    return markFloatZeros(value, schema.oneOf[0]);
+  }
+
+  if (Array.isArray(schema.anyOf) && schema.anyOf.length > 0) {
+    return markFloatZeros(value, schema.anyOf[0]);
+  }
+
   if (schema.type === 'number' && (schema.format === 'float' || schema.format === 'double') && value === 0) {
     return FLOAT_ZERO_MARKER;
   }
@@ -145,6 +157,69 @@ const stringifyWithFloatZeros = (value: any): string => {
   // so handle the top-level float marker before stringifying.
   if (value === FLOAT_ZERO_MARKER) return '0.0';
   return (safeStringify(value, undefined, 2) ?? '').replace(/"__FLOAT_ZERO__"/g, '0.0');
+};
+
+const normalizeInferredNumericBounds = (value: any, schema: any): any => {
+  if (!isPlainObject(schema)) return value;
+
+  const schemaObject: any = schema;
+
+  if (Array.isArray(schemaObject.allOf)) {
+    return schemaObject.allOf.reduce(
+      (currentValue: any, item: any) => normalizeInferredNumericBounds(currentValue, item),
+      value,
+    );
+  }
+
+  if (Array.isArray(schemaObject.oneOf) && schemaObject.oneOf.length > 0) {
+    return normalizeInferredNumericBounds(value, schemaObject.oneOf[0]);
+  }
+
+  if (Array.isArray(schemaObject.anyOf) && schemaObject.anyOf.length > 0) {
+    return normalizeInferredNumericBounds(value, schemaObject.anyOf[0]);
+  }
+
+  const explicitProperties = Array.isArray(schemaObject?.['x-stoplight']?.explicitProperties)
+    ? schemaObject['x-stoplight'].explicitProperties
+    : [];
+  const isNumericType = schemaObject.type === 'integer' || schemaObject.type === 'number';
+  const formatRange = OAS_FORMAT_RANGES[schemaObject.format];
+  const hasExplicitMinimum = explicitProperties.includes('minimum') && schemaObject.minimum !== formatRange?.minimum;
+  const hasExplicitMaximum = explicitProperties.includes('maximum') && schemaObject.maximum !== formatRange?.maximum;
+
+  if (
+    isNumericType &&
+    formatRange &&
+    ((!hasExplicitMinimum && value === formatRange.minimum) || (!hasExplicitMaximum && value === formatRange.maximum))
+  ) {
+    return schemaObject.type === 'number' && (schemaObject.format === 'float' || schemaObject.format === 'double')
+      ? FLOAT_ZERO_MARKER
+      : 0;
+  }
+
+  if (isPlainObject(value) && isPlainObject(schemaObject.properties)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        key,
+        normalizeInferredNumericBounds(nestedValue, (schemaObject.properties as any)[key] ?? {}),
+      ]),
+    );
+  }
+
+  if (Array.isArray(value) && schemaObject.items && !Array.isArray(schemaObject.items)) {
+    return value.map((item: any) => normalizeInferredNumericBounds(item, schemaObject.items));
+  }
+
+  if (Array.isArray(value) && Array.isArray(schemaObject.items)) {
+    return value.map((item: any, index: number) => normalizeInferredNumericBounds(item, schemaObject.items[index]));
+  }
+
+  return value;
+};
+
+export const stringifyExampleWithResolvedSchema = (value: any, schema: any): string => {
+  const normalizedValue = normalizeInferredNumericBounds(value, schema);
+  return stringifyWithFloatZeros(markFloatZeros(normalizedValue, schema));
 };
 
 export type GenerateExampleFromMediaTypeContentOptions = Sampler.Options;
@@ -194,7 +269,7 @@ export const generateExampleFromMediaTypeContent = (
       const generated = Sampler.sample(unwrappedSchema, options, document);
 
       if (generated === null) return '';
-      return stringifyWithFloatZeros(markFloatZeros(generated, unwrappedSchema));
+      return stringifyExampleWithResolvedSchema(generated, unwrappedSchema);
     }
   } catch (e) {
     console.warn(e);
@@ -243,7 +318,7 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7 & { 'x-exampl
       ? [
           {
             label: 'default',
-            data: stringifyWithFloatZeros(markFloatZeros(generated, resolvedSchema)),
+            data: stringifyExampleWithResolvedSchema(generated, resolvedSchema),
           },
         ]
       : [{ label: 'default', data: '' }];

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
@@ -50,6 +50,72 @@ const mergeOneOfAnyOf = (schema: any): any => {
   return result;
 };
 
+// Stoplight translation can infer numeric bounds from formats (e.g. int32/float).
+// When those bounds were not explicitly authored, omit them for example generation
+// so generated values stay consistent with raw component schemas.
+// Range bounds injected by convertToJsonSchema for OAS numeric formats.
+const OAS_FORMAT_RANGES: Record<string, { minimum: number; maximum: number }> = {
+  int32: { minimum: 0 - 2 ** 31, maximum: 2 ** 31 - 1 },
+  int64: { minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+  float: { minimum: 0 - 2 ** 128, maximum: 2 ** 128 - 1 },
+  double: { minimum: 0 - Number.MAX_VALUE, maximum: Number.MAX_VALUE },
+};
+
+const stripInferredNumericBounds = (schema: any): any => {
+  if (!isPlainObject(schema)) {
+    return schema;
+  }
+
+  const result: any = { ...schema };
+  const explicitProperties = Array.isArray(result?.['x-stoplight']?.explicitProperties)
+    ? result['x-stoplight'].explicitProperties
+    : [];
+  const isNumericType = result.type === 'integer' || result.type === 'number';
+  const formatRange = OAS_FORMAT_RANGES[result.format];
+
+  // Strip if not explicit OR if the value exactly matches the format-injected range default.
+  // The second condition handles schemas that were processed twice, causing the range value
+  // to appear in explicitProperties even though it was not authored.
+  const hasExplicitMinimum =
+    explicitProperties.includes('minimum') && result.minimum !== formatRange?.minimum;
+  const hasExplicitMaximum =
+    explicitProperties.includes('maximum') && result.maximum !== formatRange?.maximum;
+
+  if (isNumericType && !hasExplicitMinimum) {
+    delete result.minimum;
+  }
+
+  if (isNumericType && !hasExplicitMaximum) {
+    delete result.maximum;
+  }
+
+  if (result.properties && isPlainObject(result.properties)) {
+    result.properties = Object.fromEntries(
+      Object.entries(result.properties).map(([key, value]) => [key, stripInferredNumericBounds(value)]),
+    );
+  }
+
+  if (Array.isArray(result.items)) {
+    result.items = result.items.map((item: any) => stripInferredNumericBounds(item));
+  } else if (result.items) {
+    result.items = stripInferredNumericBounds(result.items);
+  }
+
+  if (Array.isArray(result.allOf)) {
+    result.allOf = result.allOf.map((item: any) => stripInferredNumericBounds(item));
+  }
+
+  if (Array.isArray(result.oneOf)) {
+    result.oneOf = result.oneOf.map((item: any) => stripInferredNumericBounds(item));
+  }
+
+  if (Array.isArray(result.anyOf)) {
+    result.anyOf = result.anyOf.map((item: any) => stripInferredNumericBounds(item));
+  }
+
+  return result;
+};
+
 export type GenerateExampleFromMediaTypeContentOptions = Sampler.Options;
 
 export const useGenerateExampleFromMediaTypeContent = (
@@ -132,6 +198,7 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7 & { 'x-exampl
 
   try {
     let resolvedSchema = getResolvedObject(schema);
+    resolvedSchema = stripInferredNumericBounds(resolvedSchema);
     resolvedSchema = mergeOneOfAnyOf(resolvedSchema);
 
     const generated = Sampler.sample(resolvedSchema, {

--- a/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
+++ b/packages/elements-core/src/utils/exampleGeneration/exampleGeneration.ts
@@ -50,9 +50,6 @@ const mergeOneOfAnyOf = (schema: any): any => {
   return result;
 };
 
-// Stoplight translation can infer numeric bounds from formats (e.g. int32/float).
-// When those bounds were not explicitly authored, omit them for example generation
-// so generated values stay consistent with raw component schemas.
 // Range bounds injected by convertToJsonSchema for OAS numeric formats.
 const OAS_FORMAT_RANGES: Record<string, { minimum: number; maximum: number }> = {
   int32: { minimum: 0 - 2 ** 31, maximum: 2 ** 31 - 1 },
@@ -61,6 +58,9 @@ const OAS_FORMAT_RANGES: Record<string, { minimum: number; maximum: number }> = 
   double: { minimum: 0 - Number.MAX_VALUE, maximum: Number.MAX_VALUE },
 };
 
+// Stoplight translation can infer numeric bounds from formats (e.g. int32/float).
+// When those bounds were not explicitly authored, omit them so the sampler generates
+// representative values instead of format-boundary extremes.
 const stripInferredNumericBounds = (schema: any): any => {
   if (!isPlainObject(schema)) {
     return schema;
@@ -116,6 +116,37 @@ const stripInferredNumericBounds = (schema: any): any => {
   return result;
 };
 
+// Sentinel replaced with literal 0.0 after JSON stringify to produce a decimal representation.
+const FLOAT_ZERO_MARKER = '__FLOAT_ZERO__';
+
+// Walks sampled value + schema in parallel; replaces 0 with FLOAT_ZERO_MARKER for float/double fields.
+const markFloatZeros = (value: any, schema: any): any => {
+  if (!isPlainObject(schema)) return value;
+
+  if (schema.type === 'number' && (schema.format === 'float' || schema.format === 'double') && value === 0) {
+    return FLOAT_ZERO_MARKER;
+  }
+
+  if (isPlainObject(value) && isPlainObject(schema.properties)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, markFloatZeros(v, (schema.properties as any)[k] ?? {})]),
+    );
+  }
+
+  if (Array.isArray(value) && schema.items && !Array.isArray(schema.items)) {
+    return value.map((item: any) => markFloatZeros(item, schema.items));
+  }
+
+  return value;
+};
+
+const stringifyWithFloatZeros = (value: any): string => {
+  // safeStringify returns a bare string (no JSON quotes) for scalar string values,
+  // so handle the top-level float marker before stringifying.
+  if (value === FLOAT_ZERO_MARKER) return '0.0';
+  return (safeStringify(value, undefined, 2) ?? '').replace(/"__FLOAT_ZERO__"/g, '0.0');
+};
+
 export type GenerateExampleFromMediaTypeContentOptions = Sampler.Options;
 
 export const useGenerateExampleFromMediaTypeContent = (
@@ -162,7 +193,8 @@ export const generateExampleFromMediaTypeContent = (
 
       const generated = Sampler.sample(unwrappedSchema, options, document);
 
-      return generated !== null ? safeStringify(generated, undefined, 2) ?? '' : '';
+      if (generated === null) return '';
+      return stringifyWithFloatZeros(markFloatZeros(generated, unwrappedSchema));
     }
   } catch (e) {
     console.warn(e);
@@ -211,7 +243,7 @@ export const generateExamplesFromJsonSchema = (schema: JSONSchema7 & { 'x-exampl
       ? [
           {
             label: 'default',
-            data: safeStringify(generated, undefined, 2) ?? '',
+            data: stringifyWithFloatZeros(markFloatZeros(generated, resolvedSchema)),
           },
         ]
       : [{ label: 'default', data: '' }];

--- a/packages/elements-dev-portal/package.json
+++ b/packages/elements-dev-portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements-dev-portal",
-  "version": "3.0.24",
+  "version": "3.0.25",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@scarf/scarf": "^1.4.0",
-    "@stoplight/elements-core": "~9.0.24",
+    "@stoplight/elements-core": "~9.0.25",
     "@stoplight/markdown-viewer": "^5.7.1",
     "@stoplight/mosaic": "^1.53.5",
     "@stoplight/path": "^1.3.2",

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stoplight/elements",
-  "version": "9.0.24",
+  "version": "9.0.25",
   "description": "UI components for composing beautiful developer documentation.",
   "keywords": [],
   "sideEffects": [
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@scarf/scarf": "^1.4.0",
-    "@stoplight/elements-core": "~9.0.24",
+    "@stoplight/elements-core": "~9.0.25",
     "@stoplight/http-spec": "^7.1.0",
     "@stoplight/json": "^3.18.1",
     "@stoplight/mosaic": "^1.53.5",


### PR DESCRIPTION
[STOP-6047](https://smartbear.atlassian.net/browse/STOP-6047)

## Description:
Fixed the issue currently affecting Integer (int32, int64) and Number (float, double) types. Previously, when no default value was provided, the example section automatically inferred and displayed the minimum value based on the type's range. With this fix, the example section now displays 0 for these types when no default value is specified.

## How Has This Been Tested?:
have tested on Elements-dev-portal

## Screenshot(s)/recordings(s):
### Internal Model:
### Before:
<img width="190" height="63" alt="image" src="https://github.com/user-attachments/assets/d07719b7-0024-48e3-b7e5-bf23f823ac30" />


### After:
<img width="156" height="69" alt="image" src="https://github.com/user-attachments/assets/64f01afb-df3d-425e-ac61-cd9e751f062b" />

### Try It Request& Response Body:
### Before:
<img width="248" height="590" alt="image" src="https://github.com/user-attachments/assets/7b7abed0-e607-4e1b-ba35-9039540f4376" />

### After:
<img width="522" height="1128" alt="image" src="https://github.com/user-attachments/assets/f5de6670-a71b-4982-9d90-f264ff385401" />



## Impact Analysis:
[https://smartbear.atlassian.net/wiki/x/DAAykwE](https://smartbear.atlassian.net/wiki/x/DAAykwE)


[STOP-6047]: https://smartbear.atlassian.net/browse/STOP-6047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ