### PR TITLE
fix: pin to node 24 with compatible lerna

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -8,7 +8,7 @@ jobs:
   lint-and-check:
     runs-on: ubuntu-latest
     container:
-      image: node:lts
+      image: node:24.19.0
     steps:
     - uses: actions/checkout@v4.1.0
     - run: yarn --frozen-lockfile
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: node:lts
+      image: node:24.19.0
     steps:
     - uses: actions/checkout@v4.1.0
     - run: yarn --frozen-lockfile
@@ -50,7 +50,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     container:
-      image: node:lts
+      image: node:24.19.0
     steps:
     - uses: actions/checkout@v4.1.0
     - run: yarn --frozen-lockfile
@@ -157,7 +157,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     container:
-      image: node:lts
+      image: node:24.19.0
     needs:
     - lint-and-check
     - build


### PR DESCRIPTION
This pins the lerna release step to 24.19, as it's incompatible with 24.20.